### PR TITLE
Show usage when required parameters are not supplied

### DIFF
--- a/internal/commands/plugin_install.go
+++ b/internal/commands/plugin_install.go
@@ -40,9 +40,12 @@ func NewPluginInstallCommand(ctx context.Context) *cobra.Command {
 		Use:   "install <path|url>",
 		Short: "Install a plugin from the given path or url",
 		Long:  installDesc,
-		Args:  cobra.MinimumNArgs(1),
-
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				cmd.Usage() //nolint
+				return fmt.Errorf("missing required arguments")
+			}
+
 			if err := plugin.Install(ctx, args[0]); err != nil {
 				return fmt.Errorf("install: %v", err)
 			}

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -51,8 +51,6 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 		Use:   "pull <repository>",
 		Short: "Download individual policies",
 		Long:  pullDesc,
-		Args:  cobra.MinimumNArgs(1),
-
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlag("policy", cmd.Flags().Lookup("policy")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
@@ -61,6 +59,11 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				cmd.Usage() //nolint
+				return fmt.Errorf("missing required arguments")
+			}
+
 			ctx = orascontext.Background()
 
 			policyDir := filepath.Join(".", viper.GetString("policy"))

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -57,7 +57,6 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 		Use:   "push <repository>",
 		Short: "Push OPA bundles to an OCI registry",
 		Long:  pushDesc,
-		Args:  cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if err := viper.BindPFlag("policy", cmd.Flags().Lookup("policy")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
@@ -67,6 +66,11 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				cmd.Usage() //nolint
+				return fmt.Errorf("missing required arguments")
+			}
+
 			ctx = orascontext.Background()
 
 			repository := args[0]

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -82,7 +82,6 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Use:   "test <path> [path [...]]",
 		Short: "Test your configuration files using Open Policy Agent",
 		Long:  testDesc,
-		Args:  cobra.MinimumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "namespace", "no-color", "no-fail", "suppress-exceptions", "output", "parser", "policy", "trace", "update"}
 			for _, name := range flagNames {
@@ -95,6 +94,11 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		},
 
 		RunE: func(cmd *cobra.Command, fileList []string) error {
+			if len(fileList) < 1 {
+				cmd.Usage() //nolint
+				return fmt.Errorf("missing required arguments")
+			}
+
 			var runner runner.TestRunner
 			if err := viper.Unmarshal(&runner); err != nil {
 				return fmt.Errorf("unmarshal parameters: %w", err)


### PR DESCRIPTION
This is more helpful to users than stating the required number of arguments was insufficient

Signed-off-by: James Alseth <james@jalseth.me>

---

Fixes #565