### PR TITLE
Fix: Version command does not print the version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,8 +98,16 @@ jobs:
       - checkout
       - setup_remote_docker
       - docker/check
+      - run:
+          name: Setup docker build environment
+          command: |
+            GIT_COMMIT=$(git rev-parse HEAD)
+            DATE=$(date)
+            echo 'export GIT_COMMIT="$GIT_COMMIT"' >> $BASH_ENV
+            echo 'export DATE="$DATE"' >> $BASH_ENV
       - docker/build:
           image: openpolicyagent/conftest
+          extra_build_args: "--build-arg VERSION=$CIRCLE_TAG --build-arg COMMIT=$GIT_COMMIT --build-arg DATE=$DATE"
           tag: $CIRCLE_TAG,latest
       - docker/push:
           image: openpolicyagent/conftest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.13-alpine as base
 ARG ARCH=amd64
+ARG VERSION
+ARG COMMIT
+ARG DATE
 ENV GOOS=linux \
     CGO_ENABLED=0 \
     GOARCH=${ARCH}
@@ -14,7 +17,7 @@ COPY . .
 
 ## BUILDER STAGE ##
 FROM base as builder
-RUN go build -o conftest -ldflags="-w -s" main.go
+RUN go build -o conftest -ldflags="-w -s -X github.com/open-policy-agent/conftest/internal/commands.version=${VERSION} -X github.com/open-policy-agent/conftest/internal/commands.commit=${COMMIT} -X github.com/open-policy-agent/conftest/internal/commands.date=${DATE}" main.go
 
 ## TEST STAGE ##
 FROM base as test

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,18 @@ all: build test acceptance
 ## RELEASES
 TAG=$(shell git describe --abbrev=0 --tags)
 IMAGE=openpolicyagent/conftest
+GIT_COMMIT=$(shell git rev-parse HEAD)
+GIT_TAG=$(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+DATE=$(shell date)
+
+VERSION = unreleased
+ifneq ($(GIT_TAG),)
+	VERSION = $(GIT_TAG)
+endif
 
 .PHONY: image
 image:
-	@docker build . -t $(IMAGE):$(TAG)
+	@docker build --build-arg VERSION="$(VERSION)" --build-arg COMMIT="$(GIT_COMMIT)" --build-arg DATE="$(DATE)" . -t $(IMAGE):$(TAG) 
 	@docker tag $(IMAGE):$(TAG) $(IMAGE):latest
 
 .PHONY: examples


### PR DESCRIPTION
The build process for Docker was missing a mechanism to set the version, commit and date variables.

Fixes: #488 