### PR TITLE
engine+reporter: enable `print()` output

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -78,7 +78,7 @@
 }
 
 @test "Verify command has trace flag" {
-    run ./conftest verify --policy ./examples/kubernetes/policy --trace
+  run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
 }
@@ -92,8 +92,17 @@
     run ./conftest verify --policy ./examples/report/policy --policy ./examples/report/success --report fails
     [ "$status" -eq 0 ]
     [[ "${lines[0]}" =~ "data.main.test_no_missing_label: PASS" ]]
-    [[ "${lines[1]}" =~ "--------------------------------------------------------------------------------" ]]
-    [[ "${lines[2]}" =~ "PASS: 1/1" ]]
+    [[ "${lines[1]}" == "--------------------------------------------------------------------------------" ]]
+    [[ "${lines[2]}" == "PASS: 1/1" ]]
+}
+
+@test "Verify command has report flag - success with print output" {
+    run ./conftest verify --policy ./examples/report/policy_print --policy ./examples/report/success --report fails
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" =~ "data.main.test_no_missing_label: PASS" ]]
+    [[ "${lines[2]}" == "--------------------------------------------------------------------------------" ]]
+    [[ "${lines[3]}" == "PASS: 1/1" ]]
+    [[ "${lines[1]}" == '  sample' ]]
 }
 
 @test "Verify command does not support report flag with table output" {
@@ -157,6 +166,12 @@
   run ./conftest test -p examples/hcl1/policy/base.rego examples/hcl1/gke-show.json
   [ "$status" -eq 1 ]
   [[ "$output" =~ "Terraform plan will change prohibited resources in the following namespaces: google_iam, google_container" ]]
+}
+
+@test "Supports print() output" {
+  run ./conftest test -p examples/report/policy_print/labels.rego examples/kubernetes/deployment.yaml --no-color
+  [ "$status" -eq 1 ]
+  [[ "${lines[0]}" == "PRNT   examples/report/policy_print/labels.rego:12: hello-kubernetes" ]]
 }
 
 @test "Can parse hcl1 files" {

--- a/examples/report/policy_print/labels.rego
+++ b/examples/report/policy_print/labels.rego
@@ -9,7 +9,7 @@ required_deployment_labels {
 
 deny[msg] {
 	input.kind = "Deployment"
+	print(name)
 	not required_deployment_labels
-	trace("just testing notes flag")
 	msg := sprintf("%s must include Kubernetes recommended labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels", [name])
 }

--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -50,7 +50,12 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, []*tester
 		engine.EnableTracing()
 	}
 
-	runner := tester.NewRunner().SetCompiler(engine.Compiler()).SetStore(engine.Store()).SetModules(engine.Modules()).EnableTracing(enableTracing).SetRuntime(engine.Runtime())
+	runner := tester.NewRunner().
+		SetCompiler(engine.Compiler()).
+		SetStore(engine.Store()).
+		SetModules(engine.Modules()).
+		EnableTracing(enableTracing).
+		SetRuntime(engine.Runtime())
 	ch, err := runner.RunTests(ctx, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("running tests: %w", err)

--- a/output/result.go
+++ b/output/result.go
@@ -6,6 +6,7 @@ import "fmt"
 type Result struct {
 	Message  string                 `json:"msg"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Outputs  []string               `json:"outputs,omitempty"`
 }
 
 // NewResult creates a new result. An error is returned if the
@@ -52,6 +53,10 @@ type QueryResult struct {
 	// Traces represents a single trace of how the query was
 	// evaluated. Each trace value is a trace line.
 	Traces []string `json:"traces"`
+
+	// Output represents anything print()'ed during the query
+	// evaluation. Each value is a print() call's result.
+	Outputs []string `json:"outputs,omitempty"`
 }
 
 // Passed returns true if all of the results in the query

--- a/output/standard.go
+++ b/output/standard.go
@@ -53,6 +53,8 @@ func (s *Standard) Output(results []CheckResult) error {
 		return nil
 	}
 
+	s.outputPrints(results, colorizer)
+
 	var totalFailures int
 	var totalExceptions int
 	var totalWarnings int
@@ -150,6 +152,16 @@ func (s *Standard) Output(results []CheckResult) error {
 	return nil
 }
 
+func (s *Standard) outputPrints(results []CheckResult, colorizer aurora.Aurora) {
+	for _, result := range results {
+		for _, query := range result.Queries {
+			for _, t := range query.Outputs {
+				fmt.Fprintln(s.Writer, colorizer.Colorize("PRNT ", aurora.BlueFg), "", t)
+			}
+		}
+	}
+}
+
 func (s *Standard) outputTrace(results []CheckResult, colorizer aurora.Aurora) {
 	for _, result := range results {
 		for _, query := range result.Queries {
@@ -169,7 +181,7 @@ func (s *Standard) outputTrace(results []CheckResult, colorizer aurora.Aurora) {
 	}
 }
 
-// outputs results as a report - similar to OPA test output
+// Report outputs results similar to OPA test output
 func (s *Standard) Report(results []*tester.Result, flag string) error {
 	reporter := tester.PrettyReporter{
 		Verbose:     true,
@@ -192,7 +204,8 @@ func (s *Standard) Report(results []*tester.Result, flag string) error {
 	return nil
 }
 
-// Filter traces - returns only failed traces
+// filterTrace returns the traces according to flag: only "fails" or "notes", or, with
+// flag = "full", all of them
 func filterTrace(trace []*topdown.Event, flag string) []*topdown.Event {
 	if flag == "full" {
 		return trace


### PR DESCRIPTION
This depends on OPA 0.34.0: #627 

- [x] conftest verify
- [x] conftest test