### PR TITLE
fix: tracing output with array inputs

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -133,6 +133,7 @@ func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, name
 				checkResult.Failures = append(checkResult.Failures, result.Failures...)
 				checkResult.Warnings = append(checkResult.Warnings, result.Warnings...)
 				checkResult.Exceptions = append(checkResult.Exceptions, result.Exceptions...)
+				checkResult.Queries = append(checkResult.Queries, result.Queries...)
 			}
 			checkResults = append(checkResults, checkResult)
 			continue

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"testing"
+	"fmt"
 
 	"github.com/open-policy-agent/conftest/parser"
 )
@@ -83,6 +84,15 @@ func TestMultifileYaml(t *testing.T) {
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Multifile yaml test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
 	}
+
+	// 10 warnings/failures/successes queries, and 2 dummy exception queries
+	const expectedQueries = 12
+	fmt.Printf("%d\n", len(results[0].Queries))
+	fmt.Printf("%v+\n", results[0].Queries)
+	actualQueries := len(results[0].Queries)
+	if actualQueries != expectedQueries {
+		t.Errorf("Multifile yaml test failure. Got %v queries, expected %v", actualQueries, expectedQueries)
+	}
 }
 
 func TestDockerfile(t *testing.T) {
@@ -115,6 +125,13 @@ func TestDockerfile(t *testing.T) {
 	actualSuccesses := results[0].Successes
 	if actualSuccesses != expectedSuccesses {
 		t.Errorf("Dockerfile test failure. Got %v successes, expected %v", actualSuccesses, expectedSuccesses)
+	}
+
+	// 1 failure, and 1 dummy exception query
+	const expectedQueries = 2
+	actualQueries := len(results[0].Queries)
+	if actualQueries != expectedQueries {
+		t.Errorf("Dockerfile test failure. Got %v queries, expected %v", actualQueries, expectedQueries)
 	}
 }
 


### PR DESCRIPTION
fix: tracing output with array inputs

Fixed tracing outputs where the inputs are an array of documents
e.g. when the input is a multi-document yaml file, Dockerfile or
.gitignore file

Aggregated Queries for multiple inputs against the filename, in
a similar manner to success/failures etc.

Fixes #454, fixes #456

Signed-off-by: Stewart Platt <shteou@gmail.com>