### PR TITLE
Fix case sensitivity in Dockerfile parser detection

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,6 +115,10 @@ func NewFromPath(path string) (Parser, error) {
 		return New(IGNORE)
 	}
 
+	if fileExtension == "Dockerfile" || fileExtension == "dockerfile" {
+		return New(Dockerfile)
+	}
+
 	parser, err := New(fileExtension)
 	if err != nil {
 		return nil, fmt.Errorf("new: %w", err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -42,6 +42,16 @@ func TestNewFromPath(t *testing.T) {
 			false,
 		},
 		{
+			"foo.Dockerfile",
+			&docker.Parser{},
+			false,
+		},
+		{
+			"foo.dockerfile",
+			&docker.Parser{},
+			false,
+		},
+		{
 			"test.tf",
 			&hcl2.Parser{},
 			false,


### PR DESCRIPTION
It is common for Dockerfiles to be named foo.Dockerfile
When detecting the parser for files of this form the logic assumes
it will be lowercase (foo.dockerfile).

Updated this logic to be more permissive, allowing both cases, and
added unit tests to cover these scenarios

Fixes #451

Signed-off-by: shteou <shteou@gmail.com>