### PR TITLE
Add file path information in returned error message

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -237,6 +237,9 @@ func CombineConfigurations(configs map[string]interface{}) map[string]interface{
 
 func parseConfigurations(paths []string, parser string) (map[string]interface{}, error) {
 	parsedConfigurations := make(map[string]interface{})
+	errWithPathInfo := func(err error, msg, path string) error {
+		return fmt.Errorf("%s: %w, path: %s", msg, err, path)
+	}
 	for _, path := range paths {
 		var fileParser Parser
 		var err error
@@ -246,17 +249,17 @@ func parseConfigurations(paths []string, parser string) (map[string]interface{},
 			fileParser, err = New(parser)
 		}
 		if err != nil {
-			return nil, fmt.Errorf("new parser: %w", err)
+			return nil, errWithPathInfo(err, "new parser", path)
 		}
 
 		contents, err := getConfigurationContent(path)
 		if err != nil {
-			return nil, fmt.Errorf("get configuration content: %w", err)
+			return nil, errWithPathInfo(err, "get configuration content", path)
 		}
 
 		var parsed interface{}
 		if err := fileParser.Unmarshal(contents, &parsed); err != nil {
-			return nil, fmt.Errorf("parser unmarshal: %w", err)
+			return nil, errWithPathInfo(err, "parser unmarshal", path)
 		}
 
 		parsedConfigurations[path] = parsed


### PR DESCRIPTION
When passing a large list of files (>30) that need to be parsed using `ParseConfigurations` and if there was an error in one of them such as not a valid yaml file then it's hard to find which file is causing it. turns out I need to create a script for validating it. so then this PR will include the information of the file path that i think it's an useful information.

sample of returned error with this PR.
```
unmarshal yaml: error converting YAML to JSON: yaml: line 6: mapping values are not allowed in this context, path: /tmp/debug-lego/validations/lego/canary/manifest/web/ingress.yml
```