### PR TITLE
ci: Limit the permissions of the GITHUB_TOKEN in the PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,18 @@ name: pr
 
 on: [pull_request]
 
+permissions:
+  actions: read
+  checks: none
+  contents: none
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
By default, the GITHUB_TOKEN secret has relatively broad permissions and
could trigger various events such as a release to GitHub which we do not
want to allow in the pull request workflow. By limiting the permissions
of this workflow we can have more confidence that external dependencies in
the workflow cannot cause unintended side effects in the workflow.

https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token

Signed-off-by: James Alseth <james@jalseth.me>