### PR TITLE
chore: remove unneeded Printlns from unit tests

### DIFF
--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -3,7 +3,6 @@ package policy
 import (
 	"context"
 	"testing"
-	"fmt"
 
 	"github.com/open-policy-agent/conftest/parser"
 )
@@ -87,8 +86,6 @@ func TestMultifileYaml(t *testing.T) {
 
 	// 10 warnings/failures/successes queries, and 2 dummy exception queries
 	const expectedQueries = 12
-	fmt.Printf("%d\n", len(results[0].Queries))
-	fmt.Printf("%v+\n", results[0].Queries)
 	actualQueries := len(results[0].Queries)
 	if actualQueries != expectedQueries {
 		t.Errorf("Multifile yaml test failure. Got %v queries, expected %v", actualQueries, expectedQueries)


### PR DESCRIPTION
Signed-off-by: Stewart Platt <shteou@gmail.com>