### PR TITLE
Update install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,8 +5,8 @@ Conftest is available for Windows, macOS and Linux on the [releases page](https:
 On Linux and macOS you can download as follows:
 
 ```console
-wget https://github.com/open-policy-agent/conftest/releases/download/v0.23.0/conftest_0.23.0_Linux_x86_64.tar.gz
-tar xzf conftest_0.23.0_Linux_x86_64.tar.gz
+wget https://github.com/open-policy-agent/conftest/releases/download/v0.24.0/conftest_0.24.0_Linux_x86_64.tar.gz
+tar xzf conftest_0.24.0_Linux_x86_64.tar.gz
 sudo mv conftest /usr/local/bin
 ```
 
@@ -15,7 +15,6 @@ sudo mv conftest /usr/local/bin
 Install with Homebrew on macOS or Linux:
 
 ```console
-brew tap instrumenta/instrumenta
 brew install conftest
 ```
 
@@ -24,7 +23,6 @@ brew install conftest
 You can also install using [Scoop](https://scoop.sh/) on Windows:
 
 ```console
-scoop bucket add instrumenta https://github.com/instrumenta/scoop-instrumenta
 scoop install conftest
 ```
 


### PR DESCRIPTION
> NOTE: Starting from v0.24.0, Conftest will be available from the core repositories for both brew and Scoop. The instrumenta repositories are no longer needed when fetching the newest version.