### PR TITLE
Simplify exposed output package methods

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -64,18 +64,6 @@
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
 
-@test "Test command with json output and trace flag" {
-  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o json --trace
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "data.kubernetes.is_service" ]]
-}
-
-@test "Test command with tap output and trace flag" {
-  run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -o tap --trace
-  [ "$status" -eq 0 ]
-  [[ "$output" =~ "data.kubernetes.is_service" ]]
-}
-
 @test "Test command with all namespaces flag" {
   run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --all-namespaces
   [ "$status" -eq 1 ]

--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -66,7 +66,7 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolP("combine", "", false, "Combine all config files to be evaluated together")
+	cmd.Flags().Bool("combine", false, "Combine all config files to be evaluated together")
 	cmd.Flags().StringP("input", "i", "", fmt.Sprintf("Input type for given source, especially useful when using conftest with stdin, valid options are: %s", parser.ValidInputs()))
 
 	return &cmd

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -105,19 +105,9 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running test: %w", err)
 			}
 
-			outputManager := output.GetOutputManager(runner.Output, !runner.NoColor)
-			if runner.Trace {
-				outputManager = outputManager.WithTracing()
-			}
-
-			for _, result := range results {
-				if err := outputManager.Put(result); err != nil {
-					return fmt.Errorf("put: %w", err)
-				}
-			}
-
-			if err := outputManager.Flush(); err != nil {
-				return fmt.Errorf("flushing output: %w", err)
+			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, Tracing: runner.Trace})
+			if err := outputter.Output(results); err != nil {
+				return fmt.Errorf("output results: %w", err)
 			}
 
 			var exitCode int
@@ -141,7 +131,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().BoolP("combine", "", false, "Combine all config files to be evaluated together")
 
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
-	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("Output format for conftest results - valid options are: %s", output.ValidOutputs()))
+	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
 	cmd.Flags().StringP("input", "i", "", fmt.Sprintf("Input type for given source, especially useful when using conftest with stdin, valid options are: %s", parser.ValidInputs()))
 
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")

--- a/output/junit_test.go
+++ b/output/junit_test.go
@@ -4,62 +4,101 @@ import (
 	"bytes"
 	"fmt"
 	"runtime"
+	"strings"
 	"testing"
 )
 
 func TestJUnit(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    CheckResult
-		expected string
+		input    []CheckResult
+		expected []string
 	}{
 		{
-			name: "no warnings or errors",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
+			name: "No warnings or failures",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+				},
 			},
-			expected: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"0\" failures=\"0\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"%s\"></property>\n\t\t</properties>\n\t</testsuite>\n</testsuites>\n",
+			expected: []string{
+				`<?xml version="1.0" encoding="UTF-8"?>`,
+				`<testsuites>`,
+				`	<testsuite tests="0" failures="0" time="0.000" name="conftest">`,
+				`		<properties>`,
+				`			<property name="go.version" value="%s"></property>`,
+				`		</properties>`,
+				`	</testsuite>`,
+				`</testsuites>`,
+				``,
+			},
 		},
 		{
-			name: "records failure and warnings",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: "first failure"}},
+			name: "A warning and a failure",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+					Warnings: []Result{{Message: "first warning"}},
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
-			expected: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"2\" failures=\"2\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"%s\"></property>\n\t\t</properties>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first warning\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first warning</failure>\n\t\t</testcase>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first failure\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first failure</failure>\n\t\t</testcase>\n\t</testsuite>\n</testsuites>\n",
+			expected: []string{
+				`<?xml version="1.0" encoding="UTF-8"?>`,
+				`<testsuites>`,
+				`	<testsuite tests="2" failures="2" time="0.000" name="conftest">`,
+				`		<properties>`,
+				`			<property name="go.version" value="%s"></property>`,
+				`		</properties>`,
+				`		<testcase classname="conftest" name="examples/kubernetes/service.yaml - first warning" time="0.000">`,
+				`			<failure message="Failed" type="">first warning</failure>`,
+				`		</testcase>`,
+				`		<testcase classname="conftest" name="examples/kubernetes/service.yaml - first failure" time="0.000">`,
+				`			<failure message="Failed" type="">first failure</failure>`,
+				`		</testcase>`,
+				`	</testsuite>`,
+				`</testsuites>`,
+				``,
+			},
 		},
 		{
-			name: "records failure with long description",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: `failure with long message
+			name: "Failure with a long description",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+					Failures: []Result{{Message: `failure with long message
 
-This is the rest of the description of the failed test`},
-				}},
-			expected: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuites>\n\t<testsuite tests=\"2\" failures=\"2\" time=\"0.000\" name=\"conftest\">\n\t\t<properties>\n\t\t\t<property name=\"go.version\" value=\"%s\"></property>\n\t\t</properties>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - first warning\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">first warning</failure>\n\t\t</testcase>\n\t\t<testcase classname=\"conftest\" name=\"examples/kubernetes/service.yaml - failure with long message\" time=\"0.000\">\n\t\t\t<failure message=\"Failed\" type=\"\">failure with long message&#xA;&#xA;This is the rest of the description of the failed test</failure>\n\t\t</testcase>\n\t</testsuite>\n</testsuites>\n",
+This is the rest of the description of the failed test`}},
+				},
+			},
+			expected: []string{
+				`<?xml version="1.0" encoding="UTF-8"?>`,
+				`<testsuites>`,
+				`	<testsuite tests="1" failures="1" time="0.000" name="conftest">`,
+				`		<properties>`,
+				`			<property name="go.version" value="%s"></property>`,
+				`		</properties>`,
+				`		<testcase classname="conftest" name="examples/kubernetes/service.yaml - failure with long message" time="0.000">`,
+				`			<failure message="Failed" type="">failure with long message&#xA;&#xA;This is the rest of the description of the failed test</failure>`,
+				`		</testcase>`,
+				`	</testsuite>`,
+				`</testsuites>`,
+				``,
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expected := fmt.Sprintf(strings.Join(tt.expected, "\n"), runtime.Version())
+
 			buf := new(bytes.Buffer)
-			s := NewJUnitOutputManager(buf)
-
-			if err := s.Put(tt.input); err != nil {
-				t.Fatalf("put output: %v", err)
+			if err := NewJUnit(buf).Output(tt.input); err != nil {
+				t.Fatal("output junit:", err)
 			}
-
-			if err := s.Flush(); err != nil {
-				t.Fatalf("flush output: %v", err)
-			}
-
 			actual := buf.String()
 
-			exp := fmt.Sprintf(tt.expected, runtime.Version())
-			if exp != actual {
-				t.Errorf("unexpected output. expected %s actual %s", tt.expected, actual)
+			if expected != actual {
+				t.Errorf("Unexpected output. expected %v actual %v", expected, actual)
 			}
 		})
 	}

--- a/output/output.go
+++ b/output/output.go
@@ -1,45 +1,55 @@
 package output
 
+import "os"
+
+// Outputter controls how results of an evaluation will
+// be recorded and reported to the end user.
+type Outputter interface {
+	Output([]CheckResult) error
+}
+
+// Options represents the options available when configuring
+// an Outputter.
+type Options struct {
+	Tracing bool
+	NoColor bool
+}
+
+// The defined output formats represent all of the supported formats
+// that can be used to format and render results.
 const (
-	outputSTD   = "stdout"
-	outputJSON  = "json"
-	outputTAP   = "tap"
-	outputTable = "table"
-	outputJUnit = "junit"
+	OutputStandard = "stdout"
+	OutputJSON     = "json"
+	OutputTAP      = "tap"
+	OutputTable    = "table"
+	OutputJUnit    = "junit"
 )
 
-// ValidOutputs returns the available output formats for reporting tests.
-func ValidOutputs() []string {
-	return []string{
-		outputSTD,
-		outputJSON,
-		outputTAP,
-		outputTable,
-		outputJUnit,
+// Get returns a type that can render output in the given format.
+func Get(format string, options Options) Outputter {
+	switch format {
+	case OutputStandard:
+		return &Standard{Writer: os.Stdout, NoColor: options.NoColor, Tracing: options.Tracing}
+	case OutputJSON:
+		return NewJSON(os.Stdout)
+	case OutputTAP:
+		return NewTAP(os.Stdout)
+	case OutputTable:
+		return NewTable(os.Stdout)
+	case OutputJUnit:
+		return NewJUnit(os.Stdout)
+	default:
+		return NewStandard(os.Stdout)
 	}
 }
 
-// OutputManager controls how results of an evaluation will be recorded and reported to the end user.
-type OutputManager interface {
-	Put(cr CheckResult) error
-	Flush() error
-	WithTracing() OutputManager
-}
-
-// GetOutputManager returns the OutputManager based on the user input.
-func GetOutputManager(outputFormat string, color bool) OutputManager {
-	switch outputFormat {
-	case outputSTD:
-		return NewDefaultStandardOutputManager(color)
-	case outputJSON:
-		return NewDefaultJSONOutputManager()
-	case outputTAP:
-		return NewDefaultTAPOutputManager()
-	case outputTable:
-		return NewDefaultTableOutputManager()
-	case outputJUnit:
-		return NewDefaultJUnitOutputManager()
-	default:
-		return NewDefaultStandardOutputManager(color)
+// Outputs returns the available output formats.
+func Outputs() []string {
+	return []string{
+		OutputStandard,
+		OutputJSON,
+		OutputTAP,
+		OutputTable,
+		OutputJUnit,
 	}
 }

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -1,56 +1,52 @@
 package output
 
 import (
+	"os"
 	"reflect"
 	"testing"
 )
 
-func TestSupportedOutputManagers(t *testing.T) {
-	for _, testunit := range []struct {
-		name          string
-		outputFormat  string
-		outputManager OutputManager
+func TestGetOutputter(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected Outputter
 	}{
 		{
-			name:          "std output should exist",
-			outputFormat:  outputSTD,
-			outputManager: NewDefaultStandardOutputManager(true),
+			input:    OutputStandard,
+			expected: NewStandard(os.Stdout),
 		},
 		{
-			name:          "json output should exist",
-			outputFormat:  outputJSON,
-			outputManager: NewDefaultJSONOutputManager(),
+			input:    OutputJSON,
+			expected: NewJSON(os.Stdout),
 		},
 		{
-			name:          "tap output should exist",
-			outputFormat:  outputTAP,
-			outputManager: NewDefaultTAPOutputManager(),
+			input:    OutputTAP,
+			expected: NewTAP(os.Stdout),
 		},
 		{
-			name:          "table output should exist",
-			outputFormat:  outputTable,
-			outputManager: NewDefaultTableOutputManager(),
+			input:    OutputTable,
+			expected: NewTable(os.Stdout),
 		},
 		{
-			name:          "JUnit should exist",
-			outputFormat:  outputJUnit,
-			outputManager: NewDefaultJUnitOutputManager(),
+			input:    OutputJUnit,
+			expected: NewJUnit(os.Stdout),
 		},
 		{
-			name:          "default output should exist",
-			outputFormat:  "somedefault",
-			outputManager: NewDefaultStandardOutputManager(true),
+			input:    "unknown_format",
+			expected: NewStandard(os.Stdout),
 		},
-	} {
-		outputManager := GetOutputManager(testunit.outputFormat, true)
-		if !reflect.DeepEqual(outputManager, testunit.outputManager) {
-			t.Errorf(
-				"We expected the output manager to be of type %v : %T and it was %T",
-				testunit.outputFormat,
-				testunit.outputManager,
-				outputManager,
-			)
-		}
+	}
 
+	for _, testCase := range testCases {
+		t.Run(testCase.input, func(t *testing.T) {
+			actual := Get(testCase.input, Options{NoColor: true})
+
+			actualType := reflect.TypeOf(actual)
+
+			expectedType := reflect.TypeOf(testCase.expected)
+			if expectedType != actualType {
+				t.Errorf("Unexpected outputter. expected %v actual %v", expectedType, actualType)
+			}
+		})
 	}
 }

--- a/output/standard_test.go
+++ b/output/standard_test.go
@@ -2,7 +2,6 @@ package output
 
 import (
 	"bytes"
-	"log"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,55 +10,59 @@ import (
 func TestStandard(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    CheckResult
+		input    []CheckResult
 		expected []string
 	}{
 		{
-			name: "records failure and Warnings",
-			input: CheckResult{
-				FileName: "foo.yaml",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: "first failure"}},
+			name: "records failures and warnings",
+			input: []CheckResult{
+				{
+					FileName: "foo.yaml",
+					Warnings: []Result{{Message: "first warning"}},
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
 			expected: []string{
 				"WARN - foo.yaml - first warning",
 				"FAIL - foo.yaml - first failure",
 				"",
 				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions",
+				"",
 			},
 		},
 		{
 			name: "skips filenames for stdin",
-			input: CheckResult{
-				FileName: "-",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: "first failure"}},
+			input: []CheckResult{
+				{
+					FileName: "-",
+					Warnings: []Result{{Message: "first warning"}},
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
 			expected: []string{
 				"WARN - first warning",
 				"FAIL - first failure",
 				"",
 				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions",
+				"",
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expected := strings.Join(tt.expected, "\n")
+
 			buf := new(bytes.Buffer)
-			s := NewStandardOutputManager(log.New(buf, "", 0), false)
-
-			if err := s.Put(tt.input); err != nil {
-				t.Fatalf("put output: %v", err)
+			standard := Standard{Writer: buf, NoColor: true}
+			if err := standard.Output(tt.input); err != nil {
+				t.Fatal("output standard:", err)
 			}
 
-			if err := s.Flush(); err != nil {
-				t.Fatalf("flush output: %v", err)
-			}
+			actual := buf.String()
 
-			actual := strings.Split(strings.TrimSuffix(buf.String(), "\n"), "\n")
-			if !reflect.DeepEqual(tt.expected, actual) {
-				t.Errorf("unexpected output. expected %v actual %v", tt.expected, actual)
+			if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("Unexpected output. expected %v actual %v", expected, actual)
 			}
 		})
 	}

--- a/output/table.go
+++ b/output/table.go
@@ -2,58 +2,50 @@ package output
 
 import (
 	"io"
-	"os"
 
-	table "github.com/olekukonko/tablewriter"
+	"github.com/olekukonko/tablewriter"
 )
 
-// TableOutputManager formats its output in a table
-type TableOutputManager struct {
-	table   *table.Table
-	tracing bool
+// Table represents an Outputter that outputs
+// results in a tabular format.
+type Table struct {
+	Writer io.Writer
 }
 
-// NewDefaultTableOutputManager creates a new TableOutputManager using standard out
-func NewDefaultTableOutputManager() *TableOutputManager {
-	return NewTableOutputManager(os.Stdout)
+// NewTable creates a new Table with the given writer.
+func NewTable(w io.Writer) *Table {
+	table := Table{
+		Writer: w,
+	}
+
+	return &table
 }
 
-// NewTableOutputManager creates a new TableOutputManager with a given Writer
-func NewTableOutputManager(w io.Writer) *TableOutputManager {
-	table := table.NewWriter(w)
+// Output outputs the results.
+func (t *Table) Output(checkResults []CheckResult) error {
+	table := tablewriter.NewWriter(t.Writer)
 	table.SetHeader([]string{"result", "file", "message"})
-	return &TableOutputManager{
-		table: table,
-	}
-}
 
-// WithTracing adds tracing to the output.
-func (t *TableOutputManager) WithTracing() OutputManager {
-	t.tracing = true
-	return t
-}
+	for _, checkResult := range checkResults {
+		for r := 0; r < checkResult.Successes; r++ {
+			table.Append([]string{"success", checkResult.FileName, ""})
+		}
 
-// Put puts the result of the check to the manager in the managers buffer
-func (t *TableOutputManager) Put(cr CheckResult) error {
-	for r := 0; r < cr.Successes; r++ {
-		t.table.Append([]string{"success", cr.FileName, ""})
-	}
+		for _, result := range checkResult.Exceptions {
+			table.Append([]string{"exception", checkResult.FileName, result.Message})
+		}
 
-	for _, r := range cr.Warnings {
-		t.table.Append([]string{"warning", cr.FileName, r.Message})
+		for _, result := range checkResult.Warnings {
+			table.Append([]string{"warning", checkResult.FileName, result.Message})
+		}
+
+		for _, result := range checkResult.Failures {
+			table.Append([]string{"failure", checkResult.FileName, result.Message})
+		}
 	}
 
-	for _, r := range cr.Failures {
-		t.table.Append([]string{"failure", cr.FileName, r.Message})
-	}
-
-	return nil
-}
-
-// Flush writes the contents of the managers buffer to the console
-func (t *TableOutputManager) Flush() error {
-	if t.table.NumLines() > 0 {
-		t.table.Render()
+	if table.NumLines() > 0 {
+		table.Render()
 	}
 
 	return nil

--- a/output/table_test.go
+++ b/output/table_test.go
@@ -2,55 +2,58 @@ package output
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
 func TestTable(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    CheckResult
-		expected string
+		input    []CheckResult
+		expected []string
 	}{
 		{
-			name: "no warnings or errors",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
+			name: "No warnings or errors",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+				},
 			},
-			expected: "",
+			expected: []string{},
 		},
 		{
-			name: "records failure and warnings",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: "first failure"}},
+			name: "A warning and a failure",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+					Warnings: []Result{{Message: "first warning"}},
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
-			expected: `+---------+----------------------------------+---------------+
-| RESULT  |               FILE               |    MESSAGE    |
-+---------+----------------------------------+---------------+
-| warning | examples/kubernetes/service.yaml | first warning |
-| failure | examples/kubernetes/service.yaml | first failure |
-+---------+----------------------------------+---------------+
-`,
+			expected: []string{
+				`+---------+----------------------------------+---------------+`,
+				`| RESULT  |               FILE               |    MESSAGE    |`,
+				`+---------+----------------------------------+---------------+`,
+				`| warning | examples/kubernetes/service.yaml | first warning |`,
+				`| failure | examples/kubernetes/service.yaml | first failure |`,
+				`+---------+----------------------------------+---------------+`,
+				``,
+			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expected := strings.Join(tt.expected, "\n")
+
 			buf := new(bytes.Buffer)
-			s := NewTableOutputManager(buf)
-
-			if err := s.Put(tt.input); err != nil {
-				t.Fatalf("put output: %v", err)
+			if err := NewTable(buf).Output(tt.input); err != nil {
+				t.Fatal("output table:", err)
 			}
-
-			if err := s.Flush(); err != nil {
-				t.Fatalf("flush output: %v", err)
-			}
-
 			actual := buf.String()
 
-			if tt.expected != actual {
-				t.Errorf("unexpected output. expected %v actual %v", tt.expected, actual)
+			if expected != actual {
+				t.Errorf("Unexpected output. expected %v actual %v", expected, actual)
 			}
 		})
 	}

--- a/output/tap.go
+++ b/output/tap.go
@@ -2,103 +2,71 @@ package output
 
 import (
 	"fmt"
-	"log"
-	"os"
+	"io"
 )
 
-// TAPOutputManager formats its output in TAP format
-type TAPOutputManager struct {
-	logger  *log.Logger
-	tracing bool
+// TAP represents an Outputter that outputs
+// results in TAP format.
+type TAP struct {
+	Writer io.Writer
 }
 
-// NewDefaultTAPOutputManager creates a new TAPOutputManager using the default logger
-func NewDefaultTAPOutputManager() *TAPOutputManager {
-	return NewTAPOutputManager(log.New(os.Stdout, "", 0))
-}
-
-// NewTAPOutputManager creates a new TAPOutputManager with a given logger instance
-func NewTAPOutputManager(l *log.Logger) *TAPOutputManager {
-	return &TAPOutputManager{
-		logger: l,
+// NewTAP creates a new TAP with the given writer.
+func NewTAP(w io.Writer) *TAP {
+	tap := TAP{
+		Writer: w,
 	}
+
+	return &tap
 }
 
-// WithTracing adds tracing to the output.
-func (t *TAPOutputManager) WithTracing() OutputManager {
-	t.tracing = true
-	return t
-}
+// Output outputs the results.
+func (t *TAP) Output(checkResults []CheckResult) error {
+	for _, result := range checkResults {
+		var indicator string
+		if result.FileName == "-" {
+			indicator = "-"
+		} else {
+			indicator = fmt.Sprintf("- %s -", result.FileName)
+		}
 
-// Put puts the result of the check to the manager in the managers buffer
-func (t *TAPOutputManager) Put(cr CheckResult) error {
+		totalTests := result.Successes + len(result.Failures) + len(result.Warnings) + len(result.Exceptions)
+		if totalTests == 0 {
+			return nil
+		}
 
-	if t.tracing {
-		t.logger.Print("# " + cr.FileName)
+		counter := 1
+		fmt.Fprintln(t.Writer, fmt.Sprintf("1..%d", totalTests))
 
-		for _, queryResult := range cr.Queries {
-			var resultLine string
-			if queryResult.Passed() {
-				resultLine = "ok " + queryResult.Query
-			} else {
-				resultLine = "not ok " + queryResult.Query
+		for _, failure := range result.Failures {
+			fmt.Fprintln(t.Writer, fmt.Sprintf("not ok %v %v %v", counter, indicator, failure.Message))
+			counter++
+		}
+
+		if len(result.Warnings) > 0 {
+			fmt.Fprintln(t.Writer, "# warnings")
+			for _, warning := range result.Warnings {
+				fmt.Fprintln(t.Writer, fmt.Sprintf("not ok %v %v %v", counter, indicator, warning.Message))
+				counter++
 			}
-			t.logger.Print(resultLine)
+		}
 
-			for index, trace := range queryResult.Traces {
-				t.logger.Print("# ", index, " ", trace)
+		if len(result.Exceptions) > 0 {
+			fmt.Fprintln(t.Writer, "# exceptions")
+			for _, exception := range result.Exceptions {
+				fmt.Fprintln(t.Writer, fmt.Sprintf("ok %v %v %v", counter, indicator, exception.Message))
+				counter++
 			}
 		}
 
-		return nil
-	}
-
-	var indicator string
-	if cr.FileName == "-" {
-		indicator = " - "
-	} else {
-		indicator = fmt.Sprintf(" - %s - ", cr.FileName)
-	}
-
-	issues := cr.Successes + len(cr.Failures) + len(cr.Warnings) + len(cr.Exceptions)
-	if issues == 0 {
-		return nil
-	}
-
-	t.logger.Print(fmt.Sprintf("1..%d", issues))
-	for i, r := range cr.Failures {
-		t.logger.Print("not ok ", i+1, indicator, r.Message)
-
-	}
-
-	if len(cr.Warnings) > 0 {
-		t.logger.Print("# warnings")
-		for i, r := range cr.Warnings {
-			counter := i + 1 + len(cr.Failures)
-			t.logger.Print("not ok ", counter, indicator, r.Message)
+		if result.Successes > 0 {
+			fmt.Fprintln(t.Writer, "# successes")
+			for i := 0; i < result.Successes; i++ {
+				fmt.Fprintln(t.Writer, fmt.Sprintf("ok %v %v", counter, indicator))
+				counter++
+			}
 		}
 	}
 
-	if len(cr.Exceptions) > 0 {
-		t.logger.Print("# exceptions")
-		for i, r := range cr.Exceptions {
-			counter := i + 1 + len(cr.Failures) + len(cr.Warnings)
-			t.logger.Print("ok ", counter, indicator, r.Message)
-		}
-	}
-
-	if cr.Successes > 0 {
-		t.logger.Print("# successes")
-		for i := 0; i < cr.Successes; i++ {
-			counter := i + 1 + len(cr.Failures) + len(cr.Warnings) + len(cr.Exceptions)
-			t.logger.Print("ok ", counter, indicator, "")
-		}
-	}
-
-	return nil
-}
-
-// Flush is currently a NOOP
-func (t *TAPOutputManager) Flush() error {
 	return nil
 }

--- a/output/tap_test.go
+++ b/output/tap_test.go
@@ -2,71 +2,85 @@ package output
 
 import (
 	"bytes"
-	"log"
+	"strings"
 	"testing"
 )
 
 func TestTAP(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    CheckResult
-		expected string
+		input    []CheckResult
+		expected []string
 	}{
 		{
-			name:     "no warnings or errors",
-			input:    CheckResult{FileName: "examples/kubernetes/service.yaml"},
-			expected: "",
+			name: "no warnings or errors",
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+				},
+			},
+			expected: []string{},
 		},
 		{
 			name: "records failure and warnings",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
-				Warnings: []Result{{Message: "first warning"}},
-				Failures: []Result{{Message: "first failure"}},
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+					Warnings: []Result{{Message: "first warning"}},
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
-			expected: `1..2
-not ok 1 - examples/kubernetes/service.yaml - first failure
-# warnings
-not ok 2 - examples/kubernetes/service.yaml - first warning
-`,
+			expected: []string{
+				"1..2",
+				"not ok 1 - examples/kubernetes/service.yaml - first failure",
+				"# warnings",
+				"not ok 2 - examples/kubernetes/service.yaml - first warning",
+				"",
+			},
 		},
 		{
 			name: "mixed failure and warnings",
-			input: CheckResult{
-				FileName: "examples/kubernetes/service.yaml",
-				Failures: []Result{{Message: "first failure"}},
+			input: []CheckResult{
+				{
+					FileName: "examples/kubernetes/service.yaml",
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
-			expected: `1..1
-not ok 1 - examples/kubernetes/service.yaml - first failure
-`,
+			expected: []string{
+				"1..1",
+				"not ok 1 - examples/kubernetes/service.yaml - first failure",
+				"",
+			},
 		},
 		{
 			name: "handles stdin input",
-			input: CheckResult{
-				FileName: "-",
-				Failures: []Result{{Message: "first failure"}},
+			input: []CheckResult{
+				{
+					FileName: "-",
+					Failures: []Result{{Message: "first failure"}},
+				},
 			},
-			expected: `1..1
-not ok 1 - first failure
-`,
+			expected: []string{
+				"1..1",
+				"not ok 1 - first failure",
+				"",
+			},
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			expected := strings.Join(tt.expected, "\n")
+
 			buf := new(bytes.Buffer)
-			s := NewTAPOutputManager(log.New(buf, "", 0))
-
-			if err := s.Put(tt.input); err != nil {
-				t.Fatalf("put output: %v", err)
-			}
-
-			if err := s.Flush(); err != nil {
-				t.Fatalf("flush output: %v", err)
+			if err := NewTAP(buf).Output(tt.input); err != nil {
+				t.Fatal("output TAP:", err)
 			}
 
 			actual := buf.String()
-			if tt.expected != actual {
-				t.Errorf("unexpected output. expected %v actual %v", tt.expected, actual)
+
+			if expected != actual {
+				t.Errorf("unexpected output. expected %v actual %v", expected, actual)
 			}
 		})
 	}


### PR DESCRIPTION
Continuing to work towards more stable and usable package APIs for a `conftest` v1 release, this PR reworks the `output` package.

- Remove `Manager` terminology in favor of types that represent what they output. A package consumer could create an output type by saying `output.JSON`

- Remove the `Flush()` and `Put()` methods on each `Outputter` in favor of a single `Output()`. Everywhere in the codebase we were just ranging over the `CheckResults` collection to Put() them into the output manager and then flushing. This lets us just pass in a collection of results and write them e.g. 

```golang
outputter := output.Get(format)
if err := outputter.Output(results); err != nil {
  return fmt.Errorf("output results: %w", err)
}
```

- Replace `log.Logger` with `io.Writer`. This gives us, as well as package consumers, way more flexibility in how they can get at the formatted output. Tests can continue to pass in`bytes.Buffer`, and the Conftest binary can pass in `os.Stdout`.

