### PR TITLE
Handle Rego errors in conftest verify

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -311,3 +311,9 @@
   [ "$status" -eq 1 ]
   [[ "$output" =~ "2 tests, 0 passed, 0 warnings, 2 failures" ]]
 }
+
+@test "Fail when there is a Rego error in test" {
+  run ./conftest verify -p examples/div-zero/policy --no-color
+
+  [ "$status" -eq 1 ]
+}

--- a/acceptance.bats
+++ b/acceptance.bats
@@ -92,7 +92,7 @@
 @test "Test command works with nested namespaces" {
   run ./conftest test --namespace main.gke -p examples/hcl1/policy/ examples/hcl1/gke.tf --no-color
   [ "$status" -eq 1 ]
-  [ "${lines[1]}" = "1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions" ]
+  [ "${lines[1]}" = "1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions, 0 errors" ]
 }
 
 @test "Verify command has trace flag" {
@@ -296,13 +296,13 @@
 @test "The number of tests run is accurate" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
   [ "$status" -eq 0 ]
-  [ "${lines[1]}" = "5 tests, 4 passed, 1 warning, 0 failures, 0 exceptions" ]
+  [ "${lines[1]}" = "5 tests, 4 passed, 1 warning, 0 failures, 0 exceptions, 0 errors" ]
 }
 
 @test "Exceptions reported correctly" {
   run ./conftest test -p examples/exceptions/policy examples/exceptions/deployments.yaml --no-color
   [ "$status" -eq 1 ]
-  [ "${lines[2]}" = "2 tests, 0 passed, 0 warnings, 1 failure, 1 exception" ]
+  [ "${lines[2]}" = "2 tests, 0 passed, 0 warnings, 1 failure, 1 exception, 0 errors" ]
 }
 
 @test "Can have multiple namespace flags" {
@@ -316,4 +316,5 @@
   run ./conftest verify -p examples/div-zero/policy --no-color
 
   [ "$status" -eq 1 ]
+  [ "${lines[1]}" = "1 test, 0 passed, 0 warnings, 0 failures, 0 exceptions, 1 error" ]
 }

--- a/examples/div-zero/policy/error_test.rego
+++ b/examples/div-zero/policy/error_test.rego
@@ -1,0 +1,6 @@
+package main
+
+# This policy will intentionally error due to division by zero
+test_deliberate_divide_by_zero_error {
+    1/0
+}

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -55,6 +55,7 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error){
 
 		var failure []output.Result
 		var success []output.Result
+		var regoError []output.Result
 
 		buf := new(bytes.Buffer)
 		topdown.PrettyTrace(buf, result.Trace)
@@ -67,6 +68,8 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error){
 
 		if result.Fail {
 			failure = append(failure, output.NewResult(msg.Error(), traces))
+		} else if result.Error != nil {
+			regoError = append(regoError, output.NewResult(msg.Error(), traces))
 		} else {
 			success = append(success, output.NewResult(msg.Error(), traces))
 		}
@@ -75,6 +78,7 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error){
 			FileName:  result.Location.File,
 			Successes: success,
 			Failures:  failure,
+			Errors:    regoError,
 		}
 
 		results = append(results, checkResult)

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -97,7 +97,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"filename": "examples/kubernetes/service.yaml",
 		"warnings": [],
 		"failures": [],
-		"successes": []
+		"successes": [],
+		"errors": []
 	}
 ]
 `,
@@ -124,7 +125,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 				"msg": "first failure"
 			}
 		],
-		"successes": []
+		"successes": [],
+		"errors": []
 	}
 ]
 `,
@@ -146,7 +148,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 				"msg": "first failure"
 			}
 		],
-		"successes": []
+		"successes": [],
+		"errors": []
 	}
 ]
 `,
@@ -168,7 +171,8 @@ func Test_jsonOutputManager_put(t *testing.T) {
 				"msg": "first failure"
 			}
 		],
-		"successes": []
+		"successes": [],
+		"errors": []
 	}
 ]
 `,
@@ -186,13 +190,15 @@ func Test_jsonOutputManager_put(t *testing.T) {
 		"filename": "examples/kubernetes/service.yaml",
 		"warnings": [],
 		"failures": [],
-		"successes": []
+		"successes": [],
+		"errors": []
 	},
 	{
 		"filename": "examples/kubernetes/deployment.yaml",
 		"warnings": [],
 		"failures": [],
-		"successes": []
+		"successes": [],
+		"errors": []
 	}
 ]
 `,

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -34,7 +34,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 				"WARN - foo.yaml - first warning",
 				"FAIL - foo.yaml - first failure",
 				"",
-				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions",
+				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions, 0 errors",
 			},
 		},
 		{
@@ -50,7 +50,7 @@ func Test_stdOutputManager_put(t *testing.T) {
 				"WARN - first warning",
 				"FAIL - first failure",
 				"",
-				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions",
+				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions, 0 errors",
 			},
 		},
 	}

--- a/output/result.go
+++ b/output/result.go
@@ -20,6 +20,7 @@ type CheckResult struct {
 	Failures   []Result
 	Exceptions []Result
 	Successes  []Result
+	Errors     []Result
 }
 
 // NewResult creates a new result from the given message
@@ -34,5 +35,5 @@ func NewResult(message string, traces []error) Result {
 }
 
 func IsResultFailure(result CheckResult, failOnWarn bool) bool {
-	return len(result.Failures) > 0 || (len(result.Warnings) > 0 && failOnWarn)
+	return len(result.Failures) > 0 || len(result.Errors) > 0 || (len(result.Warnings) > 0 && failOnWarn)
 }


### PR DESCRIPTION
Resolves #355 

Adds handling, tracking, and reporting of Rego errors

I've made some assumptions about representing errors in outputs and am happy to strip out or change any bits you'd prefer not to have.