### PR TITLE
make result output exit codes consistent

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -17,7 +17,7 @@
 
 @test "Fail when testing a service with warnings" {
   run ./conftest test --fail-on-warn -p examples/kubernetes/policy examples/kubernetes/service.yaml
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 2 ]
 }
 
 @test "Fail when testing with no policies path" {

--- a/output/result.go
+++ b/output/result.go
@@ -2,6 +2,11 @@ package output
 
 import "fmt"
 
+const (
+	failureExitCode = 1
+	warningExitCode = 2
+)
+
 // Result describes the result of a single rule evaluation.
 type Result struct {
 	Message  string                 `json:"msg"`
@@ -90,7 +95,7 @@ func ExitCode(results []CheckResult) int {
 	}
 
 	if hasFailure {
-		return 1
+		return failureExitCode
 	}
 
 	return 0
@@ -113,11 +118,11 @@ func ExitCodeFailOnWarn(results []CheckResult) int {
 	}
 
 	if hasFailure {
-		return 2
+		return failureExitCode
 	}
 
 	if hasWarning {
-		return 1
+		return warningExitCode
 	}
 
 	return 0

--- a/output/result_test.go
+++ b/output/result_test.go
@@ -19,8 +19,8 @@ func TestExitCode(t *testing.T) {
 	}{
 		{results: []CheckResult{}, expected: 0},
 		{results: []CheckResult{warning}, expected: 0},
-		{results: []CheckResult{failure}, expected: 1},
-		{results: []CheckResult{warning, failure}, expected: 1},
+		{results: []CheckResult{failure}, expected: failureExitCode},
+		{results: []CheckResult{warning, failure}, expected: failureExitCode},
 	}
 
 	for _, testCase := range testCases {
@@ -46,9 +46,9 @@ func TestExitCodeFailOnWarn(t *testing.T) {
 		expected int
 	}{
 		{results: []CheckResult{}, expected: 0},
-		{results: []CheckResult{warning}, expected: 1},
-		{results: []CheckResult{failure}, expected: 2},
-		{results: []CheckResult{warning, failure}, expected: 2},
+		{results: []CheckResult{warning}, expected: warningExitCode},
+		{results: []CheckResult{failure}, expected: failureExitCode},
+		{results: []CheckResult{warning, failure}, expected: failureExitCode},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
A failure would return a different exit code depending on whether the `fail-on-warn` is set. `1` if it's not set, `2` if it is.
This change ensures failure(s) always leads to an exit code of `1`, and warnings exit code `2` (when `fail-on-warn`  is set).

This allows us to reliably determine the overall result from the the returned exit code.