### PR TITLE
Update examples to use denylist

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -85,8 +85,8 @@
 @test "Test command with all namespaces flag" {
   run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --all-namespaces
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "blacklisted image found [\"openjdk:8-jdk-alpine\"]" ]]
-  [[ "$output" =~ "blacklisted commands found [\"apk add --no-cache python3 python3-dev build-base && pip3 install awscli==1.18.1\"]" ]]
+  [[ "$output" =~ "unallowed image found [\"openjdk:8-jdk-alpine\"]" ]]
+  [[ "$output" =~ "unallowed commands found [\"apk add --no-cache python3 python3-dev build-base && pip3 install awscli==1.18.1\"]" ]]
 }
 
 @test "Test command works with nested namespaces" {
@@ -204,7 +204,7 @@
 @test "Can parse docker files" {
   run ./conftest test -p examples/docker/policy examples/docker/Dockerfile
   [ "$status" -eq 1 ]
-  [[ "$output" =~ "blacklisted image found [\"openjdk:8-jdk-alpine\"]" ]]
+  [[ "$output" =~ "unallowed image found [\"openjdk:8-jdk-alpine\"]" ]]
 }
 
 @test "Can disable color" {

--- a/examples/awssam/policy/policy.rego
+++ b/examples/awssam/policy/policy.rego
@@ -1,31 +1,31 @@
 package main
 
-blacklist = [
+denylist = [
     "*"
 ]
 
-sensitive_blacklist = [
+sensitive_denylist = [
     "password",
     "Password",
     "Pass",
     "pass"
 ]
 
-runtime_blacklist = [
+runtime_denylist = [
     "python2.7",
     "node4.3"
 ]
 
-check_resources(actions, blacklist) {
-  endswith(actions[_], blacklist[_])
+check_resources(actions, denylist) {
+  endswith(actions[_], denylist[_])
 }
 
-check_sensitive(envs, blacklist) {
-  contains(envs[_], blacklist[_])
+check_sensitive(envs, denylist) {
+  contains(envs[_], denylist[_])
 }
 
-check_runtime(runtime, blacklist) {
-  contains(runtime, blacklist[_])
+check_runtime(runtime, denylist) {
+  contains(runtime, denylist[_])
 }
 
 deny[msg] {
@@ -34,12 +34,12 @@ deny[msg] {
 }
 
 deny[msg] {
-  input.Resources.LambdaFunction.Properties.Runtime = runtime; check_runtime(runtime, runtime_blacklist)
+  input.Resources.LambdaFunction.Properties.Runtime = runtime; check_runtime(runtime, runtime_denylist)
   msg = sprintf("%s runtime not allowed", [runtime])
 }
 
 deny[msg] {
-  input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Action = a; check_resources(a, blacklist)
+  input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Action = a; check_resources(a, denylist)
   input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Effect = "Allow"
   msg = "excessive Action permissions not allowed"
 }
@@ -51,7 +51,7 @@ deny[msg] {
 }
 
 deny[msg] {
-  input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Resource = a; check_resources(a, blacklist)
+  input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Resource = a; check_resources(a, denylist)
   input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Effect = "Allow"
   msg = "excessive Resource permissions not allowed"
 }
@@ -63,7 +63,7 @@ deny[msg] {
 }
 
 deny[msg] {
-  input.Resources.LambdaFunction.Properties.Environment.Variables = a; check_sensitive(a, sensitive_blacklist)
+  input.Resources.LambdaFunction.Properties.Environment.Variables = a; check_sensitive(a, sensitive_denylist)
   input.Resources.LambdaFunction.Properties.Policies[_].Statement[_].Effect = "Allow"
   msg = "Sensitive data not allowed in environment variables"
 }

--- a/examples/docker/policy/base.rego
+++ b/examples/docker/policy/base.rego
@@ -1,13 +1,13 @@
 package main
 
-blacklist = [
+denylist = [
   "openjdk"
 ]
 
 deny[msg] {
   input[i].Cmd == "from"
   val := input[i].Value
-  contains(val[i], blacklist[_])
+  contains(val[i], denylist[_])
 
-  msg = sprintf("blacklisted image found %s", [val])
+  msg = sprintf("unallowed image found %s", [val])
 }

--- a/examples/docker/policy/commands.rego
+++ b/examples/docker/policy/commands.rego
@@ -1,6 +1,6 @@
 package commands
 
-blacklist = [
+denylist = [
   "apk",
   "apt",
   "pip",
@@ -11,7 +11,7 @@ blacklist = [
 deny[msg] {
   input[i].Cmd == "run"
   val := input[i].Value
-  contains(val[_], blacklist[_])
+  contains(val[_], denylist[_])
 
-  msg = sprintf("blacklisted commands found %s", [val])
+  msg = sprintf("unallowed commands found %s", [val])
 }

--- a/examples/hcl1/policy/base.rego
+++ b/examples/hcl1/policy/base.rego
@@ -1,14 +1,13 @@
 package main
 
-
-blacklist = [
+denylist = [
   "google_iam",
   "google_container"
 ]
 
 deny[msg] {
-  check_resources(input.resource_changes, blacklist)
-  banned := concat(", ", blacklist)
+  check_resources(input.resource_changes, denylist)
+  banned := concat(", ", denylist)
   msg = sprintf("Terraform plan will change prohibited resources in the following namespaces: %v", [banned])
 }
 

--- a/examples/traefik/policy/base.rego
+++ b/examples/traefik/policy/base.rego
@@ -9,6 +9,6 @@ deny[msg] {
   msg = sprintf("Following ciphers are not allowed: %v", [disallowed_ciphers])
 }
 
-check_trusted_ips(ciphers, blacklist) {
-  ciphers[_] = blacklist[_]
+check_trusted_ips(ciphers, denylist) {
+  ciphers[_] = denylist[_]
 }


### PR DESCRIPTION
I feel Conftest should try to set a good example by using better terminology where possible, especially given recent events. Additionally, given the fact that we already specifically look for "deny" rules to know which to process, this keeps our terminology consistent.