### PR TITLE
Ensure successes don't return a msg

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -408,7 +408,7 @@ func (t TestRun) runQuery(ctx context.Context, query string, input interface{}) 
 	for _, result := range resultSet {
 		for _, expression := range result.Expressions {
 			if !hasResults(expression.Value) {
-				successes = append(successes, output.NewResult(expression.Text, traces))
+				successes = append(successes, output.NewResult("", traces))
 				continue
 			}
 


### PR DESCRIPTION
The msg of the successes was being constructed by the expr.Location.Text that is returned from the queries inside the Rego package. The message was expected to be empty and most of the time it was, for some random successes the message contained the location of the policy. Fixes #361 . 