### PR TITLE
Add conftest test flag to suppress exceptions

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -276,6 +276,18 @@
   [ "${lines[2]}" = "2 tests, 0 passed, 0 warnings, 1 failure, 1 exception" ]
 }
 
+@test "Exceptions output" {
+  run ./conftest test -p examples/exceptions/policy examples/exceptions/deployments.yaml --no-color
+  [ "$status" -eq 1 ]
+  [[ "${lines[1]}" =~ "EXCP - examples/exceptions/deployments.yaml - main - data.main.exception[_][_] == \"run_as_root\"" ]]
+}
+
+@test "Suppress exceptions output" {
+  run ./conftest test -p examples/exceptions/policy examples/exceptions/deployments.yaml --no-color --suppress-exceptions
+  [ "$status" -eq 1 ]
+  [ "${lines[1]}" = "2 tests, 0 passed, 0 warnings, 1 failure, 1 exception" ]
+}
+
 @test "Can combine yaml files" {
   run ./conftest test -p examples/combine/policy examples/combine/team.yaml examples/combine/user1.yaml examples/combine/user2.yaml --combine 
 

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -84,7 +84,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Long:  testDesc,
 		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "namespace", "no-color", "no-fail", "output", "parser", "policy", "trace", "update"}
+			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "namespace", "no-color", "no-fail", "suppress-exceptions", "output", "parser", "policy", "trace", "update"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -105,7 +105,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running test: %w", err)
 			}
 
-			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, Tracing: runner.Trace})
+			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, SuppressExceptions: runner.SuppressExceptions, Tracing: runner.Trace})
 			if err := outputter.Output(results); err != nil {
 				return fmt.Errorf("output results: %w", err)
 			}
@@ -131,6 +131,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().Bool("fail-on-warn", false, "Return a non-zero exit code if warnings or errors are found")
 	cmd.Flags().Bool("no-fail", false, "Return an exit code of zero even if a policy fails")
 	cmd.Flags().Bool("no-color", false, "Disable color when printing")
+	cmd.Flags().Bool("suppress-exceptions", false, "Do not include exceptions in output")
 	cmd.Flags().Bool("all-namespaces", false, "Test policies found in all namespaces")
 
 	cmd.Flags().BoolP("trace", "", false, "Enable more verbose trace output for Rego queries")

--- a/internal/runner/test.go
+++ b/internal/runner/test.go
@@ -16,19 +16,20 @@ import (
 // TestRunner is the runner for the Test command, executing
 // Rego policy checks against configuration files.
 type TestRunner struct {
-	Trace         bool
-	Policy        []string
-	Data          []string
-	Update        []string
-	Ignore        string
-	Parser        string
-	Namespace     []string
-	AllNamespaces bool `mapstructure:"all-namespaces"`
-	FailOnWarn    bool `mapstructure:"fail-on-warn"`
-	NoColor       bool `mapstructure:"no-color"`
-	NoFail        bool `mapstructure:"no-fail"`
-	Combine       bool
-	Output        string
+	Trace              bool
+	Policy             []string
+	Data               []string
+	Update             []string
+	Ignore             string
+	Parser             string
+	Namespace          []string
+	AllNamespaces      bool `mapstructure:"all-namespaces"`
+	FailOnWarn         bool `mapstructure:"fail-on-warn"`
+	NoColor            bool `mapstructure:"no-color"`
+	NoFail             bool `mapstructure:"no-fail"`
+	SuppressExceptions bool `mapstructure:"suppress-exceptions"`
+	Combine            bool
+	Output             string
 }
 
 // Run executes the TestRunner, verifying all Rego policies against the given

--- a/output/output.go
+++ b/output/output.go
@@ -11,9 +11,10 @@ type Outputter interface {
 // Options represents the options available when configuring
 // an Outputter.
 type Options struct {
-	Tracing     bool
-	NoColor     bool
-	ShowSkipped bool
+	Tracing            bool
+	NoColor            bool
+	SuppressExceptions bool
+	ShowSkipped        bool
 }
 
 // The defined output formats represent all of the supported formats
@@ -30,7 +31,7 @@ const (
 func Get(format string, options Options) Outputter {
 	switch format {
 	case OutputStandard:
-		return &Standard{Writer: os.Stdout, NoColor: options.NoColor, Tracing: options.Tracing, ShowSkipped: options.ShowSkipped}
+		return &Standard{Writer: os.Stdout, NoColor: options.NoColor, SuppressExceptions: options.SuppressExceptions, Tracing: options.Tracing, ShowSkipped: options.ShowSkipped}
 	case OutputJSON:
 		return NewJSON(os.Stdout)
 	case OutputTAP:

--- a/output/standard.go
+++ b/output/standard.go
@@ -20,6 +20,9 @@ type Standard struct {
 	// set to true.
 	NoColor bool
 
+	// SuppressExceptions will disable output for exceptions when set to true.
+	SuppressExceptions bool
+
 	// ShowSkipped whether to show skipped tests
 	// in the output.
 	ShowSkipped bool
@@ -80,8 +83,10 @@ func (s *Standard) Output(results []CheckResult) error {
 			fmt.Fprintln(s.Writer, colorizer.Colorize("FAIL", aurora.RedFg), indicator, namespace, failure.Message)
 		}
 
-		for _, exception := range result.Exceptions {
-			fmt.Fprintln(s.Writer, colorizer.Colorize("EXCP", aurora.CyanFg), indicator, namespace, exception.Message)
+		if !s.SuppressExceptions {
+			for _, exception := range result.Exceptions {
+				fmt.Fprintln(s.Writer, colorizer.Colorize("EXCP", aurora.CyanFg), indicator, namespace, exception.Message)
+			}
 		}
 
 		totalFailures += len(result.Failures)


### PR DESCRIPTION
Adds a `--suppress-exceptions` flag that does not include exceptions in
the output

Example without the flag set (default)
```sh
$ conftest test -p examples/exceptions/policy examples/exceptions/deployments.yaml
FAIL - examples/exceptions/deployments.yaml - main - Containers must not
run as root in Deployment cannot-run-as-root
EXCP - examples/exceptions/deployments.yaml - main - data.main.exception[_][_] == "run_as_root"

2 tests, 0 passed, 0 warnings, 1 failure, 1 exception
```

Example with the flag set
```bash
$ conftest test -p examples/exceptions/policy examples/exceptions/deployments.yaml --suppress-exceptions
FAIL - examples/exceptions/deployments.yaml - main - Containers must not run as root in Deployment cannot-run-as-root

2 tests, 0 passed, 0 warnings, 1 failure, 1 exception
```

Fixes #568