### PR TITLE
feat(test): add ignore flag for filtering unwanted inputs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -29,6 +29,18 @@ conftest parse examples/unknown_extension/unknown.xyz -i hcl1
 $ conftest test examples/multitype/grafana.ini examples/multitype/deployment.yaml -p examples/multitype
 ```
 
+## `--ignore`
+
+When the given input file lists/directories contain unwanted file extensions/folders, the `--ignore` flag helps you to filter them.
+A regexp pattern can be passed as the flag value for filtering. Here's some examples:
+
+```console
+conftest test -p examples/test/ test/ --ignore="parent/"
+conftest test -p examples/test/ test/ --ignore="child/"
+conftest test -p examples/test/ test/ --ignore=".*.yaml"
+conftest test -p examples/test/ test/ --ignore=".*.cue|.*.yaml"
+```
+
 ## `--combine`
 
 This flag introduces *BREAKING CHANGES* in how `conftest` provides input to rego policies. However, you may find it useful to as you can now compare multiple values from different configurations simultaneously.

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -488,7 +488,11 @@ func parseFileList(fileList []string, exceptions string) ([]string, error) {
 
 func getFilesFromDirectory(directory string, exceptions string) ([]string, error) {
 	var files []string
-	regexp := regexp.MustCompile(exceptions)
+	regexp, err := regexp.Compile(exceptions)
+	if err != nil {
+		return nil, fmt.Errorf("given regexp for --ingore couldn't be parsed :%w", err)
+	}
+
 	walk := func(currentPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("walk path: %w", err)
@@ -511,7 +515,7 @@ func getFilesFromDirectory(directory string, exceptions string) ([]string, error
 		return nil
 	}
 
-	err := filepath.Walk(directory, walk)
+	err = filepath.Walk(directory, walk)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -34,7 +34,7 @@ https://www.openpolicyagent.org/docs/latest/policy-language/
 The policy location defaults to the policy directory in the local folder.
 The location can be overridden with the '--policy' flag, e.g.:
 
-	$ conftest test --policy <my-directory> <input-file/input-folder>
+	$ conftest test --policy <my-directory> <input-file(s)/input-folder>
 
 Some policies are dependant on external data. This data is loaded in seperatly 
 from policies. The location of any data directory or file can be specified with 
@@ -490,7 +490,7 @@ func getFilesFromDirectory(directory string, exceptions string) ([]string, error
 	var files []string
 	regexp, err := regexp.Compile(exceptions)
 	if err != nil {
-		return nil, fmt.Errorf("given regexp for --ingore couldn't be parsed :%w", err)
+		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
 	}
 
 	walk := func(currentPath string, info os.FileInfo, err error) error {

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -128,7 +128,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Long:  testDesc,
 		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"fail-on-warn", "update", combineConfigFlagName, "trace", "output", "input", "namespace", "all-namespaces", "data", "dir-exceptions"}
+			flagNames := []string{"fail-on-warn", "update", combineConfigFlagName, "trace", "output", "input", "namespace", "all-namespaces", "data", "ignore"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -144,7 +144,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 			out := GetOutputManager(outputFormat, color)
 			input := viper.GetString("input")
 
-			files, err := parseFileList(fileList, viper.GetString("dir-exceptions"))
+			files, err := parseFileList(fileList, viper.GetString("ignore"))
 			if err != nil {
 				return fmt.Errorf("parse files: %w", err)
 			}
@@ -253,7 +253,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().String("namespace", "main", "namespace in which to find deny and warn rules")
 	cmd.Flags().Bool("all-namespaces", false, "find deny and warn rules in all namespaces. If set, the flag \"namespace\" is ignored")
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
-	cmd.Flags().String("dir-exceptions", "", "a regex pattern which can be used for ignoring some files/directories in a given input. i.e.: ignoring yamls: --dir-exceptions=\".*.yaml\"")
+	cmd.Flags().String("ignore", "", "a regex pattern which can be used for ignoring some files/directories in a given input. i.e.: ignoring yamls: --ignore=\".*.yaml\"")
 
 	return &cmd
 }

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -177,10 +177,14 @@ func TestGetFilesFromDirectory(t *testing.T) {
 
 	createDummyFile := func(name string) {
 		d := []byte("")
-		check(ioutil.WriteFile(name, d, 0644))
+		if err := ioutil.WriteFile(name, d, 0644); err != nil {
+			t.Fatalf("cannot write to file :%v", err)
+		}
 	}
-	err := os.MkdirAll("test/parent/child", 0755)
-	check(err)
+
+	if err := os.MkdirAll("test/parent/child", 0755); err != nil {
+		t.Fatalf("cannot create testing directory structure: %v", err)
+	}
 
 	createDummyFile("test/file1.tf")
 	createDummyFile("test/file2.tf")
@@ -202,18 +206,12 @@ func TestGetFilesFromDirectory(t *testing.T) {
 		t.Run(tt.regex, func(t *testing.T) {
 			result, err := getFilesFromDirectory("test/", tt.regex)
 			if err != nil {
-				t.Errorf("getFilesFromDirectory returns err, expected nil")
+				t.Fatalf("getFilesFromDirectory returns err, expected nil")
 			}
 
 			if !reflect.DeepEqual(tt.exp, result) {
-				t.Errorf("expected: %v, got: %v", tt.exp, result)
+				t.Fatalf("expected: %v, got: %v", tt.exp, result)
 			}
 		})
-	}
-}
-
-func check(e error) {
-	if e != nil {
-		panic(e)
 	}
 }

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
 	"testing"
 
 	"github.com/open-policy-agent/conftest/parser/docker"
@@ -165,5 +168,52 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 	actualSuccesses := len(results.Successes)
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
+	}
+}
+
+func TestGetFilesFromDirectory(t *testing.T) {
+	os.Mkdir("test/", 0700)
+	defer os.RemoveAll("test/")
+
+	createDummyFile := func(name string) {
+		d := []byte("")
+		check(ioutil.WriteFile(name, d, 0644))
+	}
+	err := os.MkdirAll("test/parent/child", 0755)
+	check(err)
+
+	createDummyFile("test/file1.tf")
+	createDummyFile("test/file2.tf")
+	createDummyFile("test/parent/file1.tf")
+	createDummyFile("test/parent/file1.yaml")
+	createDummyFile("test/parent/child/test.tf")
+
+	tests := []struct {
+		regex string
+		exp   []string
+	}{
+		{".*.yaml", []string{"test/file1.tf", "test/file2.tf", "test/parent/child/test.tf", "test/parent/file1.tf"}},
+		{".*.tf", []string{"test/parent/file1.yaml"}},
+		{"child/", []string{"test/file1.tf", "test/file2.tf", "test/parent/file1.tf", "test/parent/file1.yaml"}},
+		{"parent/", []string{"test/file1.tf", "test/file2.tf"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.regex, func(t *testing.T) {
+			result, err := getFilesFromDirectory("test/", tt.regex)
+			if err != nil {
+				t.Errorf("getFilesFromDirectory returns err, expected nil")
+			}
+
+			if !reflect.DeepEqual(tt.exp, result) {
+				t.Errorf("expected: %v, got: %v", tt.exp, result)
+			}
+		})
+	}
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
 	}
 }


### PR DESCRIPTION
Fixes: #310 

Example usage:

```shell
./conftest test -p examples/test/ test/ --ignore="parent/"
./conftest test -p examples/test/ test/ --ignore="child/"
./conftest test -p examples/test/ test/ --ignore=".*.yaml"
```

