### PR TITLE
Use dependabot for OPA updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,11 @@
+# Dependabot is used to keep track of the latest OPA releases so that
+# Conftest can use the most up to date engine.
+
 version: 2
 updates:
-  - package-ecosystem: gomod
+  - package-ecosystem: "gomod"
     directory: "/"
+    allow:
+      - dependency-name: "github.com/open-policy-agent/opa"
     schedule:
-      interval: daily
+      interval: "daily"


### PR DESCRIPTION
Theres a lot of PR noise with dependabot checking everything. The most important dependency is OPA to keep as up to date as possible.