### PR TITLE
Bump Go to 1.17.6 in pull_request and release workflows

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.6"
 
       - name: setup bats
         uses: mig4/setup-bats@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.17.2"
+          go-version: "1.17.6"
 
       - name: release
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
Dependabot bumped the version in the Dockerfile, but did not update the
GitHub Actions workflows.