### PR TITLE
Bump Go to v1.18.5

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.4"
+          go-version: "1.18.5"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.4"
+          go-version: "1.18.5"
 
       - name: release
         uses: goreleaser/goreleaser-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.4-alpine as base
+FROM golang:1.18.5-alpine as base
 ARG ARCH=amd64
 ARG VERSION
 ARG COMMIT


### PR DESCRIPTION
Dependabot tried to migrate to v1.19.0 but we do not use the first release of a new feature version.