### PR TITLE
Add maintainers field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,4 +65,5 @@ nfpms:
       - deb
       - rpm
     homepage: https://github.com/open-policy-agent/conftest
+    maintainer: jpreese <john@reese.dev>
     license: Apache-2.0


### PR DESCRIPTION
Resolves #399 

This field appears to be required by `dpkg` and .. does not support multiple aliases?