### PR TITLE
add examples for Dockerfile and k8s deployment

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -97,7 +97,7 @@
 
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
@@ -222,13 +222,13 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 5 ]
+  [ "$count" -eq 8 ]
 }
 
 @test "Can verify rego tests" {
   run ./conftest verify --policy ./examples/kubernetes/policy
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "4 tests, 4 passed" ]]
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "4 tests, 3 passed" ]]
 }
 
 @test "Can parse inputs with 'conftest parse'" {
@@ -296,7 +296,7 @@
 @test "The number of tests run is accurate" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
   [ "$status" -eq 0 ]
-  [ "${lines[1]}" = "5 tests, 4 passed, 1 warning, 0 failures, 0 exceptions" ]
+  [ "${lines[1]}" = "8 tests, 7 passed, 1 warning, 0 failures, 0 exceptions" ]
 }
 
 @test "Exceptions reported correctly" {

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -97,7 +97,7 @@
 
 @test "Verify command has trace flag" {
     run ./conftest verify --policy ./examples/kubernetes/policy --trace
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
@@ -222,13 +222,13 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 8 ]
+  [ "$count" -eq 5 ]
 }
 
 @test "Can verify rego tests" {
   run ./conftest verify --policy ./examples/kubernetes/policy
-  [ "$status" -eq 1 ]
-  [[ "$output" =~ "4 tests, 3 passed" ]]
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
 }
 
 @test "Can parse inputs with 'conftest parse'" {

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -222,7 +222,7 @@
 @test "Output results only once" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
   count="${#lines[@]}"
-  [ "$count" -eq 5 ]
+  [ "$count" -eq 8 ]
 }
 
 @test "Can verify rego tests" {

--- a/examples/docker/policy/base.rego
+++ b/examples/docker/policy/base.rego
@@ -4,10 +4,58 @@ denylist = [
   "openjdk"
 ]
 
+# Deny usage of the following tags
+image_tag_list = [
+    "latest",
+]
+
+# This alias list is used to skip check for latest tag in multistage dockerfile
+image_alias_list = [
+    "build",
+    "base",
+    "publish",
+	"test",
+]
+
+
 deny[msg] {
   input[i].Cmd == "from"
   val := input[i].Value
   contains(val[i], denylist[_])
 
   msg = sprintf("unallowed image found %s", [val])
+}
+
+# Deny "latest" docker image
+warn[msg] {
+    input[i].Cmd == "from"
+    val := split(input[i].Value[0], ":")
+    contains(lower(val[1]), image_tag_list[_])
+    msg = sprintf("Do not use latest tag with image: %s", [input[i].Value])
+}
+
+# Deny FROM image without tag, unless listed in the "image_alias_list" list
+is_line_contains_alias_image(s) = true {
+  contains(s, image_alias_list[_])
+} else = false { true }
+
+warn[msg] {
+    input[i].Cmd == "from"
+    val := split(input[i].Value[0], ":")
+    not val[1]
+    is_from_alias := is_line_contains_alias_image(val[0])
+    is_from_alias != true
+    msg = sprintf("Do not use image without any tag: %s", [input[i].Value])
+}
+
+# Deny  build without 'user' command
+file_contains_user_cmd = true {
+  input[_].Cmd = "user"
+} else = false { true }
+
+deny[msg] {
+    input[i].Cmd == "from"
+    is_user_cmd_present := file_contains_user_cmd
+    is_user_cmd_present != true
+    msg = "Dockerfile does not contain USER, run as a root suspected"
 }

--- a/examples/kubernetes/policy/base_test.rego
+++ b/examples/kubernetes/policy/base_test.rego
@@ -39,13 +39,26 @@ test_deployment_with_security_context {
       },
       "template": {
         "spec": {
-          "securityContext": {
-            "runAsNonRoot": true
-          }
+		  "automountServiceAccountToken": false,
+		  "securityContext": {
+		    "runAsNonRoot": true
+		  },
+		  "containers": [
+		    {
+			"securityContext": {
+			  "allowPrivilegeEscalation": false,
+			  "capabilities": {
+			    "drop": ["AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"]
+			  }
+            }
+			}
+		  ]
         }
       }
     }
   }
+
+
 
   no_violations with input as input
 }

--- a/examples/kubernetes/policy/deny.rego
+++ b/examples/kubernetes/policy/deny.rego
@@ -11,6 +11,26 @@ deny[msg] {
   msg = sprintf("Containers must not run as root in Deployment %s", [name])
 }
 
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.allowPrivilegeEscalation == false
+  msg = "Containers must not allow privilege escalation"
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  container := input.spec.template.spec.containers[_]
+  not container.securityContext.capabilities.drop == ["AUDIT_WRITE", "CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "MKNOD", "NET_BIND_SERVICE", "NET_RAW", "SETFCAP", "SETGID", "SETPCAP", "SETUID", "SYS_CHROOT"]
+  msg = "Containers must drop following capabilities: AUDIT_WRITE, CHOWN, DAC_OVERRIDE, FOWNER, FSETID, KILL, MKNOD, NET_BIND_SERVICE, NET_RAW, SETFCAP, SETGID, SETPCAP, SETUID, SYS_CHROOT "
+}
+
+deny[msg] {
+  input.kind == "Deployment"
+  not input.spec.template.spec.automountServiceAccountToken == false
+  msg = "Containers must not allow automount serviceaccount token"
+}
+
 required_deployment_selectors {
   input.spec.selector.matchLabels.app
   input.spec.selector.matchLabels.release

--- a/internal/commands/test_test.go
+++ b/internal/commands/test_test.go
@@ -180,13 +180,13 @@ metadata:
 		t.Fatalf("could not process policy file: %s", err)
 	}
 
-	const expectedFailures = 2
+	const expectedFailures = 3
 	actualFailures := len(results.Failures)
 	if actualFailures != expectedFailures {
 		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 1
+	const expectedSuccesses = 2
 	actualSuccesses := len(results.Successes)
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
@@ -231,13 +231,13 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 		t.Fatalf("could not process policy file: %s", err)
 	}
 
-	const expectedFailures = 1
+	const expectedFailures = 2
 	actualFailures := len(results.Failures)
 	if actualFailures != expectedFailures {
 		t.Errorf("Dockerfile test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 0
+	const expectedSuccesses = 2
 	actualSuccesses := len(results.Successes)
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)


### PR DESCRIPTION
The following examples are added:
- Dockerfile
   - deny "latest" tag usage
   - deny image without any tag usage, unless it is multistage alias
   - deny build as root by skipping USER command
- k8s deployment
  - deny "allowPrivilegeEscalation"
  - deny "automountServiceAccountToken"
  - force dropping capabilities