### PR TITLE
fix(exception): support empty string

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -444,6 +444,9 @@ func contains(collection []string, item string) bool {
 }
 
 func removeRulePrefix(rule string) string {
+	if rule=="violation" || rule == "deny" || rule == "warn"{
+		return ""
+	}
 	rule = strings.TrimPrefix(rule, "violation_")
 	rule = strings.TrimPrefix(rule, "deny_")
 	rule = strings.TrimPrefix(rule, "warn_")


### PR DESCRIPTION
The document mentions as below.

>Note that if you specify the empty string, the exception will match all rules named deny or violation. It is recommended to use identifiers in your rule names to allow for targeted exceptions.

https://www.conftest.dev/exceptions/

But it looks like an empty string from `exception` is not supported now if I'm not wrong. Please let me know if I should add a new test (and example).
