### PR TITLE
Always use ORAS context when interacting with registry

### DIFF
--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -64,11 +64,9 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("missing required arguments")
 			}
 
-			ctx = orascontext.Background()
-
 			policyDir := filepath.Join(".", viper.GetString("policy"))
 
-			if err := downloader.Download(ctx, policyDir, args); err != nil {
+			if err := downloader.Download(orascontext.Background(), policyDir, args); err != nil {
 				return fmt.Errorf("download policies: %w", err)
 			}
 

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -71,8 +71,6 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 				return fmt.Errorf("missing required arguments")
 			}
 
-			ctx = orascontext.Background()
-
 			repository := args[0]
 			if !strings.Contains(repository, "/") {
 				return errors.New("destination url missing repository")
@@ -93,7 +91,7 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 			}
 
 			logger.Printf("pushing bundle to: %s", repository)
-			manifest, err := pushBundle(ctx, repository, viper.GetString("policy"))
+			manifest, err := pushBundle(orascontext.Background(), repository, viper.GetString("policy"))
 			if err != nil {
 				return fmt.Errorf("push bundle: %w", err)
 			}

--- a/internal/runner/test.go
+++ b/internal/runner/test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/parser"
 	"github.com/open-policy-agent/conftest/policy"
+	orascontext "oras.land/oras-go/pkg/context"
 )
 
 // TestRunner is the runner for the Test command, executing
@@ -53,7 +54,7 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 	// When there are policies to download, they are currently placed in the first
 	// directory that appears in the list of policies.
 	if len(t.Update) > 0 {
-		if err := downloader.Download(ctx, t.Policy[0], t.Update); err != nil {
+		if err := downloader.Download(orascontext.Background(), t.Policy[0], t.Update); err != nil {
 			return nil, fmt.Errorf("update policies: %w", err)
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/open-policy-agent/conftest/issues/597

Some history can be found in the linked issues/PRs in the issue itself, but this effectively makes things consistent such that we always use the `orascontext` when talking to an OCI registry.

There is now a `v1.0.0` of `oras-go` which makes this a little better, but their docs don't seem to be up to date. For example, `oras.Push` has been removed from `v1.0.0` but their docs still say to use `oras.Push` -- so this felt like the simplest approach to resolve the issue until we integrate ORAS `v1` into Conftest.