### PR TITLE
Verify: count and report skipped tests

### DIFF
--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -76,7 +76,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running verification: %w", err)
 			}
 
-			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, Tracing: runner.Trace})
+			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, Tracing: runner.Trace, ShowSkipped: true})
 			if err := outputter.Output(results); err != nil {
 				return fmt.Errorf("output results: %w", err)
 			}

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -51,7 +51,7 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
 		}
 
 		var outputResult output.Result
-		if result.Fail {
+		if result.Fail || result.Skip {
 			outputResult.Message = result.Package + "." + result.Name
 		}
 
@@ -67,6 +67,8 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
 		}
 		if result.Fail {
 			checkResult.Failures = []output.Result{outputResult}
+		} else if result.Skip {
+			checkResult.Skipped = []output.Result{outputResult}
 		} else {
 			checkResult.Successes++
 		}

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -57,13 +57,14 @@ func TestJSON(t *testing.T) {
 			},
 		},
 		{
-			name: "A warning and a failure",
+			name: "A warning, a failure and a skipped test",
 			input: []CheckResult{
 				{
 					FileName: "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
 					Warnings: []Result{{Message: "first warning"}},
 					Failures: []Result{{Message: "first failure"}},
+					Skipped:  []Result{{Message: "first skipped"}},
 				},
 			},
 			expected: []string{
@@ -72,6 +73,11 @@ func TestJSON(t *testing.T) {
 				`		"filename": "examples/kubernetes/service.yaml",`,
 				`		"namespace": "namespace",`,
 				`		"successes": 0,`,
+				`		"skipped": [`,
+				`			{`,
+				`				"msg": "first skipped"`,
+				`			}`,
+				`		],`,
 				`		"warnings": [`,
 				`			{`,
 				`				"msg": "first warning"`,

--- a/output/junit.go
+++ b/output/junit.go
@@ -49,6 +49,16 @@ func (j *JUnit) Output(results []CheckResult) error {
 			tests = append(tests, &failingTest)
 		}
 
+		for _, skipped := range result.Skipped {
+			skippedTest := parser.Test{
+				Name:   getTestName(result.FileName, result.Namespace, skipped.Message),
+				Result: parser.SKIP,
+				Output: []string{skipped.Message},
+			}
+
+			tests = append(tests, &skippedTest)
+		}
+
 		for s := 0; s < result.Successes; s++ {
 			successfulTest := parser.Test{
 				Name:   getTestName(result.FileName, result.Namespace, ""),

--- a/output/junit_test.go
+++ b/output/junit_test.go
@@ -35,19 +35,20 @@ func TestJUnit(t *testing.T) {
 			},
 		},
 		{
-			name: "A warning and a failure",
+			name: "A warning, a failure and a skipped test",
 			input: []CheckResult{
 				{
 					FileName: "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
 					Warnings: []Result{{Message: "first warning"}},
 					Failures: []Result{{Message: "first failure"}},
+					Skipped:  []Result{{Message: "first skipped"}},
 				},
 			},
 			expected: []string{
 				`<?xml version="1.0" encoding="UTF-8"?>`,
 				`<testsuites>`,
-				`	<testsuite tests="2" failures="2" time="0.000" name="conftest">`,
+				`	<testsuite tests="3" failures="2" time="0.000" name="conftest">`,
 				`		<properties>`,
 				`			<property name="go.version" value="%s"></property>`,
 				`		</properties>`,
@@ -56,6 +57,9 @@ func TestJUnit(t *testing.T) {
 				`		</testcase>`,
 				`		<testcase classname="conftest" name="examples/kubernetes/service.yaml - namespace - first failure" time="0.000">`,
 				`			<failure message="Failed" type="">first failure</failure>`,
+				`		</testcase>`,
+				`		<testcase classname="conftest" name="examples/kubernetes/service.yaml - namespace - first skipped" time="0.000">`,
+				`			<skipped message="first skipped"></skipped>`,
 				`		</testcase>`,
 				`	</testsuite>`,
 				`</testsuites>`,

--- a/output/output.go
+++ b/output/output.go
@@ -11,8 +11,9 @@ type Outputter interface {
 // Options represents the options available when configuring
 // an Outputter.
 type Options struct {
-	Tracing bool
-	NoColor bool
+	Tracing     bool
+	NoColor     bool
+	ShowSkipped bool
 }
 
 // The defined output formats represent all of the supported formats
@@ -29,7 +30,7 @@ const (
 func Get(format string, options Options) Outputter {
 	switch format {
 	case OutputStandard:
-		return &Standard{Writer: os.Stdout, NoColor: options.NoColor, Tracing: options.Tracing}
+		return &Standard{Writer: os.Stdout, NoColor: options.NoColor, Tracing: options.Tracing, ShowSkipped: options.ShowSkipped}
 	case OutputJSON:
 		return NewJSON(os.Stdout)
 	case OutputTAP:

--- a/output/result.go
+++ b/output/result.go
@@ -73,6 +73,7 @@ type CheckResult struct {
 	FileName   string        `json:"filename"`
 	Namespace  string        `json:"namespace"`
 	Successes  int           `json:"successes"`
+	Skipped    []Result      `json:"skipped,omitempty"`
 	Warnings   []Result      `json:"warnings,omitempty"`
 	Failures   []Result      `json:"failures,omitempty"`
 	Exceptions []Result      `json:"exceptions,omitempty"`

--- a/output/result_test.go
+++ b/output/result_test.go
@@ -13,12 +13,17 @@ func TestExitCode(t *testing.T) {
 		Failures: []Result{{}},
 	}
 
+	skipped := CheckResult{
+		Skipped: []Result{{}},
+	}
+
 	testCases := []struct {
 		results  []CheckResult
 		expected int
 	}{
 		{results: []CheckResult{}, expected: 0},
 		{results: []CheckResult{warning}, expected: 0},
+		{results: []CheckResult{skipped}, expected: 0},
 		{results: []CheckResult{failure}, expected: 1},
 		{results: []CheckResult{warning, failure}, expected: 1},
 	}

--- a/output/standard.go
+++ b/output/standard.go
@@ -19,6 +19,10 @@ type Standard struct {
 	// NoColor will disable all coloring when
 	// set to true.
 	NoColor bool
+
+	// ShowSkipped whether to show skipped tests
+	// in the output.
+	ShowSkipped bool
 }
 
 // NewStandard creates a new Standard with the given writer.
@@ -46,6 +50,7 @@ func (s *Standard) Output(results []CheckResult) error {
 	var totalExceptions int
 	var totalWarnings int
 	var totalSuccesses int
+	var totalSkipped int
 	for _, result := range results {
 		var indicator string
 		var namespace string
@@ -61,8 +66,7 @@ func (s *Standard) Output(results []CheckResult) error {
 			namespace = fmt.Sprintf("- %s -", result.Namespace)
 		}
 
-
-		totalPolicies := result.Successes + len(result.Warnings) + len(result.Failures) + len(result.Exceptions)
+		totalPolicies := result.Successes + len(result.Warnings) + len(result.Failures) + len(result.Exceptions) + len(result.Skipped)
 		if totalPolicies == 0 {
 			fmt.Fprintln(s.Writer, colorizer.Colorize("?", aurora.WhiteFg), indicator, namespace, "no policies found")
 			continue
@@ -83,10 +87,11 @@ func (s *Standard) Output(results []CheckResult) error {
 		totalFailures += len(result.Failures)
 		totalExceptions += len(result.Exceptions)
 		totalWarnings += len(result.Warnings)
+		totalSkipped += len(result.Skipped)
 		totalSuccesses += result.Successes
 	}
 
-	totalTests := totalFailures + totalExceptions + totalWarnings + totalSuccesses
+	totalTests := totalFailures + totalExceptions + totalWarnings + totalSuccesses + totalSkipped
 
 	var pluralSuffixTests string
 	if totalTests != 1 {
@@ -115,6 +120,10 @@ func (s *Standard) Output(results []CheckResult) error {
 		totalFailures, pluralSuffixFailures,
 		totalExceptions, pluralSuffixExceptions,
 	)
+
+	if s.ShowSkipped {
+		outputText += fmt.Sprintf(", %v skipped", totalSkipped)
+	}
 
 	var outputColor aurora.Color
 	if totalFailures > 0 {

--- a/output/table.go
+++ b/output/table.go
@@ -40,6 +40,10 @@ func (t *Table) Output(checkResults []CheckResult) error {
 			table.Append([]string{"warning", checkResult.FileName, checkResult.Namespace, result.Message})
 		}
 
+		for _, result := range checkResult.Skipped {
+			table.Append([]string{"skipped", checkResult.FileName, checkResult.Namespace, result.Message})
+		}
+
 		for _, result := range checkResult.Failures {
 			table.Append([]string{"failure", checkResult.FileName, checkResult.Namespace, result.Message})
 		}

--- a/output/table_test.go
+++ b/output/table_test.go
@@ -22,13 +22,14 @@ func TestTable(t *testing.T) {
 			expected: []string{},
 		},
 		{
-			name: "A warning and a failure",
+			name: "A warning, a failure, a skipped",
 			input: []CheckResult{
 				{
 					FileName: "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
 					Warnings: []Result{{Message: "first warning"}},
 					Failures: []Result{{Message: "first failure"}},
+					Skipped:  []Result{{Message: "first skipped"}},
 				},
 			},
 			expected: []string{
@@ -36,6 +37,7 @@ func TestTable(t *testing.T) {
 				`| RESULT  |               FILE               | NAMESPACE |    MESSAGE    |`,
 				`+---------+----------------------------------+-----------+---------------+`,
 				`| warning | examples/kubernetes/service.yaml | namespace | first warning |`,
+				`| skipped | examples/kubernetes/service.yaml | namespace | first skipped |`,
 				`| failure | examples/kubernetes/service.yaml | namespace | first failure |`,
 				`+---------+----------------------------------+-----------+---------------+`,
 				``,

--- a/output/tap.go
+++ b/output/tap.go
@@ -37,7 +37,7 @@ func (t *TAP) Output(checkResults []CheckResult) error {
 			namespace = fmt.Sprintf("- %s -", result.Namespace)
 		}
 
-		totalTests := result.Successes + len(result.Failures) + len(result.Warnings) + len(result.Exceptions)
+		totalTests := result.Successes + len(result.Failures) + len(result.Warnings) + len(result.Exceptions) + len(result.Skipped)
 		if totalTests == 0 {
 			return nil
 		}
@@ -62,6 +62,14 @@ func (t *TAP) Output(checkResults []CheckResult) error {
 			fmt.Fprintln(t.Writer, "# exceptions")
 			for _, exception := range result.Exceptions {
 				fmt.Fprintln(t.Writer, fmt.Sprintf("ok %v %v %v %v", counter, indicator, namespace, exception.Message))
+				counter++
+			}
+		}
+
+		if len(result.Skipped) > 0 {
+			fmt.Fprintln(t.Writer, "# skip")
+			for _, skipped := range result.Skipped {
+				fmt.Fprintln(t.Writer, fmt.Sprintf("ok %v %v %v %v", counter, indicator, namespace, skipped.Message))
 				counter++
 			}
 		}

--- a/output/tap_test.go
+++ b/output/tap_test.go
@@ -41,17 +41,20 @@ func TestTAP(t *testing.T) {
 			},
 		},
 		{
-			name: "mixed failure and warnings",
+			name: "mixed failure, warnings and skipped",
 			input: []CheckResult{
 				{
 					FileName: "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
 					Failures: []Result{{Message: "first failure"}},
+					Skipped:  []Result{{Message: "first skipped"}},
 				},
 			},
 			expected: []string{
-				"1..1",
+				"1..2",
 				"not ok 1 - examples/kubernetes/service.yaml - namespace - first failure",
+				"# skip",
+				"ok 2 - examples/kubernetes/service.yaml - namespace - first skipped",
 				"",
 			},
 		},


### PR DESCRIPTION
Since version 0.27.0 OPA allows tests to be skipped by prefixing "todo_"
to the test name. This change brings that to the conftest verify command
and allows skipped tests to be reported in all available output formats.

Fixes #479

Signed-off-by: Anders Eknert <anders@eknert.com>