### PR TITLE
Exception docs are published but not linked in the nav

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -65,3 +65,4 @@ configuration files. As of today `conftest` supports:
 * EDN
 * VCL
 * XML
+* Jsonnet

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
     - "Options": "options.md"
     - "Installation": "install.md"
     - "Examples": "examples.md"
+    - "Exceptions": "exceptions.md"
     - "Sharing policies": "sharing.md"
     - "Debugging policies": "debug.md"
     - "Plugins": "plugins.md"


### PR DESCRIPTION
Also added a missing input format from v0.20.0