### PR TITLE
chore: replace part of linter from golint to revive, fixed warning wh…

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
     - goconst
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
@@ -19,6 +18,7 @@ linters:
     - misspell
     - nilerr
     - predeclared
+    - revive
     - staticcheck
     - structcheck
     - typecheck

--- a/parser/hcl1/hcl1_test.go
+++ b/parser/hcl1/hcl1_test.go
@@ -75,7 +75,7 @@ func TestHcl1Parser(t *testing.T) {
 	}
 
 	inputMap := input.(map[string]interface{})
-	if len(inputMap["resource"].([]map[string]interface{})) <= 0 {
+	if len(inputMap["resource"].([]map[string]interface{})) == 0 {
 		t.Error("there should be resources defined in the parsed file, but none found")
 	}
 }

--- a/parser/hocon/hocon_test.go
+++ b/parser/hocon/hocon_test.go
@@ -28,7 +28,7 @@ func TestHoconUnmarshal(t *testing.T) {
 
 	inputMap := input.(map[string]interface{})
 	item := inputMap["play"]
-	if len(item.(map[string]interface{})) <= 0 {
+	if len(item.(map[string]interface{})) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/ini/ini_test.go
+++ b/parser/ini/ini_test.go
@@ -30,7 +30,7 @@ func TestIniParser(t *testing.T) {
 
 	inputMap := input.(map[string]interface{})
 	item := inputMap["Local Variables"]
-	if len(item.(map[string]interface{})) <= 0 {
+	if len(item.(map[string]interface{})) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/json/json_test.go
+++ b/parser/json/json_test.go
@@ -36,7 +36,7 @@ func TestJSONParser(t *testing.T) {
 	}
 
 	inputMap := input.(map[string]interface{})
-	if len(inputMap) < 0 {
+	if len(inputMap) <= 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/json/json_test.go
+++ b/parser/json/json_test.go
@@ -36,7 +36,7 @@ func TestJSONParser(t *testing.T) {
 	}
 
 	inputMap := input.(map[string]interface{})
-	if len(inputMap) <= 0 {
+	if len(inputMap) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/jsonnet/jsonnet_test.go
+++ b/parser/jsonnet/jsonnet_test.go
@@ -28,7 +28,7 @@ func TestJsonnetParser(t *testing.T) {
 
 	item := input.(map[string]interface{})
 
-	if len(item) <= 0 {
+	if len(item) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/toml/toml_test.go
+++ b/parser/toml/toml_test.go
@@ -24,7 +24,7 @@ func TestTomlParser(t *testing.T) {
 
 	inputMap := input.(map[string]interface{})
 	item := inputMap["entryPoints"]
-	if len(item.(map[string]interface{})) <= 0 {
+	if len(item.(map[string]interface{})) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/vcl/vcl_test.go
+++ b/parser/vcl/vcl_test.go
@@ -20,7 +20,7 @@ func TestVCLParser(t *testing.T) {
 
 	item := input.(map[string]interface{})
 
-	if len(item) <= 0 {
+	if len(item) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }

--- a/parser/xml/xml_test.go
+++ b/parser/xml/xml_test.go
@@ -24,7 +24,7 @@ func TestXMLParser(t *testing.T) {
 
 	inputMap := input.(map[string]interface{})
 	item := inputMap["note"]
-	if len(item.(map[string]interface{})) <= 0 {
+	if len(item.(map[string]interface{})) == 0 {
 		t.Error("there should be at least one item defined in the parsed file, but none found")
 	}
 }


### PR DESCRIPTION
When I did a make lint on this repository, I got the following warnings.

<img width="773" alt="スクリーンショット 2021-11-14 14 52 28" src="https://user-images.githubusercontent.com/50270988/141669926-b98297b0-417f-4a77-89e7-2170f8f46041.png">


One is a note in golfingci-lint that golint is deperecated and revive is recommended
The other is a warning about the test code by staticcheck, one of the linters.

Therefore, I fixed it.

reference https://github.com/golangci/golangci-lint/issues/1892

Signed-off-by: ishishow <ishikawa.sho.infratop@gmail.com>