### PR TITLE
Enable Buildkit in Docker builds to speed things up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,9 @@ jobs:
   release_docker:
     docker:
       - image: circleci/golang:1.13-node
+    
+    environment:
+      DOCKER_BUILDKIT: 1
 
     steps:
       - checkout


### PR DESCRIPTION
Currently the CircleCI docker builds run all the stages as the new
builder isn't enabled.