### PR TITLE
Add GCR and ECR to OCI detector

### DIFF
--- a/downloader/detect_oci.go
+++ b/downloader/detect_oci.go
@@ -45,7 +45,7 @@ func containsOCIRegistry(src string) bool {
 }
 
 func containsLocalRegistry(src string) bool {
-	return strings.Contains(src, "127.0.0.1:5000")
+	return strings.Contains(src, "127.0.0.1:5000") || strings.Contains(src, "localhost:5000")
 }
 
 func (d *OCIDetector) detectHTTP(src string) (string, error) {

--- a/downloader/detect_oci_test.go
+++ b/downloader/detect_oci_test.go
@@ -14,6 +14,16 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"oci://user.azurecr.io/policies:tag",
 		},
 		{
+			"should detect grc",
+			"gcr.io/conftest/policies:tag",
+			"oci://gcr.io/conftest/policies:tag",
+		},
+		{
+			"should detect ecr",
+			"123456789012.dkr.ecr.us-east-1.amazonaws.com/conftest/policies:tag",
+			"oci://123456789012.dkr.ecr.us-east-1.amazonaws.com/conftest/policies:tag",
+		},
+		{
 			"should add latest tag",
 			"user.azurecr.io/policies",
 			"oci://user.azurecr.io/policies:latest",

--- a/downloader/detect_oci_test.go
+++ b/downloader/detect_oci_test.go
@@ -38,6 +38,11 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"127.0.0.1:5000/policies",
 			"oci://127.0.0.1:5000/policies:latest",
 		},
+		{
+			"should detect localhost:5000 as most likely being an OCI registry and tag it properly if no tag is supplied",
+			"localhost:5000/policies",
+			"oci://localhost:5000/policies:latest",
+		},
 	}
 	pwd := "/pwd"
 	d := &OCIDetector{}

--- a/downloader/detect_oci_test.go
+++ b/downloader/detect_oci_test.go
@@ -14,7 +14,7 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"oci://user.azurecr.io/policies:tag",
 		},
 		{
-			"should detect grc",
+			"should detect gcr",
 			"gcr.io/conftest/policies:tag",
 			"oci://gcr.io/conftest/policies:tag",
 		},


### PR DESCRIPTION
## What

As title. This PR is for adding GCR and ECR to OCI registory.

## How to test

```console
$ conftest push gcr.io/<TEST_PROJECT>/keke-test:latest -p examples/kubernetes/policy
```

```console
$ go run ./main.go pull gcr.io/<TEST_PROJECT>/keke-test:latest
```

## Why

Solves https://github.com/open-policy-agent/conftest/issues/335. 