### PR TITLE
Do not make rego trace unless --trace flag is passed in 

### DIFF
--- a/internal/runner/test.go
+++ b/internal/runner/test.go
@@ -62,6 +62,10 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 		return nil, fmt.Errorf("load: %w", err)
 	}
 
+	if t.Trace {
+		engine.EnableTracing()
+	}
+
 	namespaces := t.Namespace
 	if t.AllNamespaces {
 		namespaces = engine.Namespaces()

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -29,6 +29,10 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
 		return nil, fmt.Errorf("load: %w", err)
 	}
 
+	if r.Trace {
+		engine.EnableTracing()
+	}
+
 	runner := tester.NewRunner().SetCompiler(engine.Compiler()).SetStore(engine.Store()).SetModules(engine.Modules()).EnableTracing(true).SetRuntime(engine.Runtime())
 	ch, err := runner.RunTests(ctx, nil)
 	if err != nil {

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -33,7 +33,7 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, error) {
 		engine.EnableTracing()
 	}
 
-	runner := tester.NewRunner().SetCompiler(engine.Compiler()).SetStore(engine.Store()).SetModules(engine.Modules()).EnableTracing(true).SetRuntime(engine.Runtime())
+	runner := tester.NewRunner().SetCompiler(engine.Compiler()).SetStore(engine.Store()).SetModules(engine.Modules()).EnableTracing(r.Trace).SetRuntime(engine.Runtime())
 	ch, err := runner.RunTests(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("running tests: %w", err)


### PR DESCRIPTION
Currently conftest always uses tracing even if `--trace` flag is not used. This is causes significant memory consumption when `conftest` is used with a semi complicated rego library and big config files. This is a PR to the https://github.com/open-policy-agent/conftest/issues/555