### PR TITLE
Detect Quay.io OCI registry in downloader

### DIFF
--- a/downloader/oci_detector.go
+++ b/downloader/oci_detector.go
@@ -34,6 +34,7 @@ func containsOCIRegistry(src string) bool {
 		regexp.MustCompile("gcr.io"),
 		regexp.MustCompile("registry.gitlab.com"),
 		regexp.MustCompile("[0-9]{12}.dkr.ecr.[a-z0-9-]*.amazonaws.com"),
+		regexp.MustCompile("^quay.io"),
 	}
 
 	for _, matchRegistry := range matchRegistries {

--- a/downloader/oci_detector_test.go
+++ b/downloader/oci_detector_test.go
@@ -48,6 +48,11 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"localhost:5000/policies",
 			"oci://localhost:5000/policies:latest",
 		},
+		{
+			"should detect Quay",
+			"quay.io/conftest/policies:tag",
+			"oci://quay.io/conftest/policies:tag",
+		},
 	}
 	pwd := "/pwd"
 	d := &OCIDetector{}


### PR DESCRIPTION
Quay.io recently added support for Conftest OCI media types (see[1]), so for a bit nicer UX add quay.io to the list of OCI detectors.

[1] https://github.com/quay/quay/pull/1567

Signed-off-by: Zoran Regvart <zoran@regvart.com>