### PR TITLE
Add support for JUnit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/hashicorp/hcl/v2 v2.2.0
+	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/logrusorgru/aurora v0.0.0-20191116043053-66b7ad493a23
 	github.com/moby/buildkit v0.3.3
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -5,11 +5,13 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1 h1:lRi0CHyU+ytlvylOlFKKq0af6JncuyoRh1J+QJBqQx0=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
+cloud.google.com/go v0.46.3 h1:AVXDdKsrtX33oR9fbCMu/+c1o8Ofjq6Ku/MInaLVg5Y=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
+cloud.google.com/go/storage v1.0.0 h1:VV2nUM3wwLLGh9lSABFgZMjInyUbJeaRSE64WuAIQ+4=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cuelang.org/go v0.0.15 h1:rpZtf1ZGYfZwbMHLwIif5Gczil+HF7rHAU7MFNOGV/A=
 cuelang.org/go v0.0.15/go.mod h1:gehQASsTv+lFZknWIG0hANGVSBiHD7HyKWmAdEZL3No=
@@ -190,6 +192,7 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-getter v1.4.0 h1:ENHNi8494porjD0ZhIrjlAHnveSFhY7hvOJrV/fsKkw=
 github.com/hashicorp/go-getter v1.4.0/go.mod h1:7qxyCd8rBfcShwsvxgIguu4KbS3l8bUCwg2Umn7RjeY=
@@ -224,6 +227,7 @@ github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7 h1:SMvOWPJCES
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -534,6 +538,7 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0 h1:jbyannxz0XFD3zdjgrSUsaJbgpH4eTrkdhRChkHPfO8=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.13.0 h1:Q3Ui3V3/CVinFWFiW39Iw0kMuVrRzYX0wN6OPFp0lTA=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -551,6 +556,7 @@ google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBrqXvoKpeg0TB2l7cyZUmoaFKYIwrEpbDKLA8=
+google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a h1:Ob5/580gVHBJZgXnff1cZDbG+xLtMVE5mDRTe+nIsX4=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
@@ -419,9 +420,15 @@ func (j *JUnitOutputManager) Put(cr CheckResult) error {
 		return out
 	}
 	convert := func(r Result, status parser.Result) *parser.Test {
+		// We have to make sure that the name of the test is unique
+		name := fmt.Sprintf(
+			"%s - %s",
+			cr.FileName,
+			strings.Split(r.Message, "\n")[0],
+		)
+
 		return &parser.Test{
-			// We have to make sure that the name of the test is unique
-			Name:   fmt.Sprintf("%s - %s", cr.FileName, r.Message),
+			Name:   name,
 			Result: status,
 			Output: getOutput(r),
 		}

--- a/internal/commands/output.go
+++ b/internal/commands/output.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 
+	"github.com/jstemmer/go-junit-report/formatter"
+	"github.com/jstemmer/go-junit-report/parser"
 	"github.com/logrusorgru/aurora"
 	table "github.com/olekukonko/tablewriter"
 )
@@ -17,6 +20,7 @@ const (
 	outputJSON  = "json"
 	outputTAP   = "tap"
 	outputTable = "table"
+	outputJUnit = "junit"
 )
 
 // ValidOutputs returns the available output formats for reporting tests
@@ -26,6 +30,7 @@ func ValidOutputs() []string {
 		outputJSON,
 		outputTAP,
 		outputTable,
+		outputJUnit,
 	}
 }
 
@@ -40,6 +45,8 @@ func GetOutputManager(outputFormat string, color bool) OutputManager {
 		return NewDefaultTAPOutputManager()
 	case outputTable:
 		return NewDefaultTableOutputManager()
+	case outputJUnit:
+		return NewDefaultJUnitOutputManager()
 	default:
 		return NewDefaultStandardOutputManager(color)
 	}
@@ -127,33 +134,33 @@ func (s *StandardOutputManager) Flush() error {
 
 	totalPolicies := totalFailures + totalWarnings + totalSuccesses
 
-    var outputColor aurora.Color
-    if totalFailures > 0 {
-        outputColor = aurora.RedFg
-    } else if totalWarnings > 0 {
-        outputColor = aurora.YellowFg
-    } else {
-        outputColor = aurora.GreenFg
-    }
+	var outputColor aurora.Color
+	if totalFailures > 0 {
+		outputColor = aurora.RedFg
+	} else if totalWarnings > 0 {
+		outputColor = aurora.YellowFg
+	} else {
+		outputColor = aurora.GreenFg
+	}
 
-    var pluralSuffixTests string
-    if totalPolicies != 1 {
-        pluralSuffixTests = "s"
-    }
+	var pluralSuffixTests string
+	if totalPolicies != 1 {
+		pluralSuffixTests = "s"
+	}
 
-    var pluralSuffixWarnings string
-    if totalWarnings != 1 {
-        pluralSuffixWarnings = "s"
-    }
+	var pluralSuffixWarnings string
+	if totalWarnings != 1 {
+		pluralSuffixWarnings = "s"
+	}
 
-    var pluralSuffixFailures string
-    if totalFailures != 1 {
-        pluralSuffixFailures = "s"
-    }
+	var pluralSuffixFailures string
+	if totalFailures != 1 {
+		pluralSuffixFailures = "s"
+	}
 
-    s.logger.Println()
-    outputText := fmt.Sprintf("%v test%s, %v passed, %v warning%s, %v failure%s", totalPolicies, pluralSuffixTests, totalSuccesses, totalWarnings, pluralSuffixWarnings, totalFailures, pluralSuffixFailures)
-    s.logger.Println(s.color.Colorize(outputText, outputColor))
+	s.logger.Println()
+	outputText := fmt.Sprintf("%v test%s, %v passed, %v warning%s, %v failure%s", totalPolicies, pluralSuffixTests, totalSuccesses, totalWarnings, pluralSuffixWarnings, totalFailures, pluralSuffixFailures)
+	s.logger.Println(s.color.Colorize(outputText, outputColor))
 
 	return nil
 }
@@ -376,4 +383,68 @@ func (t *TableOutputManager) Flush() error {
 	}
 
 	return nil
+}
+
+// JUnitOutputManager formats its output as a JUnit test result
+type JUnitOutputManager struct {
+	p      parser.Package
+	writer io.Writer
+}
+
+// NewDefaultJUnitOutputManager creates a new JUnitOutputManager using standard out
+func NewDefaultJUnitOutputManager() *JUnitOutputManager {
+	return NewJUnitOutputManager(os.Stdout)
+}
+
+// NewJUnitOutputManager creates a new JUnitOutputManager with a given Writer
+func NewJUnitOutputManager(w io.Writer) *JUnitOutputManager {
+	return &JUnitOutputManager{
+		writer: w,
+		p: parser.Package{
+			Name:  "conftest",
+			Tests: []*parser.Test{},
+		},
+	}
+}
+
+// Put puts the result of the check to the manager in the managers buffer
+func (j *JUnitOutputManager) Put(cr CheckResult) error {
+	getOutput := func(r Result) []string {
+		out := []string{
+			r.Message,
+		}
+		for _, err := range r.Traces {
+			out = append(out, err.Error())
+		}
+		return out
+	}
+	convert := func(r Result, status parser.Result) *parser.Test {
+		return &parser.Test{
+			// We have to make sure that the name of the test is unique
+			Name:   fmt.Sprintf("%s - %s", cr.FileName, r.Message),
+			Result: status,
+			Output: getOutput(r),
+		}
+	}
+
+	for _, result := range cr.Warnings {
+		j.p.Tests = append(j.p.Tests, convert(result, parser.FAIL))
+	}
+	for _, result := range cr.Failures {
+		j.p.Tests = append(j.p.Tests, convert(result, parser.FAIL))
+	}
+	for _, result := range cr.Successes {
+		j.p.Tests = append(j.p.Tests, convert(result, parser.PASS))
+	}
+	return nil
+}
+
+// Flush writes the contents of the managers buffer to the console
+func (j *JUnitOutputManager) Flush() error {
+	report := &parser.Report{
+		Packages: []parser.Package{
+			j.p,
+		},
+	}
+	return formatter.JUnitReportXML(report, false, runtime.Version(), j.writer)
 }

--- a/internal/commands/output_test.go
+++ b/internal/commands/output_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"reflect"
 	"strings"
@@ -31,8 +32,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			exp: []string{
 				"WARN - foo.yaml - first warning",
 				"FAIL - foo.yaml - first failure",
-                "",
-                "2 tests, 0 passed, 1 warning, 1 failure",
+				"",
+				"2 tests, 0 passed, 1 warning, 1 failure",
 			},
 		},
 		{
@@ -47,8 +48,8 @@ func Test_stdOutputManager_put(t *testing.T) {
 			exp: []string{
 				"WARN - first warning",
 				"FAIL - first failure",
-                "",
-                "2 tests, 0 passed, 1 warning, 1 failure",
+				"",
+				"2 tests, 0 passed, 1 warning, 1 failure",
 			},
 		},
 	}
@@ -247,6 +248,11 @@ func TestSupportedOutputManagers(t *testing.T) {
 			outputManager: NewDefaultTableOutputManager(),
 		},
 		{
+			name:          "JUnit should exist",
+			outputFormat:  outputJUnit,
+			outputManager: NewDefaultJUnitOutputManager(),
+		},
+		{
 			name:          "default output should exist",
 			outputFormat:  "somedefault",
 			outputManager: NewDefaultStandardOutputManager(true),
@@ -402,6 +408,76 @@ func Test_tableOutputManager_put(t *testing.T) {
 
 			if tt.exp != actual {
 				t.Errorf("unexpected output. expected %v actual %v", tt.exp, actual)
+			}
+		})
+	}
+}
+
+func Test_junitOutputManager_put(t *testing.T) {
+	type args struct {
+		fileName string
+		cr       CheckResult
+	}
+
+	tests := []struct {
+		msg  string
+		args args
+		exp  string
+	}{
+		{
+			msg: "no warnings or errors",
+			args: args{
+				cr: CheckResult{
+					FileName: "examples/kubernetes/service.yaml",
+				},
+			},
+			exp: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"0\" failures=\"0\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"go1.13.12\"></property>\n\t\t</properties>\n\t</testsuite>\n</testsuites>\n",
+		},
+		{
+			msg: "records failure and warnings",
+			args: args{
+				cr: CheckResult{
+					FileName: "examples/kubernetes/service.yaml",
+					Warnings: []Result{NewResult("first warning", []error{})},
+					Failures: []Result{NewResult("first failure", []error{
+						fmt.Errorf("this is an error"),
+					})},
+				},
+			},
+			exp: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"2\" failures=\"2\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"go1.13.12\"></property>\n\t\t</properties>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first warning\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first warning</failure>\n\t\t</testcase>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first failure\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first failure&#xA;this is an error</failure>\n\t\t</testcase>\n\t</testsuite>\n</testsuites>\n",
+		},
+		{
+			msg: "records failure with long description",
+			args: args{
+				cr: CheckResult{
+					FileName: "examples/kubernetes/service.yaml",
+					Warnings: []Result{NewResult("first warning", []error{})},
+					Failures: []Result{NewResult(`failure with long message
+
+This is the rest of the description of the failed test`, []error{})},
+				},
+			},
+			exp: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"2\" failures=\"2\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"go1.13.12\"></property>\n\t\t</properties>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first warning\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first warning</failure>\n\t\t</testcase>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - failure with long message\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">failure with long message&#xA;&#xA;This is the rest of the description of the failed test</failure>\n\t\t</testcase>\n\t</testsuite>\n</testsuites>\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			s := NewJUnitOutputManager(buf)
+
+			if err := s.Put(tt.args.cr); err != nil {
+				t.Fatalf("put output: %v", err)
+			}
+
+			if err := s.Flush(); err != nil {
+				t.Fatalf("flush output: %v", err)
+			}
+
+			actual := buf.String()
+
+			if tt.exp != actual {
+				t.Errorf("unexpected output. expected %q actual %q", tt.exp, actual)
 			}
 		})
 	}


### PR DESCRIPTION
I discovered this project through the presentation that @garethr did for HashiConf Digital and I have to say, that this looks really great, it looks like this is the tool I've been looking for forever.

This PR adds support for JUnit which is especially useful as it's a format that GitLab is able to parse to display the result in a nice UI when browsing Pull Requests. I know there is some projects that can be used to convert TAP results to JUnit but I would like not having to ask each of my co-workers to install them.

The next feature I would love to see would be having the possibility to return a long description in addition to the message:

```
package main

deny[msg, description] {
  input.kind = "Deployment"
  not input.spec.template.spec.securityContext.runAsNonRoot = true
  msg = "Containers must not run as root"
  description = `This is a long description that explains why we don't want to run 
        containers as root and highlight a possible solution to the problem.`
}
```