### PR TITLE
Only emit valid JSON when using the parse command

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -293,6 +293,21 @@
   [[ "$output" =~ "\"Cmd\": \"from\"" ]]
 }
 
+@test "Can parse single file with 'conftest parse'" {
+  run bash -c "./conftest parse examples/kubernetes/deployment.yaml | jq '.kind'"
+  [ "$status" -eq 0 ]
+  [[ "$output" = "\"Deployment\"" ]]
+}
+
+@test "Can parse multiple files with 'conftest parse'" {
+  run bash -c "./conftest parse examples/kubernetes/deployment.yaml examples/kubernetes/deployment+service.yaml | jq 'keys'"
+  [ "$status" -eq 0 ]
+  count="${#lines[@]}"
+  [ "$count" -eq 4 ]
+  [[ "$output" =~ "\"examples/kubernetes/deployment+service.yaml\"" ]]
+  [[ "$output" =~ "\"examples/kubernetes/deployment.yaml\"" ]]
+}
+
 @test "Can output tap format in test command" {
   run ./conftest test -p examples/kubernetes/policy/ -o tap examples/kubernetes/deployment.yaml
   [[ "$output" =~ "not ok" ]]

--- a/parser/format.go
+++ b/parser/format.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -9,7 +8,7 @@ import (
 // Format takes in multiple configurations input and formats the configuration
 // to be more human readable. The key of each configuration should be its filepath.
 func Format(configurations map[string]interface{}) (string, error) {
-	output := "\n"
+	var output string
 	for file, config := range configurations {
 		output += file + "\n"
 
@@ -22,6 +21,18 @@ func Format(configurations map[string]interface{}) (string, error) {
 	}
 
 	return output, nil
+}
+
+// FormatJSON takes in multiple configurations and formats them as a JSON
+// object where each key is the path to the file and the contents are the
+// parsed configurations.
+func FormatJSON(configurations map[string]interface{}) (string, error) {
+	marshalled, err := json.MarshalIndent(configurations, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal configs: %w", err)
+	}
+
+	return string(marshalled), nil
 }
 
 // FormatCombined takes in multiple configurations, combines them, and formats the
@@ -39,19 +50,10 @@ func FormatCombined(configurations map[string]interface{}) (string, error) {
 }
 
 func format(configs interface{}) (string, error) {
-	out, err := json.Marshal(configs)
+	out, err := json.MarshalIndent(configs, "", "\t")
 	if err != nil {
 		return "", fmt.Errorf("marshal output to json: %w", err)
 	}
 
-	var prettyJSON bytes.Buffer
-	if err = json.Indent(&prettyJSON, out, "", "\t"); err != nil {
-		return "", fmt.Errorf("indentation: %w", err)
-	}
-
-	if _, err := prettyJSON.WriteString("\n"); err != nil {
-		return "", fmt.Errorf("adding line break: %w", err)
-	}
-
-	return prettyJSON.String(), nil
+	return string(out) + "\n", nil
 }


### PR DESCRIPTION
This allows for interoperability with other tooling that expects JSON
input.

Signed-off-by: James Alseth <james@jalseth.me>

---

Fixes #684. This is a **breaking change** for any tooling that relied on the previous formatting from the `parse` command.