### PR TITLE
docs: Update link to point to new default branch

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 # Security
 
-See [https://github.com/open-policy-agent/opa/blob/master/SECURITY.md](https://github.com/open-policy-agent/opa/blob/master/SECURITY.md)
+See [https://github.com/open-policy-agent/opa/blob/main/SECURITY.md](https://github.com/open-policy-agent/opa/blob/main/SECURITY.md)


### PR DESCRIPTION
This updates links to open-policy-agent/opa/SECURITY.md to point to the main tree since that is the new default branch in that repo. It is not strictly necessary since GH is redirecting the old links appropriately.