### PR TITLE
Add parse_config and parse_config_file builtins

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -258,6 +258,11 @@
   [ "$status" -eq 1 ]
 }
 
+@test "Can verify unit tests using parse_config() and parse_config_file builtins()" {
+  run ./conftest verify -p examples/hcl2/policy examples/hcl2
+  [ "$status" -eq 0 ]
+}
+
 @test "Can combine configs and reference by file" {
   run ./conftest test -p examples/hcl1/policy/gke_combine.rego examples/hcl1/gke.tf --combine --parser hcl1 --all-namespaces
   [ "$status" -eq 0 ]

--- a/builtins/parse_config.go
+++ b/builtins/parse_config.go
@@ -1,0 +1,76 @@
+package builtins
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/conftest/parser"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/types"
+)
+
+func init() {
+	decl := rego.Function{
+		Name: "parse_config",
+		Decl: types.NewFunction(
+			types.Args(types.S, types.S), // parser name, configuration
+			types.NewObject(nil, types.NewDynamicProperty(types.S, types.NewAny())), // map[string]interface{} aka JSON
+		),
+	}
+	rego.RegisterBuiltin2(&decl, parseConfig)
+}
+
+// parseConfig takes a parser name and configuration as strings and returns the
+// parsed configuration as a Rego object. This can be used to parse all of the
+// configuration formats conftest supports in-line in Rego policies.
+func parseConfig(bctx rego.BuiltinContext, op1, op2 *ast.Term) (*ast.Term, error) {
+	args, err := decodeArgs([]*ast.Term{op1, op2})
+	if err != nil {
+		return nil, fmt.Errorf("decode args: %w", err)
+	}
+	parserName, ok := args[0].(string)
+	if !ok {
+		return nil, fmt.Errorf("parser name %v [%T] is not expected type string", args[0], args[0])
+	}
+	config, ok := args[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("config %v [%T] is not expected type string", args[1], args[1])
+	}
+	parser, err := parser.New(parserName)
+	if err != nil {
+		return nil, fmt.Errorf("create config parser: %w", err)
+	}
+	var cfg map[string]interface{}
+	if err := parser.Unmarshal([]byte(config), &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal config: %w", err)
+	}
+	value, err := ast.InterfaceToValue(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("convert config to ast.Value: %w", err)
+	}
+	loc := &ast.Location{
+		File: "-", // stdin
+		Text: []byte(config),
+	}
+	if bctx.Location != nil {
+		loc = bctx.Location
+	}
+	term := &ast.Term{
+		Value:    value,
+		Location: loc,
+	}
+
+	return term, nil
+}
+
+func decodeArgs(args []*ast.Term) ([]interface{}, error) {
+	decoded := make([]interface{}, len(args))
+	for i, arg := range args {
+		v, err := ast.ValueToInterface(arg.Value, nil)
+		if err != nil {
+			return nil, fmt.Errorf("ast.ValueToInterface: %w", err)
+		}
+		decoded[i] = v
+	}
+	return decoded, nil
+}

--- a/builtins/parse_config_test.go
+++ b/builtins/parse_config_test.go
@@ -1,0 +1,75 @@
+package builtins
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/conftest/parser"
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/rego"
+)
+
+func TestParseConfig(t *testing.T) {
+	testCases := []struct {
+		desc       string
+		parser     string
+		config     string
+		wantErrMsg string
+	}{
+		{
+			desc:       "No parser supplied",
+			wantErrMsg: "create config parser",
+		},
+		{
+			desc:       "Invalid parser supplied",
+			parser:     "no-such-parser",
+			wantErrMsg: "create config parser",
+		},
+		{
+			desc:       "Invalid YAML",
+			parser:     parser.YAML,
+			config:     "```NOTVALID!",
+			wantErrMsg: "unmarshal config",
+		},
+		{
+			desc:   "Empty YAML",
+			parser: parser.YAML,
+		},
+		{
+			desc:   "Valid YAML",
+			parser: parser.YAML,
+			config: `some_field: some_value
+another_field:
+- arr1
+- arr2`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			pv, err := ast.InterfaceToValue(tc.parser)
+			if err != nil {
+				t.Fatalf("Could not convert parser %q to ast.Value: %v", tc.parser, err)
+			}
+			cv, err := ast.InterfaceToValue(tc.config)
+			if err != nil {
+				t.Fatalf("Could not convert config %q to ast.Value: %v", tc.config, err)
+			}
+
+			bctx := rego.BuiltinContext{Context: context.Background()}
+			_, err = parseConfig(bctx, ast.NewTerm(pv), ast.NewTerm(cv))
+			if err == nil && tc.wantErrMsg == "" {
+				return
+			}
+			if err != nil && tc.wantErrMsg == "" {
+				t.Errorf("Error was returned when no error was expected: %v", err)
+				return
+			}
+			if !strings.Contains(err.Error(), tc.wantErrMsg) {
+				t.Errorf("Error %q does not contain expected string %q", err.Error(), tc.wantErrMsg)
+				return
+			}
+		})
+	}
+}

--- a/examples/hcl2/policy/deny_test.rego
+++ b/examples/hcl2/policy/deny_test.rego
@@ -21,5 +21,10 @@ test_unencrypted_azure_disk {
 }
 
 test_fails_with_http_alb {
-	deny["ALB `name` is using HTTP rather than HTTPS"] with input as {"resource": {"aws_alb_listener": {"name": {"protocol": "HTTP"}}}}
+	cfg := parse_config("hcl2", `
+		resource "aws_alb_listener" "name" {
+			protocol = "HTTP"
+		}
+	`)
+	deny["ALB `name` is using HTTP rather than HTTPS"] with input as cfg
 }

--- a/examples/hcl2/policy/deny_test.rego
+++ b/examples/hcl2/policy/deny_test.rego
@@ -17,7 +17,8 @@ test_correctly_encrypted_azure_disk {
 }
 
 test_unencrypted_azure_disk {
-	deny["Azure disk `sample` is not encrypted"] with input as {"resource": {"azurerm_managed_disk": {"sample": {"encryption_settings": {"enabled": false}}}}}
+	cfg := parse_config_file("unencrypted_azure_disk.tf")
+	deny["Azure disk `sample` is not encrypted"] with input as cfg
 }
 
 test_fails_with_http_alb {

--- a/examples/hcl2/policy/unencrypted_azure_disk.tf
+++ b/examples/hcl2/policy/unencrypted_azure_disk.tf
@@ -1,0 +1,5 @@
+resource "azurerm_managed_disk" "sample" {
+  encryption_settings {
+    enabled = false
+  }
+}

--- a/examples/hcl2/terraform.tf
+++ b/examples/hcl2/terraform.tf
@@ -1,11 +1,11 @@
 resource "aws_security_group_rule" "my-rule" {
-    type        = "ingress"
-    cidr_blocks = ["0.0.0.0/0"]
+  type        = "ingress"
+  cidr_blocks = ["0.0.0.0/0"]
 }
 
-resource "aws_alb_listener" "my-alb-listener"{
-    port     = "80"
-    protocol = "HTTP"
+resource "aws_alb_listener" "my-alb-listener" {
+  port     = "80"
+  protocol = "HTTP"
 }
 
 resource "aws_db_security_group" "my-group" {
@@ -13,7 +13,7 @@ resource "aws_db_security_group" "my-group" {
 }
 
 resource "azurerm_managed_disk" "source" {
-    encryption_settings {
-        enabled = false
-    }
+  encryption_settings {
+    enabled = false
+  }
 }

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -14,6 +14,9 @@ import (
 	"github.com/spf13/viper"
 
 	opaversion "github.com/open-policy-agent/opa/version"
+
+	// Load the custom builtins.
+	_ "github.com/open-policy-agent/conftest/builtins"
 )
 
 // These values are set at build time


### PR DESCRIPTION
This builtin can be used to parse configuration snippets in-line in Rego policies,
making it easier to write unit tests in the same configuration language that will
be tested.

Signed-off-by: James Alseth <james@jalseth.me>

---

Implements a solution for #621.