### PR TITLE
Update documentation for file extensions

### DIFF
--- a/parser/docker/docker_test.go
+++ b/parser/docker/docker_test.go
@@ -67,5 +67,4 @@ RUN go build -o conftest`
 	if stage != 1 {
 		t.Errorf("expected command to be in stage 1, not stage: %v", stage)
 	}
-	t.Logf("%v", commands)
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -89,32 +89,32 @@ func New(parser string) (Parser, error) {
 // NewFromPath returns a file parser based on the file type
 // that exists at the given path.
 func NewFromPath(path string) (Parser, error) {
+
+	// We use the YAML parser as the default when passing in configuration
+	// data through standard input. This can be overridden by using the parser flag.
 	if path == "-" {
 		return New(YAML)
 	}
 
 	fileName := strings.ToLower(filepath.Base(path))
-	if fileName == "dockerfile" || strings.Contains(fileName, "dockerfile.") {
-		return New(Dockerfile)
-	}
 
-	// The yml file extension is the default when a file extension
-	// was not found.
 	fileExtension := "yml"
 	if len(filepath.Ext(path)) > 0 {
-		fileExtension = filepath.Ext(path)[1:]
+		fileExtension = strings.ToLower(filepath.Ext(path)[1:])
+	}
+
+	// A Dockerfile can either be a file named Dockerfile, be prefixed with
+	// Dockerfile, or have Dockerfile as its extension.
+	//
+	// For example: Dockerfile, Dockerfile.debug, dev.Dockerfile
+	if fileName == "dockerfile" || strings.HasPrefix(fileName, "dockerfile.") || fileExtension == "dockerfile" {
+		return New(Dockerfile)
 	}
 
 	if fileExtension == "yml" || fileExtension == "yaml" {
 		return New(YAML)
 	}
 
-	if strings.EqualFold(fileExtension, "dockerfile") {
-		return New(Dockerfile)
-	}
-
-	// When parsing Terraform files, the default parser to use
-	// should be the latest HCL parser.
 	if fileExtension == "tf" || fileExtension == "tfvars" {
 		return New(HCL2)
 	}


### PR DESCRIPTION
Improve the code documentation when figuring out which parser to use. Relates to https://github.com/open-policy-agent/conftest/issues/561

Also removed a stray `Log` line in the unit tests.