### PR TITLE
Add .tfvars as an HCL2 parseable file type

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -115,7 +115,7 @@ func NewFromPath(path string) (Parser, error) {
 
 	// When parsing Terraform files, the default parser to use
 	// should be the latest HCL parser.
-	if fileExtension == "tf" {
+	if fileExtension == "tf" || fileExtension == "tfvars" {
 		return New(HCL2)
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -67,6 +67,11 @@ func TestNewFromPath(t *testing.T) {
 			false,
 		},
 		{
+			"test.tfvars",
+			&hcl2.Parser{},
+			false,
+		},
+		{
 			"noextension",
 			&yaml.Parser{},
 			false,


### PR DESCRIPTION
I can add an `acceptance.bats` test and add a `.tfvars` file to `examples/` if y'all want but it's more HCL2 so I didn't think that was necessary.