### PR TITLE
Update documentation for installing plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,7 +27,7 @@ Under the hood conftest leverages [go-getter](https://github.com/hashicorp/go-ge
 For example, to download the Kubernetes Conftest plugin you can execute the following command:
 
 ```console
-conftest plugin install https://github.com/open-policy-agent/conftest/contrib/plugins/kubectl
+conftest plugin install git://github.com/open-policy-agent/conftest//contrib/plugins/kubectl
 ```
 
 ## Using plugins


### PR DESCRIPTION
From the `go-getter` docs, downloading subdirectories requires `//`