### PR TITLE
Add support for properties files.

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -168,6 +168,11 @@
   [[ "$output" =~ "ALB \`my-alb-listener\` is using HTTP rather than HTTP" ]]
 }
 
+@test "Can parse properties files" {
+  run ./conftest test -p examples/properties/policy/ examples/properties/sample.properties
+  [ "$status" -eq 0 ]
+}
+
 @test "Can parse stdin with parser flag" {
   run bash -c "cat examples/ini/grafana.ini | ./conftest test -p examples/ini/policy --parser ini -"
   [ "$status" -eq 1 ]

--- a/examples/properties/policy/test.rego
+++ b/examples/properties/policy/test.rego
@@ -1,0 +1,19 @@
+package main
+
+deny_valid_uri[msg] {
+  value := input[name]
+  contains(lower(name), "url")
+  not contains(lower(value), "http")
+  msg := sprintf("Must have a valid uri defined '%s'", [value])
+}
+
+secret_exceptions = {
+ "secret.value.exception"
+}
+
+deny_no_secrets[msg] {
+  value := input[name]
+  not secret_exceptions[name]
+  contains(lower(name), "secret")
+  msg := sprintf("'%s' may contain a secret value", [name])
+}

--- a/examples/properties/sample.properties
+++ b/examples/properties/sample.properties
@@ -1,0 +1,3 @@
+SAMPLE_VALUE=something-here
+other.value.url=https://example.com/
+secret.value.exception=f9761ebe-d4dc-11eb-8046-1e00e20cdb95

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/moby/buildkit v0.8.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v0.29.4

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/ini"
 	"github.com/open-policy-agent/conftest/parser/json"
 	"github.com/open-policy-agent/conftest/parser/jsonnet"
+	"github.com/open-policy-agent/conftest/parser/properties"
 	"github.com/open-policy-agent/conftest/parser/toml"
 	"github.com/open-policy-agent/conftest/parser/vcl"
 	"github.com/open-policy-agent/conftest/parser/xml"
@@ -28,20 +29,21 @@ import (
 // The defined parsers are the parsers that are valid for
 // parsing files.
 const (
-	TOML       = "toml"
+	CUE        = "cue"
+	Dockerfile = "dockerfile"
+	EDN        = "edn"
 	HCL1       = "hcl1"
 	HCL2       = "hcl2"
-	CUE        = "cue"
-	INI        = "ini"
 	HOCON      = "hocon"
-	Dockerfile = "dockerfile"
-	YAML       = "yaml"
+	IGNORE     = "ignore"
+	INI        = "ini"
 	JSON       = "json"
 	JSONNET    = "jsonnet"
-	EDN        = "edn"
+	PROPERTIES = "properties"
+	TOML       = "toml"
 	VCL        = "vcl"
 	XML        = "xml"
-	IGNORE     = "ignore"
+	YAML       = "yaml"
 )
 
 // Parser defines all of the methods that every parser
@@ -81,6 +83,8 @@ func New(parser string) (Parser, error) {
 		return &xml.Parser{}, nil
 	case IGNORE:
 		return &ignore.Parser{}, nil
+	case PROPERTIES:
+		return &properties.Parser{}, nil
 	default:
 		return nil, fmt.Errorf("unknown parser: %v", parser)
 	}
@@ -134,20 +138,21 @@ func NewFromPath(path string) (Parser, error) {
 // Parsers returns a list of the supported Parsers.
 func Parsers() []string {
 	parsers := []string{
-		TOML,
+		CUE,
+		Dockerfile,
+		EDN,
 		HCL1,
 		HCL2,
-		CUE,
-		INI,
 		HOCON,
-		Dockerfile,
-		YAML,
+		IGNORE,
+		INI,
 		JSON,
 		JSONNET,
-		EDN,
+		PROPERTIES,
+		TOML,
 		VCL,
 		XML,
-		IGNORE,
+		YAML,
 	}
 
 	return parsers

--- a/parser/properties/properties.go
+++ b/parser/properties/properties.go
@@ -3,6 +3,7 @@ package properties
 import (
 	"encoding/json"
 	"fmt"
+
 	prop "github.com/magiconair/properties"
 )
 

--- a/parser/properties/properties.go
+++ b/parser/properties/properties.go
@@ -1,9 +1,8 @@
 package properties
 
 import (
-	"fmt"
-
 	"encoding/json"
+	"fmt"
 	prop "github.com/magiconair/properties"
 )
 
@@ -11,9 +10,12 @@ import (
 type Parser struct{}
 
 func (pp *Parser) Unmarshal(p []byte, v interface{}) error {
-	raw_props := prop.MustLoadString(string(p))
+	rawProps, err := prop.LoadString(string(p))
+	if err != nil {
+		return fmt.Errorf("Could not parse properties file: %w", err)
+	}
 
-	result := raw_props.Map()
+	result := rawProps.Map()
 
 	j, err := json.Marshal(result)
 	if err != nil {

--- a/parser/properties/properties.go
+++ b/parser/properties/properties.go
@@ -1,0 +1,28 @@
+package properties
+
+import (
+	"fmt"
+
+	"encoding/json"
+	prop "github.com/magiconair/properties"
+)
+
+// Parser is a properties parser.
+type Parser struct{}
+
+func (pp *Parser) Unmarshal(p []byte, v interface{}) error {
+	raw_props := prop.MustLoadString(string(p))
+
+	result := raw_props.Map()
+
+	j, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshal properties to json: %w", err)
+	}
+
+	if err := json.Unmarshal(j, v); err != nil {
+		return fmt.Errorf("unmarshal properties json: %w", err)
+	}
+
+	return nil
+}

--- a/parser/properties/properties_test.go
+++ b/parser/properties/properties_test.go
@@ -8,7 +8,7 @@ func TestPropertiesParser(t *testing.T) {
 	parser := &Parser{}
 	sample := `# This is a simle properties file
     SAMPLE_KEY=https://example.com/
-! some comment
+! some comment=not-a-prop
 my-property=some-value`
 
 	var input interface{}
@@ -29,5 +29,10 @@ my-property=some-value`
 	spaceProp := inputMap["SAMPLE_KEY"].(string)
 	if spaceProp != "https://example.com/" {
 		t.Fatalf("Failed to strip whitespace from key: %s", myProp)
+	}
+
+	inputLen := len(inputMap)
+	if inputLen != 2 {
+		t.Fatalf("Failed to parse all properties: expected 2 got %d", inputLen)
 	}
 }

--- a/parser/properties/properties_test.go
+++ b/parser/properties/properties_test.go
@@ -1,0 +1,33 @@
+package properties
+
+import (
+	"testing"
+)
+
+func TestPropertiesParser(t *testing.T) {
+	parser := &Parser{}
+	sample := `# This is a simle properties file
+    SAMPLE_KEY=https://example.com/
+! some comment
+my-property=some-value`
+
+	var input interface{}
+	if err := parser.Unmarshal([]byte(sample), &input); err != nil {
+		t.Fatalf("parser should not have thrown an error: %v", err)
+	}
+
+	if input == nil {
+		t.Fatalf("there should be information parsed but its nil")
+	}
+
+	inputMap := input.(map[string]interface{})
+	myProp := inputMap["my-property"].(string)
+	if myProp != "some-value" {
+		t.Fatalf("Failed to parse property: %s", myProp)
+	}
+
+	spaceProp := inputMap["SAMPLE_KEY"].(string)
+	if spaceProp != "https://example.com/" {
+		t.Fatalf("Failed to strip whitespace from key: %s", myProp)
+	}
+}

--- a/parser/properties/properties_test.go
+++ b/parser/properties/properties_test.go
@@ -13,26 +13,26 @@ my-property=some-value`
 
 	var input interface{}
 	if err := parser.Unmarshal([]byte(sample), &input); err != nil {
-		t.Fatalf("parser should not have thrown an error: %v", err)
+		t.Errorf("parser should not have thrown an error: %v", err)
 	}
 
 	if input == nil {
-		t.Fatalf("there should be information parsed but its nil")
+		t.Errorf("there should be information parsed but its nil")
 	}
 
 	inputMap := input.(map[string]interface{})
 	myProp := inputMap["my-property"].(string)
 	if myProp != "some-value" {
-		t.Fatalf("Failed to parse property: %s", myProp)
+		t.Errorf("Failed to parse property: %s", myProp)
 	}
 
 	spaceProp := inputMap["SAMPLE_KEY"].(string)
 	if spaceProp != "https://example.com/" {
-		t.Fatalf("Failed to strip whitespace from key: %s", myProp)
+		t.Errorf("Failed to strip whitespace from key: %s", myProp)
 	}
 
 	inputLen := len(inputMap)
 	if inputLen != 2 {
-		t.Fatalf("Failed to parse all properties: expected 2 got %d", inputLen)
+		t.Errorf("Failed to parse all properties: expected 2 got %d", inputLen)
 	}
 }


### PR DESCRIPTION
This Change adds support for the *.properties files normally found in
Java projects. It also adds a test-case & a sample properties file with
some rego policies to show how to consume it.

Changes
- Sort the plugin arrays
- Add support for properties files

Signed-off-by: Hamish Hutchings <hamish@drybrough.nl>