### PR TITLE
Adding option to produce more useful trace for debugging

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -21,7 +21,7 @@
 }
 
 @test "Fail when testing with no policies path" {
-  run ./conftest test -p internal/ examples/kubernetes/deployment.yaml
+  run ./conftest test -p tests/no-policies-folder/ examples/kubernetes/deployment.yaml
   [ "$status" -eq 1 ]
 }
 
@@ -84,7 +84,7 @@
 }
 
 @test "Fail when verifying with no policies path" {
-  run ./conftest verify -p internal/
+  run ./conftest verify -p tests/no-policies-folder/
   [ "$status" -eq 1 ]
 }
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -108,3 +108,9 @@ TRAC | Exit data.main.deny = _
 TRAC Redo data.main.deny = _
 TRAC | Redo data.main.deny = _
 ```
+
+For more context specific debugging use `conftest verify` with `--explain {full|fails|notes}` flag. `--explain` will output the trace for failed rego tests.
+
+`full` - will produce the full trace output for failing tests. This acts the same as setting `--trace`.
+`fail` - will produce only trace of the failing rules in the failing tests
+`notes` - will produce only trace of the `trace(msg)` statements in the failing tests

--- a/examples/exceptions/policy/testdata/tracing
+++ b/examples/exceptions/policy/testdata/tracing
@@ -1,0 +1,18 @@
+package main
+
+import data.deployments
+
+is_deployment {
+	input.kind = "Deployment"
+}
+
+deny_run_as_root[msg] {
+	is_deployment
+	not input.spec.template.spec.securityContext.runAsNonRoot
+
+	msg = sprintf("Containers must not run as root in Deployment %s", [input.metadata.name])
+}
+
+test_run_as_root {
+	deny_run_as_root["Containers must not run as root in Deployment cannot-run-as-root"] with input as {"kind": "Deployment", "metadata": {"name": "cannot-run-as-root"}, "spec": {"template": {"spec": {"securityContext": {"runAsNonRoot": true}}}}}
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-getter v1.5.3
 	github.com/hashicorp/hcl v1.0.0
 	github.com/jstemmer/go-junit-report v0.9.1
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/moby/buildkit v0.8.2
 	github.com/olekukonko/tablewriter v0.0.5

--- a/internal/runner/fixtures/verify_with_tracing/main.rego
+++ b/internal/runner/fixtures/verify_with_tracing/main.rego
@@ -1,0 +1,34 @@
+package main
+
+resource_types = {"null_resource"}
+
+# all resources
+resources[resource_type] = all {
+	some resource_type
+	resource_types[resource_type]
+	all := [name |
+		name := input.resource_changes[_]
+		name.type == resource_type
+	]
+}
+
+# number of creations of resources of a given type
+num_creates[resource_type] = num {
+	some resource_type
+	resource_types[resource_type]
+	all := resources[resource_type]
+	creates := [res | res := all[_]; res.change.actions[_] == "create"]
+	num := count(creates)
+}
+
+deny[msg] {
+	num_resources := num_creates.null_resource
+	trace("Print statement")
+	num_resources > 0
+
+	msg := "null resources cannot be created"
+}
+
+test_deny_null_created {
+	count(deny[msg]) == 0 with input as {"resource_changes": [{"type": "null_resource", "change": {"actions": ["create"]}}]}
+}

--- a/internal/runner/fixtures/verify_with_tracing/testdata/expected_fails_trace.txt
+++ b/internal/runner/fixtures/verify_with_tracing/testdata/expected_fails_trace.txt
@@ -1,0 +1,4 @@
+query:1                                       Enter data.main.test_deny_null_created = _
+fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
+fixtures/verify_with_tracing/main.rego:33     | | Fail __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+query:1                                       | Fail data.main.test_deny_null_created = _

--- a/internal/runner/fixtures/verify_with_tracing/testdata/expected_full_trace.txt
+++ b/internal/runner/fixtures/verify_with_tracing/testdata/expected_full_trace.txt
@@ -1,0 +1,67 @@
+query:1                                       Enter data.main.test_deny_null_created = _
+query:1                                       | Eval data.main.test_deny_null_created = _
+query:1                                       | Index data.main.test_deny_null_created (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
+fixtures/verify_with_tracing/main.rego:33     | | Eval __local12__ = data.main.deny[msg] with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:33     | | Index data.main.deny (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:24     | | Enter data.main.deny
+fixtures/verify_with_tracing/main.rego:25     | | | Eval num_resources = data.main.num_creates.null_resource
+fixtures/verify_with_tracing/main.rego:25     | | | Index data.main.num_creates (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:16     | | | Enter data.main.num_creates
+fixtures/verify_with_tracing/main.rego:18     | | | | Eval data.main.resource_types[resource_type]
+fixtures/verify_with_tracing/main.rego:18     | | | | Index data.main.resource_types (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:3      | | | | Enter data.main.resource_types
+fixtures/verify_with_tracing/main.rego:3      | | | | | Eval true
+fixtures/verify_with_tracing/main.rego:3      | | | | | Exit data.main.resource_types
+fixtures/verify_with_tracing/main.rego:19     | | | | Eval all = data.main.resources[resource_type]
+fixtures/verify_with_tracing/main.rego:19     | | | | Index data.main.resources (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:6      | | | | Enter data.main.resources
+fixtures/verify_with_tracing/main.rego:8      | | | | | Eval data.main.resource_types[resource_type]
+fixtures/verify_with_tracing/main.rego:8      | | | | | Index data.main.resource_types (matched 1 rule)
+fixtures/verify_with_tracing/main.rego:9      | | | | | Eval all = [name | name = input.resource_changes[_]; name.type = resource_type]
+fixtures/verify_with_tracing/main.rego:10     | | | | | Enter name = input.resource_changes[_]; name.type = resource_type
+fixtures/verify_with_tracing/main.rego:10     | | | | | | Eval name = input.resource_changes[_]
+fixtures/verify_with_tracing/main.rego:11     | | | | | | Eval name.type = resource_type
+fixtures/verify_with_tracing/main.rego:10     | | | | | | Exit name = input.resource_changes[_]; name.type = resource_type
+fixtures/verify_with_tracing/main.rego:10     | | | | | Redo name = input.resource_changes[_]; name.type = resource_type
+fixtures/verify_with_tracing/main.rego:11     | | | | | | Redo name.type = resource_type
+fixtures/verify_with_tracing/main.rego:10     | | | | | | Redo name = input.resource_changes[_]
+fixtures/verify_with_tracing/main.rego:6      | | | | | Exit data.main.resources
+fixtures/verify_with_tracing/main.rego:20     | | | | Eval creates = [res | res = all[_]; res.change.actions[_] = "create"]
+fixtures/verify_with_tracing/main.rego:20     | | | | Enter res = all[_]; res.change.actions[_] = "create"
+fixtures/verify_with_tracing/main.rego:20     | | | | | Eval res = all[_]
+fixtures/verify_with_tracing/main.rego:20     | | | | | Eval res.change.actions[_] = "create"
+fixtures/verify_with_tracing/main.rego:20     | | | | | Exit res = all[_]; res.change.actions[_] = "create"
+fixtures/verify_with_tracing/main.rego:20     | | | | Redo res = all[_]; res.change.actions[_] = "create"
+fixtures/verify_with_tracing/main.rego:20     | | | | | Redo res.change.actions[_] = "create"
+fixtures/verify_with_tracing/main.rego:20     | | | | | Redo res = all[_]
+fixtures/verify_with_tracing/main.rego:21     | | | | Eval count(creates, __local10__)
+fixtures/verify_with_tracing/main.rego:21     | | | | Eval num = __local10__
+fixtures/verify_with_tracing/main.rego:16     | | | | Exit data.main.num_creates
+fixtures/verify_with_tracing/main.rego:26     | | | Eval trace("Print statement")
+fixtures/verify_with_tracing/main.rego:26     | | | Note "Print statement"
+fixtures/verify_with_tracing/main.rego:27     | | | Eval gt(num_resources, 0)
+fixtures/verify_with_tracing/main.rego:29     | | | Eval msg = "null resources cannot be created"
+fixtures/verify_with_tracing/main.rego:24     | | | Exit data.main.deny
+fixtures/verify_with_tracing/main.rego:33     | | Eval count(__local12__, __local11__) with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:33     | | Eval __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:33     | | Fail __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:33     | | Redo count(__local12__, __local11__) with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:33     | | Redo __local12__ = data.main.deny[msg] with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
+fixtures/verify_with_tracing/main.rego:24     | | Redo data.main.deny
+fixtures/verify_with_tracing/main.rego:29     | | | Redo msg = "null resources cannot be created"
+fixtures/verify_with_tracing/main.rego:27     | | | Redo gt(num_resources, 0)
+fixtures/verify_with_tracing/main.rego:26     | | | Redo trace("Print statement")
+fixtures/verify_with_tracing/main.rego:25     | | | Redo num_resources = data.main.num_creates.null_resource
+fixtures/verify_with_tracing/main.rego:16     | | | Redo data.main.num_creates
+fixtures/verify_with_tracing/main.rego:21     | | | | Redo num = __local10__
+fixtures/verify_with_tracing/main.rego:21     | | | | Redo count(creates, __local10__)
+fixtures/verify_with_tracing/main.rego:20     | | | | Redo creates = [res | res = all[_]; res.change.actions[_] = "create"]
+fixtures/verify_with_tracing/main.rego:19     | | | | Redo all = data.main.resources[resource_type]
+fixtures/verify_with_tracing/main.rego:6      | | | | Redo data.main.resources
+fixtures/verify_with_tracing/main.rego:9      | | | | | Redo all = [name | name = input.resource_changes[_]; name.type = resource_type]
+fixtures/verify_with_tracing/main.rego:8      | | | | | Redo data.main.resource_types[resource_type]
+fixtures/verify_with_tracing/main.rego:18     | | | | Redo data.main.resource_types[resource_type]
+fixtures/verify_with_tracing/main.rego:3      | | | | Redo data.main.resource_types
+fixtures/verify_with_tracing/main.rego:3      | | | | | Redo true
+query:1                                       | Fail data.main.test_deny_null_created = _

--- a/internal/runner/fixtures/verify_with_tracing/testdata/expected_notes_trace.txt
+++ b/internal/runner/fixtures/verify_with_tracing/testdata/expected_notes_trace.txt
@@ -1,0 +1,4 @@
+query:1                                       Enter data.main.test_deny_null_created = _
+fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
+fixtures/verify_with_tracing/main.rego:24     | | Enter data.main.deny
+fixtures/verify_with_tracing/main.rego:26     | | | Note "Print statement"

--- a/internal/runner/verify_test.go
+++ b/internal/runner/verify_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"context"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestTrace(t *testing.T) {
+	cases := []struct {
+		PolicyPath          []string
+		ExplainMode         string
+		Trace               bool
+		ExpFailures         int
+		ExpectedTraceOutput string
+		Description         string
+	}{
+		{
+			PolicyPath:          []string{"fixtures/verify_with_tracing/main.rego"},
+			ExplainMode:         "fails",
+			ExpFailures:         1,
+			Description:         "explain_mode_fails",
+			ExpectedTraceOutput: "fixtures/verify_with_tracing/testdata/expected_fails_trace.txt",
+		},
+		{
+			PolicyPath:          []string{"fixtures/verify_with_tracing/main.rego"},
+			ExplainMode:         "notes",
+			ExpFailures:         1,
+			Description:         "explain_mode_notes",
+			ExpectedTraceOutput: "fixtures/verify_with_tracing/testdata/expected_notes_trace.txt",
+		},
+		{
+			PolicyPath:          []string{"fixtures/verify_with_tracing/main.rego"},
+			ExplainMode:         "full",
+			ExpFailures:         1,
+			Description:         "explain_mode_full",
+			ExpectedTraceOutput: "fixtures/verify_with_tracing/testdata/expected_full_trace.txt",
+		},
+		{
+			PolicyPath:          []string{"fixtures/verify_with_tracing/main.rego"},
+			ExplainMode:         "not-supported",
+			ExpFailures:         1,
+			Description:         "no_trace",
+			ExpectedTraceOutput: "fixtures/verify_with_tracing/testdata/expected_no_trace.txt",
+		},
+		{
+			PolicyPath:          []string{"fixtures/verify_with_tracing/main.rego"},
+			Trace:               true,
+			ExpFailures:         1,
+			Description:         "trace_enabled",
+			ExpectedTraceOutput: "fixtures/verify_with_tracing/testdata/expected_full_trace.txt",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			ctx := context.Background()
+			r := VerifyRunner{
+				Policy:       c.PolicyPath,
+				Trace:        c.Trace,
+				ExplainQuery: c.ExplainMode,
+			}
+
+			outputs, err := r.Run(ctx)
+			if err != nil {
+				t.Fatalf("running verify runner: %v", err)
+			}
+
+			expTrace, err := ioutil.ReadFile(c.ExpectedTraceOutput)
+			result := outputs[0]
+			if len(result.Failures) != c.ExpFailures {
+				t.Errorf("Got %v failures, expected %v", len(result.Failures), c.ExpFailures)
+			}
+
+			query := result.Queries[0]
+			actTrace := strings.Join(query.Traces, "\n")
+
+			// Remove newline in the expected fixtures
+			if actTrace != strings.TrimSuffix(string(expTrace), "\n") {
+				t.Errorf("expected:\n%s\ngot:\n%s", expTrace, actTrace)
+			}
+		})
+	}
+}

--- a/internal/runner/verify_test.go
+++ b/internal/runner/verify_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -68,6 +69,10 @@ func TestTrace(t *testing.T) {
 			}
 
 			expTrace, err := ioutil.ReadFile(c.ExpectedTraceOutput)
+			if err != nil {
+				t.Fatalf("reding expected trace output file: %s", err)
+			}
+
 			result := outputs[0]
 			if len(result.Failures) != c.ExpFailures {
 				t.Errorf("Got %v failures, expected %v", len(result.Failures), c.ExpFailures)
@@ -78,6 +83,7 @@ func TestTrace(t *testing.T) {
 
 			// Remove newline in the expected fixtures
 			if actTrace != strings.TrimSuffix(string(expTrace), "\n") {
+				ioutil.WriteFile(fmt.Sprintf("%s.%s", c.ExpectedTraceOutput, "act"), []byte(actTrace), 0600)
 				t.Errorf("expected:\n%s\ngot:\n%s", expTrace, actTrace)
 			}
 		})

--- a/internal/runner/verify_test.go
+++ b/internal/runner/verify_test.go
@@ -70,7 +70,7 @@ func TestTrace(t *testing.T) {
 
 			expTrace, err := ioutil.ReadFile(c.ExpectedTraceOutput)
 			if err != nil {
-				t.Fatalf("reding expected trace output file: %s", err)
+				t.Fatalf("reading ExpectedTraceOutput: %s", err)
 			}
 
 			result := outputs[0]
@@ -83,7 +83,12 @@ func TestTrace(t *testing.T) {
 
 			// Remove newline in the expected fixtures
 			if actTrace != strings.TrimSuffix(string(expTrace), "\n") {
-				ioutil.WriteFile(fmt.Sprintf("%s.%s", c.ExpectedTraceOutput, "act"), []byte(actTrace), 0600)
+				actualTraceFile := fmt.Sprintf("%s.%s", c.ExpectedTraceOutput, "act")
+				err := ioutil.WriteFile(actualTraceFile, []byte(actTrace), 0600)
+				if err != nil {
+					t.Fatalf("writing file: %s", err)
+				}
+
 				t.Errorf("expected:\n%s\ngot:\n%s", expTrace, actTrace)
 			}
 		})


### PR DESCRIPTION
This PR is attempting to enhance `conftest verify` to produce more useful trace logs. Currently the only option is to use `--trace` which will produce a massive logs of rego query decisions which is very difficult to read. 

I added `--explain` flag, it will only show traces for failing tests. The flag supports 3 options:

- `full` - Outputs the whole trace for the failing rego test
- `notes` - Outputs the `trace(msg)` debug statements
- `fails` - Outputs the failing queries within the failed rego test

This is essentially the same as `--explain` from `opa test` but it keeps the output in conftest's format. Using `--trace` still works the same as before and will output everything. 

Here are some example outputs from a test case in the PR:

Explain with `notes` option:
```sh
❯ ~/bin/conftest verify -p fixtures/ --explain notes

file: fixtures/verify_with_tracing/main.rego | query: test_deny_null_created
TRAC   query:1                                       Enter data.main.test_deny_null_created = _
TRAC   fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
TRAC   fixtures/verify_with_tracing/main.rego:24     | | Enter data.main.deny
TRAC   fixtures/verify_with_tracing/main.rego:26     | | | Note "Print statement"
```

Explain with `fails` option:
```
❯ ~/bin/conftest verify -p fixtures/ --explain fails

file: fixtures/verify_with_tracing/main.rego | query: test_deny_null_created
TRAC   query:1                                       Enter data.main.test_deny_null_created = _
TRAC   fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Fail __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   query:1                                       | Fail data.main.test_deny_null_created = _
```

Explain with `full` flag:
```
❯ ~/bin/conftest verify -p fixtures/ --explain full

file: fixtures/verify_with_tracing/main.rego | query: test_deny_null_created
TRAC   query:1                                       Enter data.main.test_deny_null_created = _
TRAC   query:1                                       | Eval data.main.test_deny_null_created = _
TRAC   query:1                                       | Index data.main.test_deny_null_created (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:32     | Enter data.main.test_deny_null_created
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Eval __local12__ = data.main.deny[msg] with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Index data.main.deny (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:24     | | Enter data.main.deny
TRAC   fixtures/verify_with_tracing/main.rego:25     | | | Eval num_resources = data.main.num_creates.null_resource
TRAC   fixtures/verify_with_tracing/main.rego:25     | | | Index data.main.num_creates (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:16     | | | Enter data.main.num_creates
TRAC   fixtures/verify_with_tracing/main.rego:18     | | | | Eval data.main.resource_types[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:18     | | | | Index data.main.resource_types (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:3      | | | | Enter data.main.resource_types
TRAC   fixtures/verify_with_tracing/main.rego:3      | | | | | Eval true
TRAC   fixtures/verify_with_tracing/main.rego:3      | | | | | Exit data.main.resource_types
TRAC   fixtures/verify_with_tracing/main.rego:19     | | | | Eval all = data.main.resources[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:19     | | | | Index data.main.resources (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:6      | | | | Enter data.main.resources
TRAC   fixtures/verify_with_tracing/main.rego:8      | | | | | Eval data.main.resource_types[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:8      | | | | | Index data.main.resource_types (matched 1 rule)
TRAC   fixtures/verify_with_tracing/main.rego:9      | | | | | Eval all = [name | name = input.resource_changes[_]; name.type = resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:10     | | | | | Enter name = input.resource_changes[_]; name.type = resource_type
TRAC   fixtures/verify_with_tracing/main.rego:10     | | | | | | Eval name = input.resource_changes[_]
TRAC   fixtures/verify_with_tracing/main.rego:11     | | | | | | Eval name.type = resource_type
TRAC   fixtures/verify_with_tracing/main.rego:10     | | | | | | Exit name = input.resource_changes[_]; name.type = resource_type
TRAC   fixtures/verify_with_tracing/main.rego:10     | | | | | Redo name = input.resource_changes[_]; name.type = resource_type
TRAC   fixtures/verify_with_tracing/main.rego:11     | | | | | | Redo name.type = resource_type
TRAC   fixtures/verify_with_tracing/main.rego:10     | | | | | | Redo name = input.resource_changes[_]
TRAC   fixtures/verify_with_tracing/main.rego:6      | | | | | Exit data.main.resources
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | Eval creates = [res | res = all[_]; res.change.actions[_] = "create"]
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | Enter res = all[_]; res.change.actions[_] = "create"
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | | Eval res = all[_]
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | | Eval res.change.actions[_] = "create"
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | | Exit res = all[_]; res.change.actions[_] = "create"
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | Redo res = all[_]; res.change.actions[_] = "create"
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | | Redo res.change.actions[_] = "create"
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | | Redo res = all[_]
TRAC   fixtures/verify_with_tracing/main.rego:21     | | | | Eval count(creates, __local10__)
TRAC   fixtures/verify_with_tracing/main.rego:21     | | | | Eval num = __local10__
TRAC   fixtures/verify_with_tracing/main.rego:16     | | | | Exit data.main.num_creates
TRAC   fixtures/verify_with_tracing/main.rego:26     | | | Eval trace("Print statement")
TRAC   fixtures/verify_with_tracing/main.rego:26     | | | Note "Print statement"
TRAC   fixtures/verify_with_tracing/main.rego:27     | | | Eval gt(num_resources, 0)
TRAC   fixtures/verify_with_tracing/main.rego:29     | | | Eval msg = "null resources cannot be created"
TRAC   fixtures/verify_with_tracing/main.rego:24     | | | Exit data.main.deny
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Eval count(__local12__, __local11__) with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Eval __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Fail __local11__ = 0 with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Redo count(__local12__, __local11__) with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:33     | | Redo __local12__ = data.main.deny[msg] with input as {"resource_changes": [{"change": {"actions": ["create"]}, "type": "null_resource"}]}
TRAC   fixtures/verify_with_tracing/main.rego:24     | | Redo data.main.deny
TRAC   fixtures/verify_with_tracing/main.rego:29     | | | Redo msg = "null resources cannot be created"
TRAC   fixtures/verify_with_tracing/main.rego:27     | | | Redo gt(num_resources, 0)
TRAC   fixtures/verify_with_tracing/main.rego:26     | | | Redo trace("Print statement")
TRAC   fixtures/verify_with_tracing/main.rego:25     | | | Redo num_resources = data.main.num_creates.null_resource
TRAC   fixtures/verify_with_tracing/main.rego:16     | | | Redo data.main.num_creates
TRAC   fixtures/verify_with_tracing/main.rego:21     | | | | Redo num = __local10__
TRAC   fixtures/verify_with_tracing/main.rego:21     | | | | Redo count(creates, __local10__)
TRAC   fixtures/verify_with_tracing/main.rego:20     | | | | Redo creates = [res | res = all[_]; res.change.actions[_] = "create"]
TRAC   fixtures/verify_with_tracing/main.rego:19     | | | | Redo all = data.main.resources[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:6      | | | | Redo data.main.resources
TRAC   fixtures/verify_with_tracing/main.rego:9      | | | | | Redo all = [name | name = input.resource_changes[_]; name.type = resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:8      | | | | | Redo data.main.resource_types[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:18     | | | | Redo data.main.resource_types[resource_type]
TRAC   fixtures/verify_with_tracing/main.rego:3      | | | | Redo data.main.resource_types
TRAC   fixtures/verify_with_tracing/main.rego:3      | | | | | Redo true
```