### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,5 @@
+version: 1
+update_configs:
+  - package_manager: "go:modules"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
## What

Added `.dependable/config.yml` for configuration

## Why

Because the bot is trying to update the examples `pom.xml` which doesn't need to be updated.

https://github.com/open-policy-agent/conftest/pull/337

## References

* https://dependabot.com/docs/config-file/