### PR TITLE
feat: add quiet flag to verify

### DIFF
--- a/internal/runner/verify.go
+++ b/internal/runner/verify.go
@@ -21,6 +21,7 @@ type VerifyRunner struct {
 	NoColor bool `mapstructure:"no-color"`
 	Trace   bool
 	Report  string
+	Quiet   bool
 }
 
 const (


### PR DESCRIPTION
When running in a batch mode, successful runs can clutter the output
this allows us to run in a quiet mode where we only output failures

Signed-off-by: Soren Mathiasen <smo@tradeshift.com>