### PR TITLE
Fix "conftest pull" command's help message

### DIFF
--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -15,7 +15,7 @@ This command downloads individual policies from a remote location.
 
 Several locations are supported by the pull command. Under the hood
 conftest leverages go-getter (https://github.com/hashicorp/go-getter).
-The  following protocols are supported for downloading policies:
+The following protocols are supported for downloading policies:
 
 	- OCI Registries
 	- Local Files
@@ -23,7 +23,7 @@ The  following protocols are supported for downloading policies:
 	- HTTP/HTTPS
 	- Mercurial
 	- Amazon S3
-	- Google Cloud GCP
+	- Google Cloud Platform GCR
 
 The location of the policies is specified by passing an URL, e.g.:
 
@@ -35,7 +35,6 @@ URL does not contain a protocol. For example, the OCI mechanism will be used if
 an azure registry URL is passed, e.g.
 
 	$ conftest pull instrumenta.azurecr.io/my-registry
-
 
 The policy location defaults to the policy directory in the local folder.
 The location can be overridden with the '--policy' flag, e.g.:

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -23,6 +23,7 @@ The following protocols are supported for downloading policies:
 	- HTTP/HTTPS
 	- Mercurial
 	- Amazon S3
+	- Google Cloud Storage
 
 The location of the policies is specified by passing an URL, e.g.:
 

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -23,7 +23,6 @@ The following protocols are supported for downloading policies:
 	- HTTP/HTTPS
 	- Mercurial
 	- Amazon S3
-	- Google Cloud Platform GCR
 
 The location of the policies is specified by passing an URL, e.g.:
 


### PR DESCRIPTION
## What

I've...

* removed extra new line&space in `conftest help` command
* removed `Google Cloud GCP`. Added `Google Cloud Storage` instead.

## Why

`Google Cloud GCP` is not exactly accurate because `GCP` stands for `Google Cloud Platform` so `Google Cloud GCP` will mean `Google Cloud Google Cloud Platform` which is not correct.

As I mentioned in #326 , GCP's GCR is one of OCI registries(ref: [Container image formats, Google Cloud](https://cloud.google.com/container-registry/docs/image-formats)). Therefore, we can remove it from the help message.

Signed-off-by: KeisukeYamashita <19yamashita15@gmail.com>