### PR TITLE
Expose JSON types for marshal operations in other packages

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -138,7 +138,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolP("trace", "", false, "Enable more verbose trace output for Rego queries")
 	cmd.Flags().Bool("no-color", false, "Disable color when printing")
 	cmd.Flags().Bool("all-namespaces", false, "Test policies found in all namespaces")
-	cmd.Flags().BoolP("combine", "", false, "Combine all config files to be evaluated together")
+	cmd.Flags().Bool("combine", false, "Combine all config files to be evaluated together")
 
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
 	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("Output format for conftest results - valid options are: %s", output.ValidOutputs()))

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -54,14 +54,12 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
 		}
 
 		checkResult := output.CheckResult{
-			FileName: result.Location.File,
+			Filename: result.Location.File,
 		}
-
-		resultMessage := []output.Result{output.NewResult(result.Package+"."+result.Name, traces)}
 		if result.Fail {
-			checkResult.Failures = resultMessage
+			checkResult.Failures = []output.Result{output.NewResult(result.Package+"."+result.Name, traces)}
 		} else {
-			checkResult.Successes = resultMessage
+			checkResult.Successes++
 		}
 
 		results = append(results, checkResult)

--- a/output/json.go
+++ b/output/json.go
@@ -7,23 +7,27 @@ import (
 	"os"
 )
 
-type jsonResult struct {
+// JSONResult represents the result of a single policy evaluation
+// represented in JSON.
+type JSONResult struct {
 	Message  string                 `json:"msg"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
 	Traces   []string               `json:"traces,omitempty"`
 }
 
-type jsonCheckResult struct {
+// JSONCheckResult represents the result of checking a
+// given configuration for policy violations.
+type JSONCheckResult struct {
 	Filename  string       `json:"filename"`
 	Successes int          `json:"successes"`
-	Warnings  []jsonResult `json:"warnings"`
-	Failures  []jsonResult `json:"failures"`
+	Warnings  []JSONResult `json:"warnings"`
+	Failures  []JSONResult `json:"failures"`
 }
 
 // JSONOutputManager formats its output to JSON.
 type JSONOutputManager struct {
 	logger  *log.Logger
-	data    []jsonCheckResult
+	data    []JSONCheckResult
 	tracing bool
 }
 
@@ -51,15 +55,15 @@ func (j *JSONOutputManager) Put(cr CheckResult) error {
 		cr.FileName = ""
 	}
 
-	result := jsonCheckResult{
+	result := JSONCheckResult{
 		Filename:  cr.FileName,
 		Successes: 0,
-		Warnings:  []jsonResult{},
-		Failures:  []jsonResult{},
+		Warnings:  []JSONResult{},
+		Failures:  []JSONResult{},
 	}
 
 	for _, warning := range cr.Warnings {
-		jsonResult := jsonResult{
+		jsonResult := JSONResult{
 			Message:  warning.Message,
 			Metadata: warning.Metadata,
 		}
@@ -72,7 +76,7 @@ func (j *JSONOutputManager) Put(cr CheckResult) error {
 	}
 
 	for _, failure := range cr.Failures {
-		jsonResult := jsonResult{
+		jsonResult := JSONResult{
 			Message:  failure.Message,
 			Metadata: failure.Metadata,
 		}

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -20,14 +20,15 @@ func TestJSON(t *testing.T) {
 		{
 			msg: "no Warnings or errors",
 			args: args{
-				crs: []CheckResult{{FileName: "examples/kubernetes/service.yaml"}},
+				crs: []CheckResult{{Filename: "examples/kubernetes/service.yaml"}},
 			},
 			exp: `[
 	{
 		"filename": "examples/kubernetes/service.yaml",
 		"successes": 0,
 		"warnings": [],
-		"failures": []
+		"failures": [],
+		"exceptions": []
 	}
 ]
 `,
@@ -36,9 +37,10 @@ func TestJSON(t *testing.T) {
 			msg: "records failure and Warnings",
 			args: args{
 				crs: []CheckResult{{
-					FileName: "examples/kubernetes/service.yaml",
-					Warnings: []Result{NewResult("first warning", []error{})},
-					Failures: []Result{NewResult("first failure", []error{})},
+					Filename:   "examples/kubernetes/service.yaml",
+					Warnings:   []Result{NewResult("first warning", []error{})},
+					Failures:   []Result{NewResult("first failure", []error{})},
+					Exceptions: []Result{},
 				}},
 			},
 			exp: `[
@@ -54,7 +56,8 @@ func TestJSON(t *testing.T) {
 			{
 				"msg": "first failure"
 			}
-		]
+		],
+		"exceptions": []
 	}
 ]
 `,
@@ -63,7 +66,7 @@ func TestJSON(t *testing.T) {
 			msg: "mixed failure and Warnings",
 			args: args{
 				crs: []CheckResult{{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Failures: []Result{NewResult("first failure", []error{})},
 				}},
 			},
@@ -76,7 +79,8 @@ func TestJSON(t *testing.T) {
 			{
 				"msg": "first failure"
 			}
-		]
+		],
+		"exceptions": []
 	}
 ]
 `,
@@ -98,7 +102,8 @@ func TestJSON(t *testing.T) {
 			{
 				"msg": "first failure"
 			}
-		]
+		],
+		"exceptions": []
 	}
 ]
 `,
@@ -107,8 +112,8 @@ func TestJSON(t *testing.T) {
 			msg: "multiple check results",
 			args: args{
 				crs: []CheckResult{
-					{FileName: "examples/kubernetes/service.yaml"},
-					{FileName: "examples/kubernetes/deployment.yaml"},
+					{Filename: "examples/kubernetes/service.yaml"},
+					{Filename: "examples/kubernetes/deployment.yaml"},
 				},
 			},
 			exp: `[
@@ -116,13 +121,15 @@ func TestJSON(t *testing.T) {
 		"filename": "examples/kubernetes/service.yaml",
 		"successes": 0,
 		"warnings": [],
-		"failures": []
+		"failures": [],
+		"exceptions": []
 	},
 	{
 		"filename": "examples/kubernetes/deployment.yaml",
 		"successes": 0,
 		"warnings": [],
-		"failures": []
+		"failures": [],
+		"exceptions": []
 	}
 ]
 `,

--- a/output/junit.go
+++ b/output/junit.go
@@ -46,8 +46,8 @@ func (j *JUnitOutputManager) Put(cr CheckResult) error {
 		out := []string{
 			r.Message,
 		}
-		for _, err := range r.Traces {
-			out = append(out, err.Error())
+		for _, trace := range r.Traces {
+			out = append(out, trace)
 		}
 		return out
 	}

--- a/output/junit.go
+++ b/output/junit.go
@@ -51,11 +51,12 @@ func (j *JUnitOutputManager) Put(cr CheckResult) error {
 		}
 		return out
 	}
+
 	convert := func(r Result, status parser.Result) *parser.Test {
 		// We have to make sure that the name of the test is unique
 		name := fmt.Sprintf(
 			"%s - %s",
-			cr.FileName,
+			cr.Filename,
 			strings.Split(r.Message, "\n")[0],
 		)
 
@@ -69,12 +70,15 @@ func (j *JUnitOutputManager) Put(cr CheckResult) error {
 	for _, result := range cr.Warnings {
 		j.p.Tests = append(j.p.Tests, convert(result, parser.FAIL))
 	}
+
 	for _, result := range cr.Failures {
 		j.p.Tests = append(j.p.Tests, convert(result, parser.FAIL))
 	}
-	for _, result := range cr.Successes {
-		j.p.Tests = append(j.p.Tests, convert(result, parser.PASS))
+
+	for i := 0; i < cr.Successes; i++ {
+		j.p.Tests = append(j.p.Tests, convert(Result{}, parser.PASS))
 	}
+
 	return nil
 }
 

--- a/output/junit_test.go
+++ b/output/junit_test.go
@@ -21,7 +21,7 @@ func TestJUnit(t *testing.T) {
 			msg: "no warnings or errors",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 				},
 			},
 			exp: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"0\" failures=\"0\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"%s\"></property>\n\t\t</properties>\n\t</testsuite>\n</testsuites>\n",
@@ -30,7 +30,7 @@ func TestJUnit(t *testing.T) {
 			msg: "records failure and warnings",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult("first failure", []error{
 						fmt.Errorf("this is an error"),
@@ -43,7 +43,7 @@ func TestJUnit(t *testing.T) {
 			msg: "records failure with long description",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult(`failure with long message
 

--- a/output/result.go
+++ b/output/result.go
@@ -6,7 +6,7 @@ import "fmt"
 type Result struct {
 	Message  string                 `json:"msg"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	Traces   []error                `json:"traces,omitempty"`
+	Traces   []string               `json:"traces,omitempty"`
 }
 
 // CheckResult describes the result of a conftest policy evaluation.
@@ -25,7 +25,7 @@ func NewResult(message string, traces []error) Result {
 	result := Result{
 		Message:  message,
 		Metadata: make(map[string]interface{}),
-		Traces:   traces,
+		Traces:   errsToStrings(traces),
 	}
 
 	return result
@@ -93,4 +93,13 @@ func ExitCodeFailOnWarn(results []CheckResult) int {
 	}
 
 	return 0
+}
+
+func errsToStrings(errs []error) []string {
+	res := []string{}
+	for _, err := range errs {
+		res = append(res, err.Error())
+	}
+
+	return res
 }

--- a/output/result.go
+++ b/output/result.go
@@ -2,11 +2,22 @@ package output
 
 import "fmt"
 
-// Result describes the result of a single rule evaluation.
+// Result represents the result of a single policy evaluation.
 type Result struct {
-	Message  string
-	Metadata map[string]interface{}
-	Traces   []error
+	Message  string                 `json:"msg"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Traces   []error                `json:"traces,omitempty"`
+}
+
+// CheckResult describes the result of a conftest policy evaluation.
+// Errors produced by rego should be considered separate
+// from other classes of exceptions.
+type CheckResult struct {
+	Filename   string   `json:"filename"`
+	Successes  int      `json:"successes"`
+	Warnings   []Result `json:"warnings"`
+	Failures   []Result `json:"failures"`
+	Exceptions []Result `json:"exceptions"`
 }
 
 // NewResult creates a new result from the given message.
@@ -38,17 +49,6 @@ func NewResultWithMetadata(metadata map[string]interface{}, traces []error) (Res
 	}
 
 	return result, nil
-}
-
-// CheckResult describes the result of a conftest policy evaluation.
-// Errors produced by rego should be considered separate
-// from other classes of exceptions.
-type CheckResult struct {
-	FileName   string
-	Warnings   []Result
-	Failures   []Result
-	Exceptions []Result
-	Successes  []Result
 }
 
 // ExitCode returns the exit code that should be returned

--- a/output/standard.go
+++ b/output/standard.go
@@ -50,13 +50,13 @@ func (s *StandardOutputManager) Flush() error {
 
 	for _, cr := range s.results {
 		var indicator string
-		if cr.FileName == "-" {
+		if cr.Filename == "-" {
 			indicator = " - "
 		} else {
-			indicator = fmt.Sprintf(" - %s - ", cr.FileName)
+			indicator = fmt.Sprintf(" - %s - ", cr.Filename)
 		}
 
-		currentPolicies := len(cr.Successes) + len(cr.Warnings) + len(cr.Failures) + len(cr.Exceptions)
+		currentPolicies := cr.Successes + len(cr.Warnings) + len(cr.Failures) + len(cr.Exceptions)
 		if currentPolicies == 0 {
 			s.logger.Print(s.color.Colorize("?", aurora.WhiteFg), indicator, "no policies found")
 			continue
@@ -72,9 +72,9 @@ func (s *StandardOutputManager) Flush() error {
 
 		}
 
-		for _, r := range cr.Successes {
-			if s.tracing && len(r.Traces) > 0 {
-				printResults(r, "PASS", aurora.GreenFg)
+		for i := 0; i < cr.Successes; i++ {
+			if s.tracing {
+				printResults(Result{}, "PASS", aurora.GreenFg)
 			}
 		}
 
@@ -93,7 +93,7 @@ func (s *StandardOutputManager) Flush() error {
 		totalFailures += len(cr.Failures)
 		totalExceptions += len(cr.Exceptions)
 		totalWarnings += len(cr.Warnings)
-		totalSuccesses += len(cr.Successes)
+		totalSuccesses += cr.Successes
 	}
 
 	totalPolicies := totalFailures + totalExceptions + totalWarnings + totalSuccesses

--- a/output/standard_test.go
+++ b/output/standard_test.go
@@ -23,7 +23,7 @@ func TestStandard(t *testing.T) {
 			msg: "records failure and Warnings",
 			args: args{
 				cr: CheckResult{
-					FileName: "foo.yaml",
+					Filename: "foo.yaml",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
@@ -39,7 +39,7 @@ func TestStandard(t *testing.T) {
 			msg: "skips filenames for stdin",
 			args: args{
 				cr: CheckResult{
-					FileName: "-",
+					Filename: "-",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult("first failure", []error{})},
 				},

--- a/output/table.go
+++ b/output/table.go
@@ -47,16 +47,16 @@ func (t *TableOutputManager) Put(cr CheckResult) error {
 		}
 	}
 
-	for _, r := range cr.Successes {
-		printResults(r, "success", cr.FileName)
+	for i := 0; i < cr.Successes; i++ {
+		printResults(Result{}, "success", cr.Filename)
 	}
 
 	for _, r := range cr.Warnings {
-		printResults(r, "warning", cr.FileName)
+		printResults(r, "warning", cr.Filename)
 	}
 
 	for _, r := range cr.Failures {
-		printResults(r, "failure", cr.FileName)
+		printResults(r, "failure", cr.Filename)
 	}
 
 	return nil

--- a/output/table.go
+++ b/output/table.go
@@ -41,7 +41,7 @@ func (t *TableOutputManager) Put(cr CheckResult) error {
 
 		if t.tracing {
 			for _, trace := range r.Traces {
-				dt := []string{"trace", filename, trace.Error()}
+				dt := []string{"trace", filename, trace}
 				t.table.Append(dt)
 			}
 		}

--- a/output/table_test.go
+++ b/output/table_test.go
@@ -19,7 +19,7 @@ func TestTable(t *testing.T) {
 			msg: "no warnings or errors",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 				},
 			},
 			exp: "",
@@ -28,7 +28,7 @@ func TestTable(t *testing.T) {
 			msg: "records failure and warnings",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult("first failure", []error{})},
 				},

--- a/output/tap.go
+++ b/output/tap.go
@@ -44,7 +44,7 @@ func (t *TAPOutputManager) Put(cr CheckResult) error {
 		if len(r.Traces) > 0 && t.tracing {
 			t.logger.Print("# Traces")
 			for j, trace := range r.Traces {
-				t.logger.Print("trace ", counter, j+1, indicator, trace.Error())
+				t.logger.Print("trace ", counter, j+1, indicator, trace)
 			}
 		}
 	}

--- a/output/tap.go
+++ b/output/tap.go
@@ -33,10 +33,10 @@ func (t *TAPOutputManager) WithTracing() OutputManager {
 // Put puts the result of the check to the manager in the managers buffer
 func (t *TAPOutputManager) Put(cr CheckResult) error {
 	var indicator string
-	if cr.FileName == "-" {
+	if cr.Filename == "-" {
 		indicator = " - "
 	} else {
-		indicator = fmt.Sprintf(" - %s - ", cr.FileName)
+		indicator = fmt.Sprintf(" - %s - ", cr.Filename)
 	}
 
 	printResults := func(r Result, prefix string, counter int) {
@@ -49,13 +49,14 @@ func (t *TAPOutputManager) Put(cr CheckResult) error {
 		}
 	}
 
-	issues := len(cr.Failures) + len(cr.Warnings) + len(cr.Successes)
+	issues := len(cr.Failures) + len(cr.Warnings) + cr.Successes
 	if issues > 0 {
 		t.logger.Print(fmt.Sprintf("1..%d", issues))
 		for i, r := range cr.Failures {
 			printResults(r, "not ok ", i+1)
 
 		}
+
 		if len(cr.Warnings) > 0 {
 			t.logger.Print("# Warnings")
 			for i, r := range cr.Warnings {
@@ -63,11 +64,12 @@ func (t *TAPOutputManager) Put(cr CheckResult) error {
 				printResults(r, "not ok ", counter)
 			}
 		}
-		if len(cr.Successes) > 0 {
+
+		if cr.Successes > 0 {
 			t.logger.Print("# Successes")
-			for i, r := range cr.Successes {
+			for i := 0; i < cr.Successes; i++ {
 				counter := i + 1 + len(cr.Failures) + len(cr.Warnings)
-				printResults(r, "ok ", counter)
+				printResults(Result{}, "not ok ", counter)
 			}
 		}
 	}

--- a/output/tap_test.go
+++ b/output/tap_test.go
@@ -20,7 +20,7 @@ func TestTAP(t *testing.T) {
 			msg: "no warnings or errors",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 				},
 			},
 			exp: "",
@@ -29,7 +29,7 @@ func TestTAP(t *testing.T) {
 			msg: "records failure and warnings",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Warnings: []Result{NewResult("first warning", []error{})},
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
@@ -44,7 +44,7 @@ not ok 2 - examples/kubernetes/service.yaml - first warning
 			msg: "mixed failure and warnings",
 			args: args{
 				cr: CheckResult{
-					FileName: "examples/kubernetes/service.yaml",
+					Filename: "examples/kubernetes/service.yaml",
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
 			},
@@ -56,7 +56,7 @@ not ok 1 - examples/kubernetes/service.yaml - first failure
 			msg: "handles stdin input",
 			args: args{
 				cr: CheckResult{
-					FileName: "-",
+					Filename: "-",
 					Failures: []Result{NewResult("first failure", []error{})},
 				},
 			},

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -40,7 +40,7 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 		if subconfigs, exist := config.([]interface{}); exist {
 
 			checkResult := output.CheckResult{
-				FileName: path,
+				Filename: path,
 			}
 			for _, subconfig := range subconfigs {
 				result, err := e.check(ctx, path, subconfig, namespace)
@@ -48,7 +48,7 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 					return nil, fmt.Errorf("check: %w", err)
 				}
 
-				checkResult.Successes = append(checkResult.Successes, result.Successes...)
+				checkResult.Successes++
 				checkResult.Failures = append(checkResult.Failures, result.Failures...)
 				checkResult.Warnings = append(checkResult.Warnings, result.Warnings...)
 				checkResult.Exceptions = append(checkResult.Exceptions, result.Exceptions...)
@@ -168,7 +168,7 @@ func (e *Engine) check(ctx context.Context, path string, config interface{}, nam
 	}
 
 	checkResult := output.CheckResult{
-		FileName: path,
+		Filename: path,
 	}
 	for rule, count := range rules {
 		exceptionQuery := fmt.Sprintf("data.%s.exception[_][_] == %q", namespace, removeFailurePrefix(rule))
@@ -227,7 +227,7 @@ func (e *Engine) check(ctx context.Context, path string, config interface{}, nam
 			successes = append(successes, output.Result{})
 		}
 
-		checkResult.Successes = append(checkResult.Successes, successes...)
+		checkResult.Successes++
 		checkResult.Failures = append(checkResult.Failures, failures...)
 		checkResult.Warnings = append(checkResult.Warnings, warnings...)
 		checkResult.Exceptions = append(checkResult.Exceptions, exceptions...)

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -48,7 +48,7 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 					return nil, fmt.Errorf("check: %w", err)
 				}
 
-				checkResult.Successes++
+				checkResult.Successes = checkResult.Successes + result.Successes
 				checkResult.Failures = append(checkResult.Failures, result.Failures...)
 				checkResult.Warnings = append(checkResult.Warnings, result.Warnings...)
 				checkResult.Exceptions = append(checkResult.Exceptions, result.Exceptions...)
@@ -197,12 +197,12 @@ func (e *Engine) check(ctx context.Context, path string, config interface{}, nam
 			return output.CheckResult{}, fmt.Errorf("query input: %w", err)
 		}
 
-		var successes []output.Result
+		var successes int
 		var failures []output.Result
 		var warnings []output.Result
 		for _, ruleResult := range ruleResults {
 			if ruleResult.Message == "" {
-				successes = append(successes, ruleResult)
+				successes++
 				continue
 			}
 
@@ -223,11 +223,11 @@ func (e *Engine) check(ctx context.Context, path string, config interface{}, nam
 		// To get the true number of successes, add up the total number of evaluations
 		// that exist and add success results until the number of evaluations is the
 		// same as the number of evaluated rules.
-		for i := len(successes) + len(failures) + len(warnings) + len(exceptions); i < count; i++ {
-			successes = append(successes, output.Result{})
+		for i := successes + len(failures) + len(warnings) + len(exceptions); i < count; i++ {
+			successes++
 		}
 
-		checkResult.Successes++
+		checkResult.Successes = checkResult.Successes + successes
 		checkResult.Failures = append(checkResult.Failures, failures...)
 		checkResult.Warnings = append(checkResult.Warnings, warnings...)
 		checkResult.Exceptions = append(checkResult.Exceptions, exceptions...)

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -37,8 +37,8 @@ func TestException(t *testing.T) {
 		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 0
-	actualSuccesses := len(results[0].Successes)
+	const expectedSuccesses = 2
+	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
 	}
@@ -85,8 +85,8 @@ func TestMultifileYaml(t *testing.T) {
 		t.Errorf("Multifile yaml test failure. Got %v warnings, expected %v", actualWarnings, expectedWarnings)
 	}
 
-	const expectedSuccesses = 5
-	actualSuccesses := len(results[0].Successes)
+	const expectedSuccesses = 2
+	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
 	}
@@ -122,8 +122,8 @@ func TestDockerfile(t *testing.T) {
 		t.Errorf("Dockerfile test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 0
-	actualSuccesses := len(results[0].Successes)
+	const expectedSuccesses = 1
+	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
 	}

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -37,7 +37,7 @@ func TestException(t *testing.T) {
 		t.Errorf("Multifile yaml test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 2
+	const expectedSuccesses = 0
 	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v success, expected %v", actualSuccesses, expectedSuccesses)
@@ -85,7 +85,7 @@ func TestMultifileYaml(t *testing.T) {
 		t.Errorf("Multifile yaml test failure. Got %v warnings, expected %v", actualWarnings, expectedWarnings)
 	}
 
-	const expectedSuccesses = 2
+	const expectedSuccesses = 1
 	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
@@ -122,7 +122,7 @@ func TestDockerfile(t *testing.T) {
 		t.Errorf("Dockerfile test failure. Got %v failures, expected %v", actualFailures, expectedFailures)
 	}
 
-	const expectedSuccesses = 1
+	const expectedSuccesses = 0
 	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)


### PR DESCRIPTION
When using `conftest test file --output json` it may be desirable to capture the JSON and Unmarshal it into a type--however these are not currently exposed.

https://github.com/open-policy-agent/conftest/issues/387

edit: I'll wrap this up tomorrow--I also just noticed we have two types that should really just be combined (jsonCheckResult/CheckResult and jsonResult/Result)