### PR TITLE
Support for terragrunt default config files

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -119,7 +119,7 @@ func NewFromPath(path string) (Parser, error) {
 		return New(YAML)
 	}
 
-	if fileExtension == "tf" || fileExtension == "tfvars" {
+	if fileExtension == "hcl" || fileExtension == "tf" || fileExtension == "tfvars" {
 		return New(HCL2)
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/docker"
 	"github.com/open-policy-agent/conftest/parser/hcl2"
 	"github.com/open-policy-agent/conftest/parser/ignore"
+	"github.com/open-policy-agent/conftest/parser/json"
 	"github.com/open-policy-agent/conftest/parser/yaml"
 )
 
@@ -69,6 +70,16 @@ func TestNewFromPath(t *testing.T) {
 		{
 			"test.tfvars",
 			&hcl2.Parser{},
+			false,
+		},
+		{
+			"terragrunt.hcl",
+			&hcl2.Parser{},
+			false,
+		},
+		{
+			"terragrunt.hcl.json",
+			&json.Parser{},
 			false,
 		},
 		{


### PR DESCRIPTION
As stated in the following url,

https://terragrunt.gruntwork.io/docs/getting-started/configuration/

There are two known default filenames which terragrunt will look for
when running; terragrunt.hcl and terragrunt.hcl.json.

The latter of these files is presently handled by conftest. The former,
is incorrectly detected due to the hcl file extension. Terragrunt uses
HCL2 as of v0.19 when it moved to the terragrunt.hcl file format (and
away from the terraform.tfvars which it used to use).

[upgrading-to-terragrunt-0.19](https://github.com/gruntwork-io/terragrunt/blob/master/docs/_docs/06_migration_guides/upgrading_to_terragrunt_0.19.x.md)

This patch adds specific detection of the known terragrunt configuration
files and sets their type to HCL2

Signed-off-by: Tim Rupp <caphrim007@gmail.com>