### PR TITLE
Use pkg.go.dev for constants reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -168,7 +168,7 @@ test_deny_alb_protocol_unspecified {
 ```
 
 For the full list of supported parsers and their names, please refer to the
-constants [defined in the parser package](https://github.com/open-policy-agent/conftest/blob/master/parser/parser.go).
+constants [defined in the parser package](https://pkg.go.dev/github.com/open-policy-agent/conftest/parser#pkg-constants).
 
 If you prefer to have your configuration snippets outside of the Rego unit test
 (for syntax highlighting, etc.) you can use the `parse_config_file` builtin. It


### PR DESCRIPTION
This allows us to link to the anchor that takes the user directly to the constants.

Signed-off-by: James Alseth <james@jalseth.me>