### PR TITLE
 fix: Flags with hyphens were skipped with config from ENV 

### DIFF
--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/open-policy-agent/conftest/plugin"
 
@@ -30,6 +31,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd.SetVersionTemplate(`{{.Version}}`)
 
 	viper.SetEnvPrefix("CONFTEST")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.SetConfigName("conftest")
 	viper.AddConfigPath(".")
 	viper.AutomaticEnv()


### PR DESCRIPTION
Previously when a viper.GetX call was made for a flag with a hypen in
it, if that was set via the environment it would fail because viper's
internal store had it as a value with an underscore instead of a hyphen.
By adding this replacer the conversion happens automatically for
configuration in the environment without affecting the existing flags.

Signed-off-by: James Alseth <james@jalseth.me>

---

See https://github.com/spf13/viper#working-with-environment-variables and https://pkg.go.dev/github.com/spf13/viper#SetEnvKeyReplacer for more info.