### PR TITLE
Set policy flag as string

### DIFF
--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -70,7 +70,7 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
+	cmd.Flags().StringP("policy", "p", "policy", "Path to download the policies to")
 
 	return &cmd
 }


### PR DESCRIPTION
Define a `policy` flag for the `pull` command rather than the typical StringSlice used in other commands.