### PR TITLE
Migrate dependabot to GitHub native version 2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,5 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: "go:modules"
-    directory: "/"
-    update_schedule: "live"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
## What

Currently, we are using v1 dependabot.
The v2 dependabot has GitHub native integrations.

## References

* [Configuration options for dependency updates](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates)