### PR TITLE
Support XDG specification

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -6,7 +6,13 @@ This guide will explain how you can use plugins and how you can create new plugi
 
 ## Installing a plugin
 
-A plugin can be installed using the `conftest plugin install` command. This command takes a url and will download the plugin and install it in the plugin cache, located at `~/.conftest/plugins`.
+A plugin can be installed using the `conftest plugin install` command. This command takes a url and will download the plugin and install it in the plugin cache.
+
+Conftest adheres to the XDG specification, so the location depends on whether `XDG_DATA_HOME` or `XDG_DATA_DIRS` is set. Conftest will now search `XDG_DATA_HOME` or `XDG_DATA_DIRS` for the location of the conftest plugins cache. The preference order is as follows:
+
+1. XDG_DATA_HOME if set and .conftest/plugins exists within the XDG_DATA_HOME dir
+2. XDG_DATA_DIRS if set and .conftest/plugins exists within one of the XDG_DATA_DIRS
+3. ~/.conftest/plugins
 
 Under the hood conftest leverages [go-getter](https://github.com/hashicorp/go-getter) to download plugins. This means the following protocols are supported for downloading plugins:
 

--- a/plugin/install.go
+++ b/plugin/install.go
@@ -22,7 +22,7 @@ import (
 // as defined in the plugins configuration file.
 func Install(ctx context.Context, source string) error {
 	if _, err := os.Stat(CacheDirectory()); os.IsNotExist(err) {
-		if err := os.MkdirAll(CacheDirectory(), os.ModePerm); err != nil {
+		if err := os.MkdirAll(cacheDirectory.Preferred("plugins"), os.ModePerm); err != nil {
 			return fmt.Errorf("make plugin dir: %w", err)
 		}
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -14,6 +14,12 @@ import (
 	"github.com/ghodss/yaml"
 )
 
+const (
+	cacheDir = ".conftest"
+	cacheDirectory = xdgPath(cacheDir)
+)
+
+
 // Plugin represents a plugin.
 type Plugin struct {
 	Name        string `yaml:"name"`
@@ -139,14 +145,8 @@ func (p *Plugin) Directory() string {
 // CacheDirectory returns the full path to the
 // cache directory where all of the plugins are stored.
 func CacheDirectory() string {
-	const cacheDir = ".conftest/plugins"
-
-	homeDir, _ := os.UserHomeDir()
-
-	directory := filepath.Join(homeDir, cacheDir)
-	directory = filepath.ToSlash(directory)
-
-	return directory
+	dir, _ := cacheDirectory.Find("plugins")
+	return dir
 }
 
 // FromDirectory returns a plugin from a specific directory.

--- a/plugin/xdg.go
+++ b/plugin/xdg.go
@@ -1,0 +1,83 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// XDGDataHome is the directory to search for data files in the XDG spec
+	XDGDataHome = "XDG_DATA_HOME"
+
+	// XDGDataDirs defines an additional list of directories which can be searched for data files
+	XDGDataDirs = "XDG_DATA_DIRS"
+)
+
+// xdgPath is a 
+type xdgPath string
+
+// Preferred returns the preferred path according to the XDG specification
+func (p xdgPath) Preferred(path string) string {
+	dataHome := os.Getenv(XDGDataHome)
+	if dataHome != "" {
+		return filepath.ToSlash(filepath.Join(dataHome, string(p), path))
+	}
+
+	dataDirs := os.Getenv(XDGDataDirs)
+	if dataDirs != "" {
+		dirs := strings.Split(dataDirs, ":")
+		return filepath.ToSlash(filepath.Join(dirs[0], string(p), path))
+	}
+
+	homeDir, _ := os.UserHomeDir()
+	return filepath.ToSlash(filepath.Join(homeDir, string(p), path))
+}
+
+// Find verifies whether the file exists somewhere in the expected XDG
+// preference order. If no error is returned, the given string indicates
+// where the file was found.
+func (p xdgPath) Find(path string) (string, error) {
+	dataHome := os.Getenv(XDGDataHome)
+	if dataHome != "" {
+		dir := filepath.ToSlash(filepath.Join(dataHome, string(p), path))
+		_, err := os.Stat(dir)
+		if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("get data home directory: %w", err)
+		}
+
+		if err == nil {
+			return dir, nil
+		}
+	}
+
+	dataDirs := os.Getenv(XDGDataDirs)
+	if dataDirs != "" {
+		dirs := strings.Split(dataDirs, ":")
+		for _, dataDir := range dirs {
+			dir := filepath.ToSlash(filepath.Join(dataDir, string(p), path))
+			_, err := os.Stat(dir);
+			if err != nil && !os.IsNotExist(err) {
+				return "", fmt.Errorf("get data dirs directory: %w", err)
+			}
+	
+			if err == nil {
+				return dir, nil
+			}
+		}
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+
+	dir := filepath.ToSlash(filepath.Join(homeDir, string(p), path))
+	_, err = os.Stat(dir);
+	if err != nil {
+		return "", fmt.Errorf("get data dirs directory: %w", err)
+	}
+
+	return dir, nil
+}

--- a/plugin/xdg_test.go
+++ b/plugin/xdg_test.go
@@ -1,0 +1,256 @@
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPreferred(t *testing.T) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	const (
+		conftestDir = ".conftest"
+		pluginsDir  = "plugins"
+	)
+
+	tests := []struct {
+		name  string
+		xdg   xdgPath
+		path  string
+		setup func()
+		want  string
+	}{
+		{
+			"should return homeDir if no XDG path is set.",
+			xdgPath(conftestDir),
+			pluginsDir,
+			func() {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+			},
+			filepath.Join(userHome, conftestDir, pluginsDir),
+		},
+		{
+			"should return XDG_DATA_HOME if both XDG_DATA_HOME and XDG_DATA_DIRS is set",
+			xdgPath(conftestDir),
+			pluginsDir,
+			func() {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+				os.Setenv(XDGDataHome, "/tmp")
+				os.Setenv(XDGDataDirs, "/tmp2:/tmp3")
+			},
+			filepath.Join("/tmp", conftestDir, pluginsDir),
+		},
+		{
+			"should return first XDG_DATA_DIRS if only XDG_DATA_DIRS is set",
+			xdgPath(conftestDir),
+			pluginsDir,
+			func() {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+				os.Setenv(XDGDataDirs, "/tmp2:/tmp3")
+			},
+			filepath.Join("/tmp2", conftestDir, pluginsDir),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+
+			if got := tt.xdg.Preferred(tt.path); got != tt.want {
+				t.Errorf("xdgPath.Preferred() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFind(t *testing.T) {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+
+	const (
+		cacheDir   = ".conftestcache"
+		pluginsDir = "plugins"
+		xdgDataHome = "xdgDataHome"
+		xdgDataDirOne = "xdgDataDirOne"
+		xdgDataDirTwo = "xdgDataDirTwo"
+	)
+
+	tests := []struct {
+		name     string
+		path     string
+		setup    func() (string, error)
+		teardown func(string) error
+		want     func(string) string
+		wantErr  bool
+	}{
+		{
+			"should return error if dir does not exist.",
+			pluginsDir,
+			func() (string, error) {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+				return "/does/not/exist", nil
+			},
+			func(path string) error {
+				return nil
+			},
+			func(_ string) string {
+				return ""
+			},
+			true,
+		},
+		{
+			"should return homeDir if no XDG path is set.",
+			pluginsDir,
+			func() (string, error) {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return "", err
+				}
+
+				dir := filepath.ToSlash(filepath.Join(homeDir))
+				cache := filepath.Join(dir, cacheDir)
+
+				err = os.MkdirAll(filepath.Join(cache, pluginsDir), os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+
+				return cache, nil
+			},
+			func(path string) error {
+				return os.RemoveAll(path)
+			},
+			func(_ string) string {
+				return filepath.Join(userHome, cacheDir, pluginsDir)
+			},
+			false,
+		},
+		{
+			"should return XDG_DATA_HOME if XDG_DATA_HOME is set.",
+			pluginsDir,
+			func() (string, error) {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return "", err
+				}
+
+				dir := filepath.ToSlash(filepath.Join(homeDir))
+				tmp, err := ioutil.TempDir(dir, "")
+				if err != nil {
+					return "", err
+				}
+
+				tmpXdg := filepath.Join(tmp, xdgDataHome)
+				err = os.Mkdir(tmpXdg, os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+				os.Setenv(XDGDataHome, tmpXdg)
+
+				err = os.MkdirAll(filepath.Join(tmpXdg, cacheDir, pluginsDir), os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+
+				return tmp, nil
+			},
+			func(path string) error {
+				return os.RemoveAll(path)
+			},
+			func(path string) string {
+
+				return filepath.Join(path, xdgDataHome, cacheDir, pluginsDir)
+			},
+			false,
+		},
+		{
+			"should return Data Dir with cache if XDG_DATA_DIRS is set.",
+			pluginsDir,
+			func() (string, error) {
+				os.Unsetenv(XDGDataHome)
+				os.Unsetenv(XDGDataDirs)
+
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					return "", err
+				}
+
+				dir := filepath.ToSlash(filepath.Join(homeDir))
+				tmp, err := ioutil.TempDir(dir, "")
+				if err != nil {
+					return "", err
+				}
+
+				tmpXdg1 := filepath.Join(tmp, xdgDataDirOne)
+				err = os.Mkdir(tmpXdg1, os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+
+				tmpXdg2 := filepath.Join(tmp, xdgDataDirTwo)
+				err = os.Mkdir(tmpXdg2, os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+				os.Setenv(XDGDataDirs, tmpXdg1 + ":" + tmpXdg2)
+
+				err = os.MkdirAll(filepath.Join(tmpXdg2, cacheDir, pluginsDir), os.ModePerm)
+				if err != nil {
+					return "", err
+				}
+
+				return tmp, nil
+			},
+			func(path string) error {
+				return os.RemoveAll(path)
+			},
+			func(path string) string {
+				return filepath.Join(path, xdgDataDirTwo, cacheDir, pluginsDir)
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := tt.setup()
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+
+			defer func() {
+				err := tt.teardown(dir)
+				if err != nil {
+					t.Fatalf("unexpected error %v", err)
+				}
+			}()
+
+			xdg := xdgPath(cacheDir)
+			got, err := xdg.Find(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("xdgPath.Find() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			want := tt.want(dir)
+			if got != want {
+				t.Errorf("xdgPath.Find() = %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Conftest will now search XDG_DATA_HOME or XDG_DATA_DIRS for the location of the conftest plugins cache. The preference order is as follows:

1. XDG_DATA_HOME if set and .conftest/plugins exists within the XDG_DATA_HOME dir
2. XDG_DATA_DIRS if set and .conftest/plugins exists within one of the XDG_DATA_DIRS
3. ~/.conftest/plugins

First PR for the XDG specification as discussed in #436. This PR makes sure the plugins adhere to the XDG spec. We can follow it up with a PR for the `conftest plugins list` command.