### PR TITLE
Parse command returns incorrect result with --combined flag.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -26,7 +26,7 @@ namespace = "conftest"
 
 This flag introduces *BREAKING CHANGES* in how Conftest provides input to rego policies. However, you may find it useful to use as it allows you to compare multiple values from different configurations simultaneously.
 
-The `--combine` flag combines files into one `input` data structure. The structure is a `map` where each index is the file path of the file being evaluated.
+The `--combine` flag combines files into one `input` data structure. The structure is an `array` where each element is a `map` with two keys: a `path` key with the relative file path of the file being evaluated and a `contents` key containing the actual document.
 
 Let's try it!
 

--- a/parser/format.go
+++ b/parser/format.go
@@ -30,7 +30,7 @@ func Format(configurations map[string]interface{}) (string, error) {
 func FormatCombined(configurations map[string]interface{}) (string, error) {
 	combinedConfigurations := CombineConfigurations(configurations)
 
-	formattedConfigs, err := format(combinedConfigurations)
+	formattedConfigs, err := format(combinedConfigurations["Combined"])
 	if err != nil {
 		return "", fmt.Errorf("formatting configs: %w", err)
 	}

--- a/parser/format_test.go
+++ b/parser/format_test.go
@@ -58,22 +58,20 @@ func TestFormatCombined(t *testing.T) {
 		t.Fatalf("parsing configs: %s", err)
 	}
 
-	expected := `{
-	"Combined": [
-		{
-			"path": "file1.json",
-			"contents": {
-				"Sut": "test"
-			}
-		},
-		{
-			"path": "file2.json",
-			"contents": {
-				"Foo": "bar"
-			}
+	expected := `[
+	{
+		"path": "file1.json",
+		"contents": {
+			"Sut": "test"
 		}
-	]
-}
+	},
+	{
+		"path": "file2.json",
+		"contents": {
+			"Foo": "bar"
+		}
+	}
+]
 `
 
 	if !strings.Contains(actual, expected) {


### PR DESCRIPTION
Fixed an issue where the parse command returns a different result from what is passed internally to the policy engine with the --combine flag. This leads to incorrect expectations when writing policies using combined input. I also updated the documentation to reflect the actual structure of the combined input.