### PR TITLE
Add output format for GitHub.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -161,6 +161,7 @@ As of today Conftest supports the following output types:
 - [TAP](https://testanything.org/): `--output=tap`
 - Table `--output=table`
 - JUnit `--output=junit`
+- GitHub `--output=github`
 
 ### Plaintext
 
@@ -256,6 +257,43 @@ $ conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml -
                 </testcase>
                 <testcase classname="conftest" name="examples/kubernetes/deployment.yaml - " time="0.000"></testcase>
         </testsu
+```
+
+### GitHub
+
+```console
+$ conftest test -o github -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
+::group::Testing 'examples/kubernetes/deployment.yaml' against 5 policies in namespace 'main'
+::error file=examples/kubernetes/deployment.yaml::Containers must not run as root in Deployment hello-kubernetes
+::error file=examples/kubernetes/deployment.yaml::Deployment hello-kubernetes must provide app/release labels for pod selectors
+::error file=examples/kubernetes/deployment.yaml::hello-kubernetes must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
+::error file=examples/kubernetes/deployment.yaml::Found deployment hello-kubernetes but deployments are not allowed
+success file=examples/kubernetes/deployment.yaml 1
+::endgroup::
+5 tests, 1 passed, 0 warnings, 4 failures, 0 exceptions
+```
+
+Use Conftest directly to check incoming Pull Requests in GitHub:
+
+```yaml
+---
+name: Conftest
+
+on:
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  conftest:
+    runs-on: ubuntu-latest
+    container: openpolicyagent/conftest:latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+      - name: Validate Kubernetes policy
+        run: |
+          conftest test -o github -p examples/kubernetes/policy examples/kubernetes/deployment.yaml
 ```
 
 ## `--parser`

--- a/output/github.go
+++ b/output/github.go
@@ -1,0 +1,101 @@
+package output
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/open-policy-agent/opa/tester"
+)
+
+// GitHub represents an Outputter that outputs
+// results in GitHub workflow format.
+// https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+type GitHub struct {
+	writer io.Writer
+}
+
+// NewGitHub creates a new GitHub with the given writer.
+func NewGitHub(w io.Writer) *GitHub {
+	github := GitHub{
+		writer: w,
+	}
+
+	return &github
+}
+
+// Output outputs the results.
+func (t *GitHub) Output(checkResults []CheckResult) error {
+	var totalFailures int
+	var totalExceptions int
+	var totalWarnings int
+	var totalSuccesses int
+	var totalSkipped int
+	for _, result := range checkResults {
+		totalPolicies := result.Successes + len(result.Failures) + len(result.Warnings) + len(result.Exceptions) + len(result.Skipped)
+
+		fmt.Fprintf(t.writer, "::group::Testing '%v' against %v policies in namespace '%v'\n", result.FileName, totalPolicies, result.Namespace)
+		for _, failure := range result.Failures {
+			fmt.Fprintf(t.writer, "::error file=%v::%v\n", result.FileName, failure.Message)
+		}
+
+		for _, warning := range result.Warnings {
+			fmt.Fprintf(t.writer, "::warning file=%v::%v\n", result.FileName, warning.Message)
+		}
+
+		for _, exception := range result.Exceptions {
+			fmt.Fprintf(t.writer, "exception file=%v %v\n", result.FileName, exception.Message)
+		}
+
+		for _, skipped := range result.Skipped {
+			fmt.Fprintf(t.writer, "skipped file=%v %v\n", result.FileName, skipped.Message)
+		}
+
+		if result.Successes > 0 {
+			fmt.Fprintf(t.writer, "success file=%v %v\n", result.FileName, result.Successes)
+		}
+
+		totalFailures += len(result.Failures)
+		totalExceptions += len(result.Exceptions)
+		totalWarnings += len(result.Warnings)
+		totalSkipped += len(result.Skipped)
+		totalSuccesses += result.Successes
+		fmt.Fprintf(t.writer, "::endgroup::\n")
+	}
+
+	totalTests := totalFailures + totalExceptions + totalWarnings + totalSuccesses + totalSkipped
+
+	var pluralSuffixTests string
+	if totalTests != 1 {
+		pluralSuffixTests = "s"
+	}
+
+	var pluralSuffixWarnings string
+	if totalWarnings != 1 {
+		pluralSuffixWarnings = "s"
+	}
+
+	var pluralSuffixFailures string
+	if totalFailures != 1 {
+		pluralSuffixFailures = "s"
+	}
+
+	var pluralSuffixExceptions string
+	if totalExceptions != 1 {
+		pluralSuffixExceptions = "s"
+	}
+
+	outputText := fmt.Sprintf("%v test%s, %v passed, %v warning%s, %v failure%s, %v exception%s",
+		totalTests, pluralSuffixTests,
+		totalSuccesses,
+		totalWarnings, pluralSuffixWarnings,
+		totalFailures, pluralSuffixFailures,
+		totalExceptions, pluralSuffixExceptions,
+	)
+	fmt.Fprintln(t.writer, outputText)
+
+	return nil
+}
+
+func (t *GitHub) Report(results []*tester.Result, flag string) error {
+	return fmt.Errorf("report is not supported in GitHub output")
+}

--- a/output/github_test.go
+++ b/output/github_test.go
@@ -1,0 +1,103 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestGitHub(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []CheckResult
+		expected []string
+	}{
+		{
+			name: "no warnings or errors",
+			input: []CheckResult{
+				{
+					FileName:  "examples/kubernetes/service.yaml",
+					Namespace: "namespace",
+				},
+			},
+			expected: []string{
+				"::group::Testing 'examples/kubernetes/service.yaml' against 0 policies in namespace 'namespace'",
+				"::endgroup::",
+				"0 tests, 0 passed, 0 warnings, 0 failures, 0 exceptions",
+				"",
+			},
+		},
+		{
+			name: "records failure and warnings",
+			input: []CheckResult{
+				{
+					FileName:  "examples/kubernetes/service.yaml",
+					Namespace: "namespace",
+					Warnings:  []Result{{Message: "first warning"}},
+					Failures:  []Result{{Message: "first failure"}},
+				},
+			},
+			expected: []string{
+				"::group::Testing 'examples/kubernetes/service.yaml' against 2 policies in namespace 'namespace'",
+				"::error file=examples/kubernetes/service.yaml::first failure",
+				"::warning file=examples/kubernetes/service.yaml::first warning",
+				"::endgroup::",
+				"2 tests, 0 passed, 1 warning, 1 failure, 0 exceptions",
+				"",
+			},
+		},
+		{
+			name: "mixed failure, warnings and skipped",
+			input: []CheckResult{
+				{
+					FileName:  "examples/kubernetes/service.yaml",
+					Namespace: "namespace",
+					Failures:  []Result{{Message: "first failure"}},
+					Skipped:   []Result{{Message: "first skipped"}},
+				},
+			},
+			expected: []string{
+				"::group::Testing 'examples/kubernetes/service.yaml' against 2 policies in namespace 'namespace'",
+				"::error file=examples/kubernetes/service.yaml::first failure",
+				"skipped file=examples/kubernetes/service.yaml first skipped",
+				"::endgroup::",
+				"2 tests, 0 passed, 0 warnings, 1 failure, 0 exceptions",
+				"",
+			},
+		},
+		{
+			name: "handles stdin input",
+			input: []CheckResult{
+				{
+					FileName:  "-",
+					Namespace: "namespace",
+					Failures:  []Result{{Message: "first failure"}},
+				},
+			},
+			expected: []string{
+				"::group::Testing '-' against 1 policies in namespace 'namespace'",
+				"::error file=-::first failure",
+				"::endgroup::",
+				"1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions",
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expected := strings.Join(tt.expected, "\n")
+
+			buf := new(bytes.Buffer)
+			if err := NewGitHub(buf).Output(tt.input); err != nil {
+				t.Fatal("output GitHub:", err)
+			}
+
+			actual := buf.String()
+
+			if expected != actual {
+				t.Errorf("unexpected output. expected %v actual %v", expected, actual)
+			}
+		})
+	}
+}

--- a/output/output.go
+++ b/output/output.go
@@ -30,6 +30,7 @@ const (
 	OutputTAP      = "tap"
 	OutputTable    = "table"
 	OutputJUnit    = "junit"
+	OutputGitHub   = "github"
 )
 
 // Get returns a type that can render output in the given format.
@@ -45,6 +46,8 @@ func Get(format string, options Options) Outputter {
 		return NewTable(os.Stdout)
 	case OutputJUnit:
 		return NewJUnit(os.Stdout)
+	case OutputGitHub:
+		return NewGitHub(os.Stdout)
 	default:
 		return NewStandard(os.Stdout)
 	}
@@ -58,5 +61,6 @@ func Outputs() []string {
 		OutputTAP,
 		OutputTable,
 		OutputJUnit,
+		OutputGitHub,
 	}
 }


### PR DESCRIPTION
GitHub output includes the specialized [workflow commands](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions) that will automatically be parsed by GitHub during a Pull Request and annotate the policy-violating file.

Example (using **koozz/conftest:v0.26.0-alpha** instead of **openpolicyagent/conftest** to be able to test this unmerged/unreleased code):

```yaml
---
name: Validate

on:
  pull_request:
    branches: 
      - main
    paths:
      - '**.yml'
      - '**.yaml'

jobs:
  validate:
    name: 'Rego'
    runs-on: ubuntu-latest
    container: koozz/conftest:v0.26.0-alpha
    steps:
      - name: Check out the code
        uses: actions/checkout@v2
      - name: Validate workflows
        run: |
          conftest test -o github .github/workflows/*.yml -p policy -n workflows
```

policy/workflows.rego:

```rego
package workflows

deny[msg] {
	not input.name
	msg = sprintf("Missing 'name' on: %s", [input])
}
```

The deny message can of course be as succinct and/or as pretty as you want, it will be outputted in the console and annotated on the file where the violation was.

GitHub action output:

```text
Run conftest test -o github .github/workflows/*.yml -p policy -n workflows
  conftest test -o github .github/workflows/*.yml -p policy -n workflows
  shell: sh -e {0}
Testing '.github/workflows/validate.yml' against 1 policies in namespace 'workflows'
  success file=.github/workflows/validate.yml 1
Testing '.github/workflows/yamllint.yml' against 1 policies in namespace 'workflows'
  Error: Missing 'name' on: {"jobs": {"linter": {"runs-on": "ubuntu-latest", "steps": [{"name": "Check out code", "uses": "actions/checkout@v2"}, {"name": "Run yamllint", "uses": "actionshub/yamllint@v1.0.0"}]}}, "true": {"push": {"branches-ignore": ["main"], "paths": ["**.yml", "**.yaml"]}}}
2 tests, 1 passed, 0 warnings, 1 failure, 0 exceptions
Error: Process completed with exit code 1.
```

Annotated file:

![image](https://user-images.githubusercontent.com/264372/123966366-a8d87c80-d9b5-11eb-83ad-763de75f93d2.png)
