### PR TITLE
Add GitLab registry to OCI detector

### DIFF
--- a/downloader/detect_oci.go
+++ b/downloader/detect_oci.go
@@ -9,6 +9,7 @@ import (
 var matchRegistries = []*regexp.Regexp{
 	regexp.MustCompile("azurecr.io"),
 	regexp.MustCompile("gcr.io"),
+	regexp.MustCompile("registry.gitlab.com"),
 	regexp.MustCompile("[0-9]{12}.dkr.ecr.[a-z0-9-]*.amazonaws.com"),
 }
 

--- a/downloader/detect_oci_test.go
+++ b/downloader/detect_oci_test.go
@@ -24,6 +24,11 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"oci://123456789012.dkr.ecr.us-east-1.amazonaws.com/conftest/policies:tag",
 		},
 		{
+			"should detect gitlab",
+			"registry.gitlab.com/conftest/policies:tag",
+			"oci://registry.gitlab.com/conftest/policies:tag",
+		},
+		{
 			"should add latest tag",
 			"user.azurecr.io/policies",
 			"oci://user.azurecr.io/policies:latest",


### PR DESCRIPTION
## What

Add GitLab registry support for OCI detector.

## Why

Developers are now doesn't need to add `oci://` for GitLab registries.

Solves: #349
