### PR TITLE
Change input flag to parser

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -30,13 +30,13 @@
   [ "$status" -eq 0 ]
 }
 
-@test "when testing a YAML document via stdin, default parser should be yaml if no input flag is passed" {
+@test "when testing a YAML document via stdin, default parser should be yaml if no parser flag is passed" {
   run ./conftest test -p examples/kubernetes/policy - < examples/kubernetes/service.yaml
   [ "$status" -eq 0 ]
 }
 
 @test "Pass when testing a YAML document via stdin" {
-  run ./conftest test -i yaml -p examples/kubernetes/policy - < examples/kubernetes/service.yaml
+  run ./conftest test --parser yaml -p examples/kubernetes/policy - < examples/kubernetes/service.yaml
   [ "$status" -eq 0 ]
 }
 
@@ -133,7 +133,7 @@
 }
 
 @test "Can parse hocon files" {
-  run ./conftest test -p examples/hocon/policy examples/hocon/hocon.conf -i hocon
+  run ./conftest test -p examples/hocon/policy examples/hocon/hocon.conf --parser hocon
   [ "$status" -eq 1 ]
   [[ "$output" =~ "Play http server port should be 9000" ]]
 }
@@ -184,20 +184,20 @@
   [[ "$output" =~ "ALB \`my-alb-listener\` is using HTTP rather than HTTP" ]]
 }
 
-@test "Can parse stdin with input flag" {
-  run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --input ini -"
+@test "Can parse stdin with parser flag" {
+  run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --parser ini -"
   [ "$status" -eq 1 ]
   [[ "$output" =~ "Users should verify their e-mail address" ]]
   [[ "$output" != *"Basic auth should be enabled"* ]]
 }
 
-@test "Using -i/--input should force the chosen parser and fail the rego policy" {
-  run ./conftest test -p examples/terraform/policy/gke.rego examples/terraform/gke.tf -i ini
+@test "Using --parser should force the chosen parser and fail the rego policy" {
+  run ./conftest test -p examples/terraform/policy/gke.rego examples/terraform/gke.tf --parser ini
   [ "$status" -eq 1 ]
 }
 
 @test "Can combine configs and reference by file" {
-  run ./conftest test -p examples/hcl1/policy/gke_combine.rego examples/hcl1/gke.tf --combine -i hcl1 --all-namespaces
+  run ./conftest test -p examples/hcl1/policy/gke_combine.rego examples/hcl1/gke.tf --combine --parser hcl1 --all-namespaces
   [ "$status" -eq 0 ]
 }
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -148,20 +148,6 @@ conftest test -p examples/test/ test/ --ignore=".*.yaml"
 conftest test -p examples/test/ test/ --ignore=".*.cue|.*.yaml"
 ```
 
-## `--input`
-
-Conftest normally detects input type with the file extension, even when multiple input files are passed in. It is possible force a specific input type with the `--input` flag (`-i`).
-
-For the available parsers, take a look at [parsers](https://github.com/open-policy-agent/conftest/tree/master/parser).
-
-For instance:
-
-```console
-$ conftest test -p examples/hcl1/policy examples/hcl1/gke.tf -i hcl2
-
-2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions
-```
-
 ## `--output`
 
 The output of Conftest can be configured using the `--output` flag (`-o`).
@@ -173,6 +159,20 @@ As of today Conftest supports the following output types:
 - [TAP](https://testanything.org/): `--output=tap`
 - Table `--output=table`
 - JUnit `--output=junit`
+
+## `--parser`
+
+Conftest normally detects which parser to used based on the file extension of the file, even when multiple input files are passed in. However, it is possible force a specific parser to be used with the `--parser` flag.
+
+For the available parsers, take a look at [parsers](https://github.com/open-policy-agent/conftest/tree/master/parser).
+
+For instance:
+
+```console
+$ conftest test -p examples/hcl1/policy examples/hcl1/gke.tf --parser hcl2
+
+2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions
+```
 
 ### Plaintext
 

--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -30,7 +30,7 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 		Short: "Print out structured data from your input files",
 		Long:  parseDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"input", "combine"}
+			flagNames := []string{"parser", "combine"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -42,8 +42,8 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 		RunE: func(cmd *cobra.Command, files []string) error {
 			var configurations map[string]interface{}
 			var err error
-			if viper.GetString("input") != "" {
-				configurations, err = parser.ParseConfigurationsAs(files, viper.GetString("input"))
+			if viper.GetString("parser") != "" {
+				configurations, err = parser.ParseConfigurationsAs(files, viper.GetString("parser"))
 			} else {
 				configurations, err = parser.ParseConfigurations(files)
 			}
@@ -67,7 +67,7 @@ func NewParseCommand(ctx context.Context) *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("combine", "", false, "Combine all config files to be evaluated together")
-	cmd.Flags().StringP("input", "i", "", fmt.Sprintf("Input type for given source, especially useful when using conftest with stdin, valid options are: %s", parser.ValidInputs()))
+	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
 
 	return &cmd
 }

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -84,7 +84,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Long:  testDesc,
 		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "input", "namespace", "no-color", "output", "policy", "trace", "update"}
+			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "namespace", "no-color", "output", "parser", "policy", "trace", "update"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -140,9 +140,10 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().Bool("all-namespaces", false, "Test policies found in all namespaces")
 	cmd.Flags().BoolP("combine", "", false, "Combine all config files to be evaluated together")
 
-	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
 	cmd.Flags().StringP("output", "o", "", fmt.Sprintf("Output format for conftest results - valid options are: %s", output.ValidOutputs()))
-	cmd.Flags().StringP("input", "i", "", fmt.Sprintf("Input type for given source, especially useful when using conftest with stdin, valid options are: %s", parser.ValidInputs()))
+
+	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
+	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
 
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 	cmd.Flags().StringSliceP("update", "u", []string{}, "A list of URLs can be provided to the update flag, which will download before the tests run")

--- a/internal/runner/test.go
+++ b/internal/runner/test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/parser"
@@ -19,7 +18,7 @@ type TestRunner struct {
 	Data          []string
 	Update        []string
 	Ignore        string
-	Input         string
+	Parser        string
 	Namespace     []string
 	AllNamespaces bool `mapstructure:"all-namespaces"`
 	FailOnWarn    bool `mapstructure:"fail-on-warn"`
@@ -37,8 +36,8 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 	}
 
 	var configurations map[string]interface{}
-	if t.Input != "" {
-		configurations, err = parser.ParseConfigurationsAs(files, t.Input)
+	if t.Parser != "" {
+		configurations, err = parser.ParseConfigurationsAs(files, t.Parser)
 	} else {
 		configurations, err = parser.ParseConfigurations(files)
 	}
@@ -139,12 +138,8 @@ func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, erro
 			return nil
 		}
 
-		for _, input := range parser.ValidInputs() {
-			currentInput := strings.ToLower(input)
-
-			if strings.HasSuffix(info.Name(), currentInput) {
-				files = append(files, currentPath)
-			}
+		if parser.FileSupported(currentPath) {
+			files = append(files, currentPath)
 		}
 
 		return nil

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4,100 +4,54 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/open-policy-agent/conftest/parser/cue"
 	"github.com/open-policy-agent/conftest/parser/docker"
-	"github.com/open-policy-agent/conftest/parser/edn"
-	"github.com/open-policy-agent/conftest/parser/hcl1"
 	"github.com/open-policy-agent/conftest/parser/hcl2"
-	"github.com/open-policy-agent/conftest/parser/ini"
-	"github.com/open-policy-agent/conftest/parser/json"
-	"github.com/open-policy-agent/conftest/parser/toml"
 	"github.com/open-policy-agent/conftest/parser/yaml"
 )
 
-func TestGetParser(t *testing.T) {
-	testTable := []struct {
-		fileType string
+func TestNewFromPath(t *testing.T) {
+	testCases := []struct {
+		path     string
 		expected Parser
 	}{
 		{
-			fileType: "hcl1",
-			expected: new(hcl1.Parser),
+			"-",
+			&yaml.Parser{},
 		},
 		{
-			fileType: "tf",
-			expected: new(hcl2.Parser),
+			"test.yaml",
+			&yaml.Parser{},
 		},
 		{
-			fileType: "hcl",
-			expected: new(hcl2.Parser),
+			"test.yml",
+			&yaml.Parser{},
 		},
 		{
-			fileType: "toml",
-			expected: new(toml.Parser),
+			"dockerfile",
+			&docker.Parser{},
 		},
 		{
-			fileType: "cue",
-			expected: new(cue.Parser),
+			"Dockerfile",
+			&docker.Parser{},
 		},
 		{
-			fileType: "ini",
-			expected: new(ini.Parser),
-		},
-		{
-			fileType: "json",
-			expected: new(json.Parser),
-		},
-		{
-			fileType: "yaml",
-			expected: new(yaml.Parser),
-		},
-		{
-			fileType: "yml",
-			expected: new(yaml.Parser),
-		},
-		{
-			fileType: "edn",
-			expected: new(edn.Parser),
-		},
-		{
-			fileType: "Dockerfile",
-			expected: new(docker.Parser),
+			"test.tf",
+			&hcl2.Parser{},
 		},
 	}
 
-	for _, testUnit := range testTable {
-		t.Run(testUnit.fileType, func(t *testing.T) {
-			actual, err := GetParser(testUnit.fileType)
+	for _, testCase := range testCases {
+		t.Run(testCase.path, func(t *testing.T) {
+			expectedType := reflect.TypeOf(testCase.expected)
+
+			actual, err := NewFromPath(testCase.path)
 			if err != nil {
-				t.Fatal("get parser failed:", err)
+				t.Fatal("from path:", err)
 			}
+			actualType := reflect.TypeOf(actual)
 
-			if !reflect.DeepEqual(actual, testUnit.expected) {
-				t.Errorf("Unexpected parser. expected %v actual %v", testUnit.expected, actual)
-			}
-		})
-	}
-}
-
-func TestGetFileType(t *testing.T) {
-	testTable := []struct {
-		path     string
-		expected string
-	}{
-		{"-", "yaml"},
-		{"test.yaml", "yaml"},
-		{"test.yml", "yml"},
-		{"some/path/test.toml", "toml"},
-		{"dockerfile", "dockerfile"},
-	}
-
-	for _, testUnit := range testTable {
-		t.Run(testUnit.path, func(t *testing.T) {
-			actual := getFileType(testUnit.path)
-
-			if actual != testUnit.expected {
-				t.Errorf("Unexpected filetype. expected %v actual %v", testUnit.expected, actual)
+			if !reflect.DeepEqual(actualType, expectedType) {
+				t.Errorf("Unexpected parser. expected %v actual %v", expectedType, actualType)
 			}
 		})
 	}


### PR DESCRIPTION
This PR aims to change the `--input` flag to instead, be named `--parser`.

**Reasoning:**

The `parser` package exposes a number of different parsers, and these parsers are responsible for parsing different file _formats_. I feel its currently a little confusing to have `conftest test --input tf`, under the hood this just means to use the `hcl2` parser, which we've done a mapping for. Instead, I think it makes more sense to say `conftest test --parser hcl1` or `conftest test --parser hcl2`.

I do think theres value in being able to figure out which Parser to use, based on a file, which `NewFromPath` accomplishes.

This also keeps the language more consistent with what is really happening under the hood, figuring out which _parser_ to use with the given input. As well as keeps the parser package focused on its _parsers_ rather than specific implementations that use the language.