### PR TITLE
fix: Incorrect hash in go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -516,7 +516,7 @@ github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/crfs v0.0.0-20191108021818-71d77da419c9/go.mod h1:etGhoOqfwPkooV6aqoX3eBGQOJblqdoc9XvWOeuxpPw=
-github.com/google/flatbuffers v1.12.0 h1:N8EguYFm2wwdpoNcpchQY0tPs85vOJkboFb2dPxmixo=
+github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oogeh6w=
 github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
Dependabot introduced [1] an incorrect hash in the go.sum file for the
github.com/google/flatbuffers@v1.12.0 dependency. After working with
Github support, the root cause was determined to be that the default
public Go modules proxy has a different hash than if you connect
directly, likely because at some point the tags were swapped. Dependabot
runs with GOPRIVATE=* set, so it does not use the default proxy and is
why the hash is different.

This change uses the same hash as the public Go modules proxy in order
to ensure the builds work and anyone consuming the Conftest repository
are able to build. The flatbuffers maintainers introduced a 1.12.1 which
is the same code as the 1.12.0 release to fix [2] this issue going forward,
which we will use once the dependency that introduced the 1.12.0 version
is updated.

[1] https://github.com/open-policy-agent/conftest/pull/607
[2] https://github.com/google/flatbuffers/issues/6466