### PR TITLE
Mac OS support and other fixes

### DIFF
--- a/contrib/plugins/kubectl-conftest.sh
+++ b/contrib/plugins/kubectl-conftest.sh
@@ -7,7 +7,7 @@
 
 # Check if a specified command exists on the path and is executable
 function check_command () {
-    if ! [[ -x $(command -v $1) ]] ; then
+    if ! [[ -x $(command -v "$1") ]] ; then
         echo "$1 not installed"
         exit 1
     fi
@@ -22,12 +22,9 @@ function usage () {
     echo "   kubectl conftest (TYPE[.VERSION][.GROUP] [NAME] | TYPE[.VERSION][.GROUP]/NAME)"
 }
 
-SCRIPT_DIR="$( cd "$( dirname "$(readlink -f "$0")")" && pwd )"
-conftest="${SCRIPT_DIR}/conftest"
-
 # Check the required commands are available on the PATH
 check_command "kubectl"
-
+check_command "conftest"
 
 if [[ ($# -eq 0) || ($1 == "--help") || ($1 == "-h") ]]; then
     # No commands or the --help flag passed and we'll show the usage instructions
@@ -36,18 +33,24 @@ elif [[ ($# -eq 1) && $1 =~ ^[a-z\.]+$ ]]; then
     # If we have one argument we get the list of objects from kubectl
     # parse our the individual items and then pass those one by one into conftest
     check_command "jq"
-    if output=$(kubectl get $1 $2 -o json); then
-        echo $output | jq -cj '.items[] | tostring+"\u0000"' | xargs -n1 -0 -I@ bash -c "echo '@' | ${conftest} test -"
+    if output=$(kubectl get "$1" -o json); then
+        while IFS= read -r -d $'\0' json; do
+            name=$(echo "$json" | jq -cj .metadata.name)
+            echo "Testing $1/$name"
+            echo "$json" | conftest test -
+        done < <(echo "$output" | jq -cj '.items[] | tostring+"\u0000"')
     fi
 elif [[ ($# -eq 1 ) ]]; then
     # Support the / variant for getting an individual resource
-    if output=$(kubectl get $1 -o json); then
-        echo $output | ${conftest} test -
+    if output=$(kubectl get "$1" -o json); then
+        echo "Testing $1"
+        echo "$output" | conftest test -
     fi
 elif [[ ($# -eq 2 ) && $1 =~ ^[a-z]+$ ]]; then
     # if we have two arguments then we assume the first is the type and the second the resource name
-    if output=$(kubectl get $1 $2 -o json); then
-        echo $output | ${conftest} test -
+    if output=$(kubectl get "$1" "$2" -o json); then
+        echo "Testing $1/$2"
+        echo "$output" | conftest test -
     fi
 else
     echo "Please check the arguments to kubectl conftest"


### PR DESCRIPTION
Wanting to try `kubectl conftest` on my mac, I ran into a couple of errors that are fixed here. Changes:

1. Fix the single argument (resource type only) call to work on Mac OS. The xargs version there will silently discard arguments exceeding 255 bytes, which is pretty much any kubernetes resource. The replacement is tested on both OS X and Ubuntu 20.04.
2. Require conftest to be on path just as kubectl and don't expect it to be placed anywhere in particular. The previous check would also fail on Mac OS as the readline parameter '-f' is not available there.
3. Print the name of the resources as they are tested - without that the output of the tests when not providing a resource name was hard to comprehend, to say the least. Added similar printouts when actually specifying a resource name for consistency.
4. Fix all shellcheck warnings, primarily about missing quotes around variables.

Signed-off-by: Anders Eknert <anders@eknert.com>