### PR TITLE
Remove runtime check on YAML parser

### DIFF
--- a/parser/yaml/yaml.go
+++ b/parser/yaml/yaml.go
@@ -3,7 +3,6 @@ package yaml
 import (
 	"bytes"
 	"fmt"
-	"runtime"
 
 	"github.com/ghodss/yaml"
 )
@@ -31,8 +30,7 @@ func (yp *Parser) Unmarshal(p []byte, v interface{}) error {
 
 func separateSubDocuments(data []byte) [][]byte {
 	linebreak := "\n"
-	windowsLineEnding := bytes.Contains(data, []byte("\r\n"))
-	if windowsLineEnding && runtime.GOOS == "windows" {
+	if bytes.Contains(data, []byte("\r\n---\r\n")) {
 		linebreak = "\r\n"
 	}
 


### PR DESCRIPTION
There really shouldn't need to be a distinction made between Windows/not-Windows when figuring out how to break apart the YAML document. Just which line breaks the document is being used.

Noticed when trying to build the Docker image (alpine) on a Windows machine. Build fails due to linebreaks consisting of CRLF, but the runtime is not windows.