### PR TITLE
Ignore .git for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .circle
+.git
 dist
 README.md
 CODE_OF_CONDUCT.md


### PR DESCRIPTION
This reduces the context sent to the docker daemon from 4.151MB to 607.2kB

Longer term this will help docker builds from getting bogged down by a larger context as the git history increases. This shouldn't cause any issues as nothing in the Dockerfile uses git