### PR TITLE
Update install.md - Fix install command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ Conftest is available for Windows, macOS and Linux on the [releases page](https:
 On Linux and macOS you can download as follows:
 
 ```console
-LATEST_VERSION=$(wget -O - "https://api.github.com/repos/open-policy-agent/conftest/releases/latest" > /dev/null | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
+LATEST_VERSION=$(wget -O - "https://api.github.com/repos/open-policy-agent/conftest/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | cut -c 2-)
 wget "https://github.com/open-policy-agent/conftest/releases/download/v${LATEST_VERSION}/conftest_${LATEST_VERSION}_Linux_x86_64.tar.gz"
 tar xzf conftest_${LATEST_VERSION}_Linux_x86_64.tar.gz
 sudo mv conftest /usr/local/bin


### PR DESCRIPTION
The installation commands snippet did not work since wget output was redirected to /dev/null and not being passed to the next pipes for extracting latest version number.