### PR TITLE
feat: improve combined input example

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -36,8 +36,8 @@ Save the following as `policy/combine.rego`:
 package main
 
 deny[msg] {
-  input[_].contents.kind == "Deployment"
-  deployment := input[_].contents
+  input[deployment].contents.kind == "Deployment"
+  deployment := input[deployment].contents
 
   not service_selects_app(deployment.spec.selector.matchLabels.app)
 
@@ -45,8 +45,8 @@ deny[msg] {
 }
 
 service_selects_app(app) {
-  input[_].contents.kind == "Service"
-  input[_].contents.spec.selector.app == app
+  input[service].contents.kind == "Service"
+  input[service].contents.spec.selector.app == app
 }
 ```
 


### PR DESCRIPTION
The docs example policy for the `combine` flag uses underscores
for the index of the input document

The underscore should be avoided here, as it can lead to data
being resolved in multiple input documents where the policy calls
for acting on a single document in a set

Signed-off-by: Stewart Platt <shteou@gmail.com>