### PR TITLE
[DRAFT] Add example of how to exclude workloads or containers-in-workloads from policies

### DIFF
--- a/examples/kubernetes/policy/lib/common.rego
+++ b/examples/kubernetes/policy/lib/common.rego
@@ -1,0 +1,18 @@
+package lib.common
+
+list_contains_value(list, item) {
+	list_item = list[_]
+	list_item == item
+}
+
+else = false {
+	true # It will return false unconditionally, if previous function is not true
+}
+
+has_field(obj, field) {
+	obj[field]
+}
+
+else = false {
+	true # It will return false unconditionally, if previous function is not true
+}

--- a/examples/kubernetes/policy/lib/common_test.rego
+++ b/examples/kubernetes/policy/lib/common_test.rego
@@ -1,0 +1,40 @@
+package lib.common
+
+sample_list := [
+	"marshall",
+	"mathers",
+	"haley",
+	"kim",
+]
+
+test_list_contains_value_pass {
+	list_contains_value(sample_list, "mathers")
+}
+
+test_list_contains_value_false {
+	list_contains_value(sample_list, "biggie") == false
+}
+
+test_list_contains_value_not {
+	not list_contains_value(sample_list, "biggie")
+}
+
+sample_object_for_has_key := {
+	"luke": "skywalker",
+	"obiwan": "kenobi",
+}
+
+# Pass example
+test_has_field_pass {
+	has_field(sample_object_for_has_key, "luke")
+}
+
+# False example
+test_has_field_false {
+	false == has_field(sample_object_for_has_key, "kylo")
+}
+
+# Not example
+test_has_field_not {
+	not has_field(sample_object_for_has_key, "kylo")
+}

--- a/examples/kubernetes/policy/lib/exclusions_logic.rego
+++ b/examples/kubernetes/policy/lib/exclusions_logic.rego
@@ -1,0 +1,19 @@
+package lib.exclusion_logic
+
+import data.exclusions
+import data.lib.common
+
+workload_is_excluded_from(rule, workload) {
+	common.has_field(exclusions, "rule_names")
+	common.has_field(exclusions.rule_names, rule)
+	common.has_field(exclusions.rule_names[rule], workload)
+}
+
+workload_container_is_excluded_from(rule, workload, container) {
+	common.has_field(exclusions, "rule_names")
+	common.has_field(exclusions.rule_names, rule)
+	common.has_field(exclusions.rule_names[rule], workload)
+	common.has_field(exclusions.rule_names[rule][workload], container)
+    # Must specify a reason
+    re_match(".+", exclusions.rule_names[rule][workload][container])
+}

--- a/examples/kubernetes/policy/lib/exclusions_logic_workload_container_test.rego
+++ b/examples/kubernetes/policy/lib/exclusions_logic_workload_container_test.rego
@@ -1,0 +1,41 @@
+package lib.exclusion_logic
+
+workload_container_exclusion_samples = {"rule_names": {"no-capes": {"mr-incredible": {
+	"shirt": "Who wears a cape with a shirt? Ridiculous.",
+	"tie": "",
+}}}}
+
+test_excluded_when_workload_and_container_are_with_reason {
+	rule_name := "no-capes"
+	workload_name := "mr-incredible"
+	container_name := "shirt"
+	workload_container_is_excluded_from(rule_name, workload_name, container_name) with data.exclusions as workload_container_exclusion_samples
+}
+
+test_not_excluded_when_workload_and_container_are_but_no_reason_given {
+	rule_name := "no-capes"
+	workload_name := "mr-incredible"
+	container_name := "tie"
+	not workload_container_is_excluded_from(rule_name, workload_name, container_name) with data.exclusions as workload_container_exclusion_samples
+}
+
+test_not_excluded_when_workload_is_not {
+	rule_name := "no-capes"
+	workload_name := "elastigirl"
+	container_name := "shirt"
+	not workload_container_is_excluded_from(rule_name, workload_name, container_name) with data.exclusions as workload_container_exclusion_samples
+}
+
+test_not_excluded_when_workload_is_but_container_is_not {
+	rule_name := "no-capes"
+	workload_name := "mr-incredible"
+	container_name := "socks"
+	not workload_container_is_excluded_from(rule_name, workload_name, container_name) with data.exclusions as workload_container_exclusion_samples
+}
+
+test_not_excluded_when_rule_not_present {
+	rule_name := "maintain-secret-identities"
+	workload_name := "mr-incredible"
+	container_name := "shirt"
+	not workload_container_is_excluded_from(rule_name, workload_name, container_name) with data.exclusions as workload_container_exclusion_samples
+}

--- a/examples/kubernetes/policy/lib/exclusions_logic_workload_test.rego
+++ b/examples/kubernetes/policy/lib/exclusions_logic_workload_test.rego
@@ -1,0 +1,22 @@
+package lib.exclusion_logic
+
+workload_exclusion_samples = {"rule_names": {"no-capes": {"mr-incredible": {
+}}}}
+
+test_excluded_when_workload_is_present {
+	rule_name := "no-capes"
+	workload_name := "mr-incredible"
+	workload_is_excluded_from(rule_name, workload_name) with data.exclusions as workload_exclusion_samples
+}
+
+test_not_excluded_when_workload_is_not_present {
+	rule_name := "no-capes"
+	workload_name := "elastigirl"
+	not workload_is_excluded_from(rule_name, workload_name) with data.exclusions as workload_exclusion_samples
+}
+
+test_not_excluded_when_rule_is_not_present {
+	rule_name := "maintain-secret-identities"
+	workload_name := "mr-incredible"
+	not workload_is_excluded_from(rule_name, workload_name) with data.exclusions as workload_exclusion_samples
+}


### PR DESCRIPTION
So that it's possible to incrementally apply new policies but also not regress workloads or containers that are already compliant, add an example of exclusion logic

Note: this is incomplete in its current state - I'm really struggling with the next step, which is how to apply this logic to `kubernetes.containers[container]` via a rego rule.

I'm aiming at a `security.exclusions.yaml` that contains content like

```yaml
---
rule_names:
  containers-resources-limits-memory: # the rule name
    tmp-sidecar-proxy:                # the workload name - a workload is a thing that contains Pods running initContainers/containers
      nginx: "boo"                    # the container name, with a reason for why it's ignored
```

I'd _like_ to make a more elaborate YAML file here that's more self describing, like the following, but I haven't made the first work yet so am deferring that until I become more adept.

```yaml
---
rule_names:
  containers-resources-limits-memory:
    workloads:
      - name: elasticsearch
        reason: "not a problem"
      - name: grafana
        containers:
          - name: nginx
            reason: "very fine"
```

I'd like to be able to write a policy whose output looks something like 

```
kubernetes_security: No memory resource limit set. Instances StatefulSet[vault], containers [vault]
kubernetes_security: No memory resource limit set. Instances Deployment[grafana], containers [nginx, grafana]
```

That is, mention the type of workload, the name of workload, and the names of containers.