### PR TITLE
Chore: Refactor Test Command.

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -1,22 +1,15 @@
 package commands
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 
+	"github.com/open-policy-agent/conftest/internal/runner"
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/parser"
-	"github.com/open-policy-agent/conftest/policy"
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/topdown"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -77,12 +70,6 @@ the output will include a detailed trace of how the policy was evaluated, e.g.
 	$ conftest test --trace <input-file>
 `
 
-var (
-	denyQ                 = regexp.MustCompile("^(deny|violation)(_[a-zA-Z0-9]+)*$")
-	warnQ                 = regexp.MustCompile("^warn(_[a-zA-Z0-9]+)*$")
-	combineConfigFlagName = "combine"
-)
-
 // TestRun stores the compiler and store for a test run
 type TestRun struct {
 	Compiler *ast.Compiler
@@ -97,7 +84,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Long:  testDesc,
 		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"fail-on-warn", "update", combineConfigFlagName, "trace", "output", "input", "namespace", "all-namespaces", "data", "ignore"}
+			flagNames := []string{"fail-on-warn", "update", "combine", "trace", "output", "input", "namespace", "all-namespaces", "data", "ignore"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -111,94 +98,26 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 			outputFormat := viper.GetString("output")
 			color := !viper.GetBool("no-color")
 			out := output.GetOutputManager(outputFormat, color)
-			input := viper.GetString("input")
 
-			files, err := parseFileList(fileList, viper.GetString("ignore"))
+			runner := &runner.TestRunner{}
+			err := viper.Unmarshal(runner)
 			if err != nil {
-				return fmt.Errorf("parse files: %w", err)
+				return fmt.Errorf("unmarshal parameters: %w", err)
 			}
 
-			configManager := parser.ConfigManager{}
-			configurations, err := configManager.GetConfigurations(ctx, input, files)
+			results, err := runner.Run(ctx, fileList)
 			if err != nil {
-				return fmt.Errorf("get configurations: %w", err)
-			}
-
-			policyPaths := viper.GetStringSlice("policy")
-			urls := viper.GetStringSlice("update")
-			// Downloaded policies are put into the first policy directory specified
-			for _, url := range urls {
-				sourcedURL, err := policy.Detect(url, policyPaths[0])
-				if err != nil {
-					return fmt.Errorf("detect policies: %w", err)
-				}
-
-				if err := policy.Download(ctx, policyPaths[0], []string{sourcedURL}); err != nil {
-					return fmt.Errorf("update policies: %w", err)
-				}
-			}
-
-			regoFiles, err := policy.ReadFiles(policyPaths...)
-			if err != nil {
-				return fmt.Errorf("read rego files: %w", err)
-			}
-
-			compiler, err := policy.BuildCompiler(regoFiles)
-			if err != nil {
-				return fmt.Errorf("build compiler: %w", err)
-			}
-
-			dataPaths := viper.GetStringSlice("data")
-			store, err := policy.StoreFromDataFiles(dataPaths)
-			if err != nil {
-				return fmt.Errorf("build store: %w", err)
-			}
-
-			testRun := TestRun{
-				Compiler: compiler,
-				Store:    store,
-			}
-
-			var namespaces []string
-			if viper.GetBool("all-namespaces") {
-				namespaces, err = policy.GetNamespaces(regoFiles, compiler)
-				if err != nil {
-					return fmt.Errorf("get namespaces: %w", err)
-				}
-			} else {
-				namespaces = viper.GetStringSlice("namespace")
+				return fmt.Errorf("running test: %w", err)
 			}
 
 			var failureFound bool
-			if viper.GetBool(combineConfigFlagName) {
-				result, err := testRun.GetResult(ctx, namespaces, configurations)
-				if err != nil {
-					return fmt.Errorf("get combined test result: %w", err)
-				}
-
-				if output.IsResultFailure(result, viper.GetBool("fail-on-warn")) {
+			for _, result := range results {
+				if output.IsResultFailure(result, viper.GetBool(("fail-on-warn"))) {
 					failureFound = true
 				}
 
-				result.FileName = "Combined"
 				if err := out.Put(result); err != nil {
-					return fmt.Errorf("writing combined error: %w", err)
-				}
-			} else {
-				for fileName, config := range configurations {
-					result, err := testRun.GetResult(ctx, namespaces, config)
-					if err != nil {
-						return fmt.Errorf("get test result: %w", err)
-					}
-
-					if output.IsResultFailure(result, viper.GetBool("fail-on-warn")) {
-						failureFound = true
-					}
-
-					result.FileName = fileName
-					if err := out.Put(result); err != nil {
-						return fmt.Errorf("writing error: %w", err)
-					}
+					return fmt.Errorf("writing error: %w", err)
 				}
 			}
 
@@ -215,7 +134,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().Bool("fail-on-warn", false, "return a non-zero exit code if only warnings are found")
-	cmd.Flags().BoolP(combineConfigFlagName, "", false, "combine all given config files to be evaluated together")
+	cmd.Flags().BoolP("combine", "", false, "combine all given config files to be evaluated together")
 	cmd.Flags().Bool("trace", false, "enable more verbose trace output for rego queries")
 
 	cmd.Flags().StringSliceP("update", "u", []string{}, "a list of urls can be provided to the update flag, which will download before the tests run")
@@ -229,302 +148,3 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	return &cmd
 }
 
-// GetResult returns the result of testing the structured data against their policies
-func (t TestRun) GetResult(ctx context.Context, namespaces []string, input interface{}) (output.CheckResult, error) {
-	var totalWarnings []output.Result
-	var totalFailures []output.Result
-	var totalExceptions []output.Result
-	var totalSuccesses []output.Result
-
-	for _, namespace := range namespaces {
-		warnings, warnExceptions, successes, err := t.runRules(ctx, namespace, input, warnQ)
-		if err != nil {
-			return output.CheckResult{}, fmt.Errorf("running warn rules: %w", err)
-		}
-		totalSuccesses = append(totalSuccesses, successes...)
-
-		failures, denyExceptions, successes, err := t.runRules(ctx, namespace, input, denyQ)
-		if err != nil {
-			return output.CheckResult{}, fmt.Errorf("running deny rules: %w", err)
-		}
-		totalSuccesses = append(totalSuccesses, successes...)
-
-		totalFailures = append(totalFailures, failures...)
-		totalWarnings = append(totalWarnings, warnings...)
-		totalExceptions = append(totalExceptions, warnExceptions...)
-		totalExceptions = append(totalExceptions, denyExceptions...)
-	}
-
-	result := output.CheckResult{
-		Warnings:   totalWarnings,
-		Failures:   totalFailures,
-		Exceptions: totalExceptions,
-		Successes:  totalSuccesses,
-	}
-
-	return result, nil
-}
-
-func (t TestRun) runRules(ctx context.Context, namespace string, input interface{}, regex *regexp.Regexp) ([]output.Result, []output.Result, []output.Result, error) {
-	var successes []output.Result
-	var exceptions []output.Result
-	var errors []output.Result
-
-	var rules []string
-	var numberRules int = 0
-	for _, module := range t.Compiler.Modules {
-		currentNamespace := strings.Replace(module.Package.Path.String(), "data.", "", 1)
-		if currentNamespace == namespace {
-			for _, rule := range module.Rules {
-				ruleName := rule.Head.Name.String()
-
-				if regex.MatchString(ruleName) {
-					numberRules += 1
-					if !stringInSlice(ruleName, rules) {
-						rules = append(rules, ruleName)
-					}
-				}
-			}
-		}
-	}
-
-	var err error
-	var totalErrors []output.Result
-	var totalExceptions []output.Result
-	var totalSuccesses []output.Result
-	for _, rule := range rules {
-		query := fmt.Sprintf("data.%s.%s", namespace, rule)
-		exceptionQuery := fmt.Sprintf("data.%s.exception[_][_] == %q", namespace, removeDenyPrefix(rule))
-
-		switch input.(type) {
-		case []interface{}:
-			errors, exceptions, successes, err = t.runMultipleQueries(ctx, query, exceptionQuery, input)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("run multiple queries: %w", err)
-			}
-		default:
-			errors, exceptions, successes, err = t.filterExceptionsQuery(ctx, query, exceptionQuery, input)
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("run query: %w", err)
-			}
-		}
-
-		totalErrors = append(totalErrors, errors...)
-		totalExceptions = append(totalExceptions, exceptions...)
-		totalSuccesses = append(totalSuccesses, successes...)
-	}
-
-	for i := len(totalErrors) + len(totalSuccesses) + len(totalExceptions); i < numberRules; i++ {
-		totalSuccesses = append(totalSuccesses, output.Result{})
-	}
-
-	return totalErrors, totalExceptions, totalSuccesses, nil
-}
-
-func removeDenyPrefix(rule string) string {
-	if strings.HasPrefix(rule, "deny_") {
-		return strings.TrimPrefix(rule, "deny_")
-	} else if strings.HasPrefix(rule, "violation_") {
-		return strings.TrimPrefix(rule, "violation_")
-	}
-	return rule
-}
-
-func stringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-
-	return false
-}
-
-func (t TestRun) runMultipleQueries(ctx context.Context, query string, exceptionQuery string, inputs interface{}) ([]output.Result, []output.Result, []output.Result, error) {
-	var totalViolations []output.Result
-	var totalExceptions []output.Result
-	var totalSuccesses []output.Result
-	for _, input := range inputs.([]interface{}) {
-		violations, exceptions, successes, err := t.filterExceptionsQuery(ctx, query, exceptionQuery, input)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("run query: %w", err)
-		}
-
-		totalExceptions = append(totalExceptions, exceptions...)
-		totalViolations = append(totalViolations, violations...)
-		totalSuccesses = append(totalSuccesses, successes...)
-	}
-	return totalViolations, totalExceptions, totalSuccesses, nil
-}
-
-func (t TestRun) filterExceptionsQuery(ctx context.Context, query string, exceptionQuery string, input interface{}) ([]output.Result, []output.Result, []output.Result, error) {
-	var totalViolations []output.Result
-	var totalExceptions []output.Result
-	var totalSuccesses []output.Result
-	violations, successes, err := t.runQuery(ctx, query, input)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("run query: %w", err)
-	}
-	_, exceptions, err := t.runQuery(ctx, exceptionQuery, input)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("exception query: %w", err)
-	}
-	if len(exceptions) > 0 {
-		totalExceptions = append(totalExceptions, exceptions...)
-	} else {
-		totalViolations = append(totalViolations, violations...)
-	}
-	totalSuccesses = append(totalSuccesses, successes...)
-
-	return totalViolations, totalExceptions, totalSuccesses, nil
-}
-
-func (t TestRun) runQuery(ctx context.Context, query string, input interface{}) ([]output.Result, []output.Result, error) {
-	rego, stdout := t.buildRego(viper.GetBool("trace"), query, input)
-	resultSet, err := rego.Eval(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("evaluating policy: %w", err)
-	}
-
-	buf := new(bytes.Buffer)
-	topdown.PrettyTrace(buf, *stdout)
-	var traces []error
-	for _, line := range strings.Split(buf.String(), "\n") {
-		if len(line) > 0 {
-			traces = append(traces, errors.New(line))
-		}
-	}
-
-	hasResults := func(expression interface{}) bool {
-		if v, ok := expression.([]interface{}); ok {
-			return len(v) > 0
-		}
-
-		return false
-	}
-
-	var errs []output.Result
-	var successes []output.Result
-	for _, result := range resultSet {
-		for _, expression := range result.Expressions {
-			if !hasResults(expression.Value) {
-				successes = append(successes, output.NewResult("", traces))
-				continue
-			}
-
-			for _, v := range expression.Value.([]interface{}) {
-				switch val := v.(type) {
-				case string:
-					errs = append(errs, output.NewResult(val, traces))
-				case map[string]interface{}:
-					if _, ok := val["msg"]; !ok {
-						return nil, nil, fmt.Errorf("rule missing msg field: %v", val)
-					}
-					if _, ok := val["msg"].(string); !ok {
-						return nil, nil, fmt.Errorf("msg field must be string: %v", val)
-					}
-
-					result := output.NewResult(val["msg"].(string), traces)
-					for k, v := range val {
-						if k != "msg" {
-							result.Metadata[k] = v
-						}
-
-					}
-					errs = append(errs, result)
-				}
-			}
-		}
-	}
-
-	return errs, successes, nil
-}
-
-func (t TestRun) buildRego(trace bool, query string, input interface{}) (*rego.Rego, *topdown.BufferTracer) {
-	var regoObj *rego.Rego
-	var regoFunc []func(r *rego.Rego)
-	buf := topdown.NewBufferTracer()
-	runtime := policy.RuntimeTerm()
-
-	regoFunc = append(regoFunc, rego.Query(query), rego.Compiler(t.Compiler), rego.Input(input), rego.Store(t.Store), rego.Runtime(runtime))
-	if trace {
-		regoFunc = append(regoFunc, rego.Tracer(buf))
-	}
-
-	regoObj = rego.New(regoFunc...)
-
-	return regoObj, buf
-}
-
-func parseFileList(fileList []string, exceptions string) ([]string, error) {
-	var files []string
-	for _, file := range fileList {
-		if file == "" {
-			continue
-		}
-
-		if file == "-" {
-			files = append(files, "-")
-			continue
-		}
-
-		fileInfo, err := os.Stat(file)
-		if err != nil {
-			return nil, fmt.Errorf("get file info: %w", err)
-		}
-
-		if fileInfo.IsDir() {
-			directoryFiles, err := getFilesFromDirectory(file, exceptions)
-			if err != nil {
-				return nil, fmt.Errorf("get files from directory: %w", err)
-			}
-
-			files = append(files, directoryFiles...)
-		} else {
-			files = append(files, file)
-		}
-	}
-
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no files found")
-	}
-
-	return files, nil
-}
-
-func getFilesFromDirectory(directory string, exceptions string) ([]string, error) {
-	var files []string
-	regexp, err := regexp.Compile(exceptions)
-	if err != nil {
-		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
-	}
-
-	walk := func(currentPath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return fmt.Errorf("walk path: %w", err)
-		}
-
-		if exceptions != "" && regexp.MatchString(currentPath) {
-			return nil
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		for _, input := range parser.ValidInputs() {
-			if strings.HasSuffix(info.Name(), input) {
-				files = append(files, currentPath)
-			}
-		}
-
-		return nil
-	}
-
-	err = filepath.Walk(directory, walk)
-	if err != nil {
-		return nil, err
-	}
-
-	return files, nil
-}

--- a/internal/runner/test.go
+++ b/internal/runner/test.go
@@ -1,0 +1,330 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/open-policy-agent/conftest/output"
+	"github.com/open-policy-agent/conftest/parser"
+	"github.com/open-policy-agent/conftest/policy"
+)
+
+type TestRunner struct {
+	Trace  bool
+	Policy []string
+	Data   []string
+	Update []string
+	Ignore string
+	Input string
+	Namespace []string
+	AllNamespaces bool `mapstructure:"all-namespaces"`
+	Combine bool
+
+	engine *policy.Engine
+}
+
+var (
+	denyQ                 = regexp.MustCompile("^(deny|violation)(_[a-zA-Z0-9]+)*$")
+	warnQ                 = regexp.MustCompile("^warn(_[a-zA-Z0-9]+)*$")
+)
+
+// Run executes the TestRunner, verifying all Rego policies against the given
+// list of configuration files.
+func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.CheckResult, error) {
+	files, err := parseFileList(fileList, t.Ignore)
+	if err != nil {
+		return nil, fmt.Errorf("parse files: %w", err)
+	}
+
+	configManager := parser.ConfigManager{}
+	configurations, err := configManager.GetConfigurations(ctx, t.Input, files)
+	if err != nil {
+		return nil, fmt.Errorf("get configurations: %w", err)
+	}
+
+	loader := &policy.Loader{
+		DataPaths: t.Data,
+		PolicyPaths: t.Policy,
+		URLs: t.Update,
+	}
+
+	regoFiles, store, err := loader.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load failed: %w", err)
+	}
+
+
+	compiler, err := policy.BuildCompiler(regoFiles)
+	if err != nil {
+		return nil, fmt.Errorf("build compiler: %w", err)
+	}
+
+	engine := &policy.Engine{
+		Compiler: compiler,
+		Store: store,
+		Trace: t.Trace,
+	}
+	t.engine = engine
+
+	var namespaces []string
+	if t.AllNamespaces {
+		namespaces, err = policy.GetNamespaces(regoFiles, compiler)
+		if err != nil {
+			return nil, fmt.Errorf("get namespaces: %w", err)
+		}
+	} else {
+		namespaces = t.Namespace
+	}
+
+	var results []output.CheckResult
+	if t.Combine {
+		result, err := t.GetResult(ctx, namespaces, configurations)
+		if err != nil {
+			return nil, fmt.Errorf("get combined test result: %w", err)
+		}
+
+		result.FileName = "Combined"
+		results = append(results, result)
+		return results, nil
+	} else {
+		for fileName, config := range configurations {
+			result, err := t.GetResult(ctx, namespaces, config)
+			if err != nil {
+				return nil, fmt.Errorf("get test result: %w", err)
+			}
+
+			result.FileName = fileName
+			results = append(results, result)
+		}
+		return results, nil
+	}
+}
+
+
+func parseFileList(fileList []string, exceptions string) ([]string, error) {
+	var files []string
+	for _, file := range fileList {
+		if file == "" {
+			continue
+		}
+
+		if file == "-" {
+			files = append(files, "-")
+			continue
+		}
+
+		fileInfo, err := os.Stat(file)
+		if err != nil {
+			return nil, fmt.Errorf("get file info: %w", err)
+		}
+
+		if fileInfo.IsDir() {
+			directoryFiles, err := getFilesFromDirectory(file, exceptions)
+			if err != nil {
+				return nil, fmt.Errorf("get files from directory: %w", err)
+			}
+
+			files = append(files, directoryFiles...)
+		} else {
+			files = append(files, file)
+		}
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no files found")
+	}
+
+	return files, nil
+}
+
+func getFilesFromDirectory(directory string, exceptions string) ([]string, error) {
+	var files []string
+	regexp, err := regexp.Compile(exceptions)
+	if err != nil {
+		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
+	}
+
+	walk := func(currentPath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("walk path: %w", err)
+		}
+
+		if exceptions != "" && regexp.MatchString(currentPath) {
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		for _, input := range parser.ValidInputs() {
+			if strings.HasSuffix(info.Name(), input) {
+				files = append(files, currentPath)
+			}
+		}
+
+		return nil
+	}
+
+	err = filepath.Walk(directory, walk)
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
+
+// GetResult returns the result of testing the structured data against their policies
+func (t *TestRunner) GetResult(ctx context.Context, namespaces []string, input interface{}) (output.CheckResult, error) {
+	var totalWarnings []output.Result
+	var totalFailures []output.Result
+	var totalExceptions []output.Result
+	var totalSuccesses []output.Result
+
+	for _, namespace := range namespaces {
+		warnings, warnExceptions, successes, err := t.runRules(ctx, namespace, input, warnQ)
+		if err != nil {
+			return output.CheckResult{}, fmt.Errorf("running warn rules: %w", err)
+		}
+		totalSuccesses = append(totalSuccesses, successes...)
+
+		failures, denyExceptions, successes, err := t.runRules(ctx, namespace, input, denyQ)
+		if err != nil {
+			return output.CheckResult{}, fmt.Errorf("running deny rules: %w", err)
+		}
+		totalSuccesses = append(totalSuccesses, successes...)
+
+		totalFailures = append(totalFailures, failures...)
+		totalWarnings = append(totalWarnings, warnings...)
+		totalExceptions = append(totalExceptions, warnExceptions...)
+		totalExceptions = append(totalExceptions, denyExceptions...)
+	}
+
+	result := output.CheckResult{
+		Warnings:   totalWarnings,
+		Failures:   totalFailures,
+		Exceptions: totalExceptions,
+		Successes:  totalSuccesses,
+	}
+
+	return result, nil
+}
+
+func (t *TestRunner) runRules(ctx context.Context, namespace string, input interface{}, regex *regexp.Regexp) ([]output.Result, []output.Result, []output.Result, error) {
+	var successes []output.Result
+	var exceptions []output.Result
+	var errors []output.Result
+
+	var rules []string
+	var numberRules int = 0
+	for _, module := range t.engine.Compiler.Modules {
+		currentNamespace := strings.Replace(module.Package.Path.String(), "data.", "", 1)
+		if currentNamespace == namespace {
+			for _, rule := range module.Rules {
+				ruleName := rule.Head.Name.String()
+
+				if regex.MatchString(ruleName) {
+					numberRules += 1
+					if !stringInSlice(ruleName, rules) {
+						rules = append(rules, ruleName)
+					}
+				}
+			}
+		}
+	}
+
+	var err error
+	var totalErrors []output.Result
+	var totalExceptions []output.Result
+	var totalSuccesses []output.Result
+	for _, rule := range rules {
+		query := fmt.Sprintf("data.%s.%s", namespace, rule)
+		exceptionQuery := fmt.Sprintf("data.%s.exception[_][_] == %q", namespace, removeDenyPrefix(rule))
+
+		switch input.(type) {
+		case []interface{}:
+			errors, exceptions, successes, err = t.runMultipleQueries(ctx, query, exceptionQuery, input)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("run multiple queries: %w", err)
+			}
+		default:
+			errors, exceptions, successes, err = t.filterExceptionsQuery(ctx, query, exceptionQuery, input)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("run query: %w", err)
+			}
+		}
+
+		totalErrors = append(totalErrors, errors...)
+		totalExceptions = append(totalExceptions, exceptions...)
+		totalSuccesses = append(totalSuccesses, successes...)
+	}
+
+	for i := len(totalErrors) + len(totalSuccesses) + len(totalExceptions); i < numberRules; i++ {
+		totalSuccesses = append(totalSuccesses, output.Result{})
+	}
+
+	return totalErrors, totalExceptions, totalSuccesses, nil
+}
+
+func removeDenyPrefix(rule string) string {
+	if strings.HasPrefix(rule, "deny_") {
+		return strings.TrimPrefix(rule, "deny_")
+	} else if strings.HasPrefix(rule, "violation_") {
+		return strings.TrimPrefix(rule, "violation_")
+	}
+	return rule
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (t *TestRunner) runMultipleQueries(ctx context.Context, query string, exceptionQuery string, inputs interface{}) ([]output.Result, []output.Result, []output.Result, error) {
+	var totalViolations []output.Result
+	var totalExceptions []output.Result
+	var totalSuccesses []output.Result
+	for _, input := range inputs.([]interface{}) {
+		violations, exceptions, successes, err := t.filterExceptionsQuery(ctx, query, exceptionQuery, input)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("run query: %w", err)
+		}
+
+		totalExceptions = append(totalExceptions, exceptions...)
+		totalViolations = append(totalViolations, violations...)
+		totalSuccesses = append(totalSuccesses, successes...)
+	}
+	return totalViolations, totalExceptions, totalSuccesses, nil
+}
+
+func (t *TestRunner) filterExceptionsQuery(ctx context.Context, query string, exceptionQuery string, input interface{}) ([]output.Result, []output.Result, []output.Result, error) {
+	var totalViolations []output.Result
+	var totalExceptions []output.Result
+	var totalSuccesses []output.Result
+	violations, successes, err := t.engine.Query(ctx, query, input)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("run query: %w", err)
+	}
+	_, exceptions, err := t.engine.Query(ctx, exceptionQuery, input)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("exception query: %w", err)
+	}
+	if len(exceptions) > 0 {
+		totalExceptions = append(totalExceptions, exceptions...)
+	} else {
+		totalViolations = append(totalViolations, violations...)
+	}
+	totalSuccesses = append(totalSuccesses, successes...)
+
+	return totalViolations, totalExceptions, totalSuccesses, nil
+}

--- a/internal/runner/test_test.go
+++ b/internal/runner/test_test.go
@@ -1,4 +1,4 @@
-package commands
+package runner
 
 import (
 	"context"
@@ -12,62 +12,6 @@ import (
 	"github.com/open-policy-agent/conftest/policy"
 	"github.com/open-policy-agent/opa/storage/inmem"
 )
-
-func TestWarnQuery(t *testing.T) {
-	tests := []struct {
-		in  string
-		exp bool
-	}{
-		{"", false},
-		{"warn", true},
-		{"warnXYZ", false},
-		{"warn_", false},
-		{"warn_x", true},
-		{"warn_1", true},
-		{"warn_x_y_z", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			res := warnQ.MatchString(tt.in)
-
-			if tt.exp != res {
-				t.Errorf("%s recognized as `warn` query - expected: %v actual: %v", tt.in, tt.exp, res)
-			}
-		})
-	}
-}
-
-func TestFailQuery(t *testing.T) {
-	tests := []struct {
-		in  string
-		exp bool
-	}{
-		{"", false},
-		{"deny", true},
-		{"violation", true},
-		{"denyXYZ", false},
-		{"violationXYZ", false},
-		{"deny_", false},
-		{"violation_", false},
-		{"deny_x", true},
-		{"violation_x", true},
-		{"deny_1", true},
-		{"violation_1", true},
-		{"deny_x_y_z", true},
-		{"violation_x_y_z", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.in, func(t *testing.T) {
-			res := denyQ.MatchString(tt.in)
-
-			if tt.exp != res {
-				t.Fatalf("%s recognized as `fail` query - expected: %v actual: %v", tt.in, tt.exp, res)
-			}
-		})
-	}
-}
 
 func TestException(t *testing.T) {
 	ctx := context.Background()
@@ -112,9 +56,13 @@ spec:
 		t.Fatalf("could not build rego compiler: %s", err)
 	}
 
-	testRun := TestRun{
+	engine := &policy.Engine{
 		Compiler: compiler,
 		Store:    inmem.New(),
+	}
+
+	testRun := TestRunner{
+		engine: engine,
 	}
 
 	defaultNamespace := []string{"main"}
@@ -169,9 +117,13 @@ metadata:
 		t.Fatalf("could not build rego compiler: %s", err)
 	}
 
-	testRun := TestRun{
+	engine := &policy.Engine{
 		Compiler: compiler,
 		Store:    inmem.New(),
+	}
+
+	testRun := TestRunner{
+		engine: engine,
 	}
 
 	defaultNamespace := []string{"main"}
@@ -220,9 +172,13 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 		t.Fatalf("could not build rego compiler: %s", err)
 	}
 
-	testRun := TestRun{
+	engine := &policy.Engine{
 		Compiler: compiler,
 		Store:    inmem.New(),
+	}
+
+	testRun := TestRunner{
+		engine: engine,
 	}
 
 	defaultNamespace := []string{"main"}
@@ -241,6 +197,63 @@ ENTRYPOINT ["java","-cp","app:app/lib/*","hello.Application"]`
 	actualSuccesses := len(results.Successes)
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
+	}
+}
+
+
+func TestWarnQuery(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp bool
+	}{
+		{"", false},
+		{"warn", true},
+		{"warnXYZ", false},
+		{"warn_", false},
+		{"warn_x", true},
+		{"warn_1", true},
+		{"warn_x_y_z", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			res := warnQ.MatchString(tt.in)
+
+			if tt.exp != res {
+				t.Errorf("%s recognized as `warn` query - expected: %v actual: %v", tt.in, tt.exp, res)
+			}
+		})
+	}
+}
+
+func TestFailQuery(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp bool
+	}{
+		{"", false},
+		{"deny", true},
+		{"violation", true},
+		{"denyXYZ", false},
+		{"violationXYZ", false},
+		{"deny_", false},
+		{"violation_", false},
+		{"deny_x", true},
+		{"violation_x", true},
+		{"deny_1", true},
+		{"violation_1", true},
+		{"deny_x_y_z", true},
+		{"violation_x_y_z", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			res := denyQ.MatchString(tt.in)
+
+			if tt.exp != res {
+				t.Fatalf("%s recognized as `fail` query - expected: %v actual: %v", tt.in, tt.exp, res)
+			}
+		})
 	}
 }
 

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -21,25 +21,20 @@ type VerifyRunner struct {
 
 // Run executes the Rego tests at the given PolicyPath(s)
 func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
-	paths := r.Policy
-	regoFiles, err := policy.ReadFilesWithTests(paths...)
-	if err != nil {
-		return nil, fmt.Errorf("read rego test files: %s", err)
+	loader := &policy.Loader{
+		DataPaths: r.Data,
+		PolicyPaths: r.Policy,
 	}
 
-	if len(regoFiles) < 1 {
-		return nil, fmt.Errorf("no policies found in %s", paths)
+	loader.SetTestLoad(true)
+	regoFiles, store, err := loader.Load(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load failed: %w", err)
 	}
 
 	compiler, err := policy.BuildCompiler(regoFiles)
 	if err != nil {
 		return nil, fmt.Errorf("build compiler: %w", err)
-	}
-
-	dataPaths := r.Data
-	store, err := policy.StoreFromDataFiles(dataPaths)
-	if err != nil {
-		return nil, fmt.Errorf("build store: %w", err)
 	}
 
 	runtime := policy.RuntimeTerm()

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -1,0 +1,109 @@
+package policy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/conftest/output"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/topdown"
+)
+
+// Engine represents the policy engine
+type Engine struct {
+	Compiler *ast.Compiler
+	Store storage.Store
+	Trace bool
+}
+
+// NewEngine returns a new instatiated Engine
+func NewEngine(compiler *ast.Compiler, store storage.Store, trace bool) (*Engine) {
+	return &Engine{
+		Compiler: compiler,
+		Store: store,
+		Trace: trace,
+	}
+}
+
+// Query the policy engine with the given query and given input.
+func (e *Engine) Query(ctx context.Context, query string, input interface{}) ([]output.Result, []output.Result, error) {
+	rego, stdout := e.buildRego(e.Trace, query, input)
+	resultSet, err := rego.Eval(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("evaluating policy: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	topdown.PrettyTrace(buf, *stdout)
+	var traces []error
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if len(line) > 0 {
+			traces = append(traces, errors.New(line))
+		}
+	}
+
+	hasResults := func(expression interface{}) bool {
+		if v, ok := expression.([]interface{}); ok {
+			return len(v) > 0
+		}
+
+		return false
+	}
+
+	var errs []output.Result
+	var successes []output.Result
+	for _, result := range resultSet {
+		for _, expression := range result.Expressions {
+			if !hasResults(expression.Value) {
+				successes = append(successes, output.NewResult("", traces))
+				continue
+			}
+
+			for _, v := range expression.Value.([]interface{}) {
+				switch val := v.(type) {
+				case string:
+					errs = append(errs, output.NewResult(val, traces))
+				case map[string]interface{}:
+					if _, ok := val["msg"]; !ok {
+						return nil, nil, fmt.Errorf("rule missing msg field: %v", val)
+					}
+					if _, ok := val["msg"].(string); !ok {
+						return nil, nil, fmt.Errorf("msg field must be string: %v", val)
+					}
+
+					result := output.NewResult(val["msg"].(string), traces)
+					for k, v := range val {
+						if k != "msg" {
+							result.Metadata[k] = v
+						}
+
+					}
+					errs = append(errs, result)
+				}
+			}
+		}
+	}
+
+	return errs, successes, nil
+}
+
+func (e *Engine) buildRego(trace bool, query string, input interface{}) (*rego.Rego, *topdown.BufferTracer) {
+	var regoObj *rego.Rego
+	var regoFunc []func(r *rego.Rego)
+	buf := topdown.NewBufferTracer()
+	runtime := RuntimeTerm()
+
+	regoFunc = append(regoFunc, rego.Query(query), rego.Compiler(e.Compiler), rego.Input(input), rego.Store(e.Store), rego.Runtime(runtime))
+	if trace {
+		regoFunc = append(regoFunc, rego.Tracer(buf))
+	}
+
+	regoObj = rego.New(regoFunc...)
+
+	return regoObj, buf
+}

--- a/policy/loader.go
+++ b/policy/loader.go
@@ -1,0 +1,61 @@
+package policy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/storage"
+)
+
+// Loader handles the retrieval of all rego policies and related data.
+type Loader struct {
+	PolicyPaths []string
+	DataPaths []string
+	URLs []string
+
+	test bool
+}
+
+// SetTestLoad configures the loader to load Rego test files as well
+func (l *Loader) SetTestLoad(test bool) *Loader {
+	l.test = test
+	return l
+}
+
+// Load retrieves policies from several locations:
+// first it checks for any remote sources of policies and downloads
+// the policies into the given policy paths.
+// After retrieving the policies from the remote sources, all .rego, .json and .yaml
+// files are recursively retrieved from disk and loaded into 
+// a rego Compiler and Store respectively.
+func (l *Loader) Load(ctx context.Context) ([]string, storage.Store, error) {
+	// Downloaded policies are put into the first policy directory specified
+	for _, url := range l.URLs {
+		sourcedURL, err := Detect(url, l.PolicyPaths[0])
+		if err != nil {
+			return nil, nil, fmt.Errorf("detect policies: %w", err)
+		}
+
+		if err := Download(ctx, l.PolicyPaths[0], []string{sourcedURL}); err != nil {
+			return nil, nil, fmt.Errorf("update policies: %w", err)
+		}
+	}
+
+	var regoFiles []string
+	var err error
+	if l.test {
+		regoFiles, err = ReadFilesWithTests(l.PolicyPaths...)
+	} else {
+		regoFiles, err = ReadFiles(l.PolicyPaths...)
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read rego files: %w", err)
+	}
+
+	store, err := StoreFromDataFiles(l.DataPaths)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build store: %w", err)
+	}
+
+	return regoFiles, store, nil
+}


### PR DESCRIPTION
Fixes #363 

Loading rego files + data files has been refactored into a separate struct. The Test command now also uses the Runner pattern. An Engine class has been created to execute queries against the policies.