### PR TITLE
Minor documentation update to latest Conftest version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,8 @@ Conftest is available for Windows, macOS and Linux on the [releases page](https:
 On Linux and macOS you can download as follows:
 
 ```console
-$ wget https://github.com/open-policy-agent/conftest/releases/download/v0.21.0/conftest_0.21.0_Linux_x86_64.tar.gz
-$ tar xzf conftest_0.21.0_Linux_x86_64.tar.gz
+$ wget https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Linux_x86_64.tar.gz
+$ tar xzf conftest_0.23.0_Linux_x86_64.tar.gz
 $ sudo mv conftest /usr/local/bin
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,9 +5,9 @@ Conftest is available for Windows, macOS and Linux on the [releases page](https:
 On Linux and macOS you can download as follows:
 
 ```console
-$ wget https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Linux_x86_64.tar.gz
-$ tar xzf conftest_0.23.0_Linux_x86_64.tar.gz
-$ sudo mv conftest /usr/local/bin
+wget https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Linux_x86_64.tar.gz
+tar xzf conftest_0.23.0_Linux_x86_64.tar.gz
+sudo mv conftest /usr/local/bin
 ```
 
 ## Brew


### PR DESCRIPTION
I hit an issue on conftest 0.21.0 and found [a resolution](https://github.com/open-policy-agent/conftest/issues/427) which required upgrading. Noticed on Conftest's documentation that the old version was still the "copy+paste" installation method. Quick update.

Additionally, the `$` at the beginning of the first step of install commands make copy+pasting the commands fail. Unless that is intentional, would be nicer to change that to mimic the rest of the commands on that page, so removed those characters.