### PR TITLE
DEVELOPMENT.md: bats -> bats-core

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@ Windows users can download Make from [here](http://gnuwin32.sourceforge.net/pack
 
 There are a few ways to install Bats:
 
-- Brew: `brew install bats`
+- Brew: `brew install bats-core`
 - npm: `npm install -g bats`
 
 ## Building and Testing


### PR DESCRIPTION
The brew page states that 'bats' is deprecated, because the repo was
archived. It looks like everything's moved to bats-core.

https://formulae.brew.sh/formula/bats
https://formulae.brew.sh/formula/bats-core
