### PR TITLE
Fix badge for Netlify docs deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conftest
 
-[![CircleCI](https://circleci.com/gh/open-policy-agent/conftest.svg?style=svg)](https://circleci.com/gh/open-policy-agent/conftest) [![Netlify](https://api.netlify.com/api/v1/badges/6a0aee44-2654-43d5-8558-ea1b8a9e6c43/deploy-status)](https://app.netlify.com/sites/quirky-almeida-4e0967/deploys)
+[![CircleCI](https://circleci.com/gh/open-policy-agent/conftest.svg?style=svg)](https://circleci.com/gh/open-policy-agent/conftest) [![Netlify](https://api.netlify.com/api/v1/badges/2d928746-3380-4123-b0eb-1fd74ba390db/deploy-status)](https://app.netlify.com/sites/vibrant-villani-65041c/deploys)
 
 Conftest helps you write tests against structured configuration data. Using Conftest you can
 write tests for your Kubernetes configuration, Tekton pipeline definitions, Terraform code,


### PR DESCRIPTION
Moving the site over to the new repository caused the old badge to
break.