### PR TITLE
Load policies and data documents individually

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -12,7 +12,6 @@ import (
 	"github.com/open-policy-agent/conftest/output"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
@@ -21,7 +20,7 @@ import (
 
 // Engine represents the policy engine.
 type Engine struct {
-	result   *loader.Result
+	modules  map[string]*ast.Module
 	compiler *ast.Compiler
 	store    storage.Store
 	docs     map[string]string
@@ -105,8 +104,8 @@ func (e *Engine) Documents() map[string]string {
 // and its value is the raw contents of the loaded policy.
 func (e *Engine) Policies() map[string]string {
 	policies := make(map[string]string)
-	for m := range e.result.Modules {
-		policies[e.result.Modules[m].Name] = string(e.result.Modules[m].Raw)
+	for path, module := range e.Modules() {
+		policies[path] = module.String()
 	}
 
 	return policies
@@ -124,7 +123,7 @@ func (e *Engine) Store() storage.Store {
 
 // Modules returns the modules from the loaded policies.
 func (e *Engine) Modules() map[string]*ast.Module {
-	return e.result.ParsedModules()
+	return e.modules
 }
 
 // Runtime returns the runtime of the engine.


### PR DESCRIPTION
Because we allow end-users to explicitly specify the paths for both policy and data, it could lead to unexpected errors when attempting to load a given path. 

There could exist other valid documents (like data documents), that would also get loaded and have the potential to error. This does force us to load the policies and documents separately.