### PR TITLE
Include warnings when subconfigs are present

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -37,7 +37,7 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 		//
 		// If the current configuration contains multiple configurations, evaluate each policy
 		// independent from one another and aggregate the results under the same file name.
-		if subconfigs, ok := config.([]interface{}); ok {
+		if subconfigs, exist := config.([]interface{}); exist {
 
 			checkResult := output.CheckResult{
 				FileName: path,
@@ -47,8 +47,10 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 				if err != nil {
 					return nil, fmt.Errorf("check: %w", err)
 				}
+
 				checkResult.Successes = append(checkResult.Successes, result.Successes...)
 				checkResult.Failures = append(checkResult.Failures, result.Failures...)
+				checkResult.Warnings = append(checkResult.Warnings, result.Warnings...)
 				checkResult.Exceptions = append(checkResult.Exceptions, result.Exceptions...)
 			}
 			checkResults = append(checkResults, checkResult)
@@ -68,16 +70,15 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 
 // CheckCombined combines the input and evaluates the policies against the combined result.
 func (e *Engine) CheckCombined(ctx context.Context, configs map[string]interface{}, namespace string) (output.CheckResult, error) {
-	result, err := e.check(ctx, "", configs, namespace)
+	result, err := e.check(ctx, "Combined", configs, namespace)
 	if err != nil {
 		return output.CheckResult{}, fmt.Errorf("combined query: %w", err)
 	}
 
-	result.FileName = "Combined"
 	return result, nil
 }
 
-// Namespaces returns all of the namespaces in the Engine.
+// Namespaces returns all of the namespaces in the engine.
 func (e *Engine) Namespaces() []string {
 	var namespaces []string
 	for _, module := range e.Modules() {

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -10,7 +10,7 @@ import (
 func TestException(t *testing.T) {
 	ctx := context.Background()
 
-	regoFiles := []string{"../examples/exceptions/policy/policy.rego", "../examples/exceptions/policy/exception.rego"}
+	regoFiles := []string{"../examples/exceptions/policy"}
 	loader := Loader{
 		PolicyPaths: regoFiles,
 	}
@@ -53,11 +53,10 @@ func TestException(t *testing.T) {
 func TestMultifileYaml(t *testing.T) {
 	ctx := context.Background()
 
-	regoFiles := []string{"../examples/kubernetes/policy/kubernetes.rego", "../examples/kubernetes/policy/deny.rego"}
+	regoFiles := []string{"../examples/kubernetes/policy"}
 	loader := Loader{
 		PolicyPaths: regoFiles,
 	}
-
 	engine, err := loader.Load(ctx)
 	if err != nil {
 		t.Fatalf("loading policies: %v", err)
@@ -74,23 +73,29 @@ func TestMultifileYaml(t *testing.T) {
 		t.Fatalf("could not process policy file: %s", err)
 	}
 
-	const expectedFailures = 2
+	const expectedFailures = 4
 	actualFailures := len(results[0].Failures)
 	if actualFailures != expectedFailures {
 		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 2
+	const expectedWarnings = 1
+	actualWarnings := len(results[0].Warnings)
+	if actualWarnings != expectedWarnings {
+		t.Errorf("Multifile yaml test failure. Got %v warnings, expected %v", actualWarnings, expectedWarnings)
+	}
+
+	const expectedSuccesses = 5
 	actualSuccesses := len(results[0].Successes)
 	if actualSuccesses != expectedSuccesses {
-		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
+		t.Errorf("Multifile yaml test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
 	}
 }
 
 func TestDockerfile(t *testing.T) {
 	ctx := context.Background()
 
-	regoFiles := []string{"../examples/docker/policy/base.rego"}
+	regoFiles := []string{"../examples/docker/policy"}
 	loader := Loader{
 		PolicyPaths: regoFiles,
 	}
@@ -124,7 +129,7 @@ func TestDockerfile(t *testing.T) {
 	}
 }
 
-func TestWarnQuery(t *testing.T) {
+func TestIsWarning(t *testing.T) {
 	tests := []struct {
 		in  string
 		exp bool
@@ -148,7 +153,7 @@ func TestWarnQuery(t *testing.T) {
 	}
 }
 
-func TestFailQuery(t *testing.T) {
+func TestIsFailure(t *testing.T) {
 	tests := []struct {
 		in  string
 		exp bool


### PR DESCRIPTION
Aggregate warnings in the subconfig loop and add a test for warnings.