### PR TITLE
Fix an issue where push would only load json data

### DIFF
--- a/policy/store.go
+++ b/policy/store.go
@@ -37,10 +37,14 @@ func ReadDataFiles(path string) ([]string, error) {
 		}
 
 		if info.IsDir() {
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+
 			return nil
 		}
 
-		if filepath.Ext(currentPath) == ".json" || filepath.Ext(currentPath) == ".yaml" {
+		if filepath.Ext(currentPath) == ".json" || filepath.Ext(currentPath) == ".yaml" || filepath.Ext(currentPath) == ".yml" {
 			data = append(data, currentPath)
 		}
 

--- a/policy/store.go
+++ b/policy/store.go
@@ -26,6 +26,33 @@ func StoreFromDataFiles(paths []string) (storage.Store, error) {
 	return store, nil
 }
 
+// ReadDataFiles returns the paths to all data documents
+// at the given path. Any JSON or YAML document
+// could be a valid document.
+func ReadDataFiles(path string) ([]string, error) {
+	var data []string
+	err := filepath.Walk(path, func(currentPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk path: %w", err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(currentPath) == ".json" || filepath.Ext(currentPath) == ".yaml" {
+			data = append(data, currentPath)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find data files: %w", err)
+	}
+
+	return data, nil
+}
+
 func filterDataFiles(abspath string, info os.FileInfo, depth int) bool {
 	pattern := "*.rego"
 	match, _ := filepath.Match(pattern, info.Name())


### PR DESCRIPTION
Something I noticed while looking at the push command: It would only load JSON files as data, not YAML, which is the current expected behaviour.