### PR TITLE
Refactor JUnit output formatting

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -83,7 +83,23 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Short: "Test your configuration files using Open Policy Agent",
 		Long:  testDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"all-namespaces", "combine", "data", "fail-on-warn", "ignore", "namespace", "no-color", "no-fail", "suppress-exceptions", "output", "parser", "policy", "trace", "update"}
+			flagNames := []string{
+				"all-namespaces",
+				"combine",
+				"data",
+				"fail-on-warn",
+				"ignore",
+				"namespace",
+				"no-color",
+				"no-fail",
+				"suppress-exceptions",
+				"output",
+				"parser",
+				"policy",
+				"trace",
+				"update",
+				"junit-hide-message",
+			}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -109,7 +125,12 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running test: %w", err)
 			}
 
-			outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, SuppressExceptions: runner.SuppressExceptions, Tracing: runner.Trace})
+			outputter := output.Get(runner.Output, output.Options{
+				NoColor:            runner.NoColor,
+				SuppressExceptions: runner.SuppressExceptions,
+				Tracing:            runner.Trace,
+				JUnitHideMessage:   viper.GetBool("junit-hide-message"),
+			})
 			if err := outputter.Output(results); err != nil {
 				return fmt.Errorf("output results: %w", err)
 			}
@@ -145,6 +166,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
 
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
+	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")
 
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 	cmd.Flags().StringSliceP("update", "u", []string{}, "A list of URLs can be provided to the update flag, which will download before the tests run")

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -68,7 +68,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 		Short: "Verify Rego unit tests",
 		Long:  verifyDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"data", "no-color", "output", "policy", "trace", "report", "quiet"}
+			flagNames := []string{"data", "no-color", "output", "policy", "trace", "report", "quiet", "junit-hide-message"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -90,7 +90,12 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 			exitCode := output.ExitCode(results)
 			if !runner.Quiet || exitCode != 0 {
-				outputter := output.Get(runner.Output, output.Options{NoColor: runner.NoColor, Tracing: runner.Trace, ShowSkipped: true})
+				outputter := output.Get(runner.Output, output.Options{
+					NoColor:          runner.NoColor,
+					Tracing:          runner.Trace,
+					ShowSkipped:      true,
+					JUnitHideMessage: viper.GetBool("junit-hide-message"),
+				})
 				if runner.IsReportOptionOn() {
 					// report currently available with stdout only
 					if runner.Output != output.OutputStandard {
@@ -121,6 +126,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().String("report", "", "Shows output for Rego queries as a report with summary. Available options are {full|notes|fails}.")
 
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
+	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")
 
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")

--- a/output/output.go
+++ b/output/output.go
@@ -20,6 +20,7 @@ type Options struct {
 	NoColor            bool
 	SuppressExceptions bool
 	ShowSkipped        bool
+	JUnitHideMessage   bool
 }
 
 // The defined output formats represent all of the supported formats
@@ -45,7 +46,7 @@ func Get(format string, options Options) Outputter {
 	case OutputTable:
 		return NewTable(os.Stdout)
 	case OutputJUnit:
-		return NewJUnit(os.Stdout)
+		return NewJUnit(os.Stdout, options.JUnitHideMessage)
 	case OutputGitHub:
 		return NewGitHub(os.Stdout)
 	default:

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -29,7 +29,7 @@ func TestGetOutputter(t *testing.T) {
 		},
 		{
 			input:    OutputJUnit,
-			expected: NewJUnit(os.Stdout),
+			expected: NewJUnit(os.Stdout, false),
 		},
 		{
 			input:    "unknown_format",


### PR DESCRIPTION
To better integrate with CI systems such as Jenkis, the JUnit output now
includes the test namespace in the package name using dot notation. This
enables the tests under a namespace to be grouped where previously all
tests were under a single "conftest" group.

A `--junit-hide-message` flag was introduced to optionally suppress the
test summary message from the test name. This can be useful for tracking
trends over time since all violations for a file in a given namespace
will have a consistent test name.

---

Fixes #695 