### PR TITLE
build: Specify Go 1.17 in the release workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.17.1"
 
       - name: setup bats
         uses: mig4/setup-bats@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,11 @@ jobs:
           VERSION: ${{ steps.get-version.outputs.VERSION }}
         run: make push TAG=$VERSION
 
+      - name: setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.1"
+
       - name: release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.0-alpine as base
+FROM golang:1.17.1-alpine as base
 ARG ARCH=amd64
 ARG VERSION
 ARG COMMIT
@@ -48,7 +48,7 @@ RUN apk add --no-cache npm make git jq ca-certificates openssl unzip wget && \
 RUN wget -O /usr/local/bin/kustomize "https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64" && \
     chmod +x /usr/local/bin/kustomize
 
-RUN go get -u cuelang.org/go/cmd/cue
+RUN go install cuelang.org/go/cmd/cue@latest
 
 WORKDIR /examples
 


### PR DESCRIPTION
This ensures that the release is built with the same version of Go that
it was tested with.

Signed-off-by: James Alseth <james@jalseth.me>