### PR TITLE
Add OPA version to --version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ IMAGE := openpolicyagent/conftest
 
 DOCKER := DOCKER_BUILDKIT=1 docker
 
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+
 ## All of the directories that contain tests to be executed
 ## e.g. echo $(TEST_DIRS) prints tests/foo tests/bar
 TEST_DIRS := $(patsubst tests/%/, tests/%, $(dir $(wildcard tests/**/.)))
@@ -23,7 +25,7 @@ TEST_DIRS := $(patsubst tests/%/, tests/%, $(dir $(wildcard tests/**/.)))
 
 .PHONY: build
 build: ## Builds Conftest.
-	@go build
+	@go build -ldflags="-X github.com/open-policy-agent/conftest/internal/commands.version=${GIT_VERSION}"
 
 .PHONY: test
 test: ## Tests Conftest.

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	opaversion "github.com/open-policy-agent/opa/version"
 )
 
 // These values are set at build time
@@ -24,7 +26,7 @@ func NewDefaultCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:          "conftest <subcommand>",
 		Short:        "Test your configuration files using Open Policy Agent",
-		Version:      fmt.Sprintf("Version: %s\n", version),
+		Version:      createVersionString(),
 		SilenceUsage: true,
 	}
 
@@ -83,4 +85,8 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 	}
 
 	return &pluginCommand
+}
+
+func createVersionString() string {
+	return fmt.Sprintf("Conftest: %s\nOPA: %s\n", version, opaversion.Version)
 }


### PR DESCRIPTION
This can be useful when troubleshooting Rego policy errors for language
features that were recently introduced.

--- 

Fixes #671