### PR TITLE
Adding data flag to conftest push

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -109,7 +109,7 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 	}
 
 	cmd.Flags().StringP("policy", "p", "policy", "Directory to push as a bundle")
-	cmd.Flags().StringP("data", "d", "", "Directory containing data to include in the bundle")
+	cmd.Flags().StringP("data", "d", "", "Directory containing data to include in the bundle, defaults to the value of the policy flag")
 
 	return &cmd
 }

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -61,7 +61,9 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 			if err := viper.BindPFlag("policy", cmd.Flags().Lookup("policy")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
 			}
-
+			if err := viper.BindPFlag("data", cmd.Flags().Lookup("data")); err != nil {
+				return fmt.Errorf("bind flag: %w", err)
+			}
 			return nil
 		},
 
@@ -91,7 +93,12 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 			}
 
 			logger.Printf("pushing bundle to: %s", repository)
-			manifest, err := pushBundle(orascontext.Background(), repository, viper.GetString("policy"))
+			policyPath := viper.GetString("policy")
+			dataPath := viper.GetString("data")
+			if dataPath == "" {
+				dataPath = policyPath
+			}
+			manifest, err := pushBundle(orascontext.Background(), repository, policyPath, dataPath)
 			if err != nil {
 				return fmt.Errorf("push bundle: %w", err)
 			}
@@ -102,11 +109,12 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 	}
 
 	cmd.Flags().StringP("policy", "p", "policy", "Directory to push as a bundle")
+	cmd.Flags().StringP("data", "d", "", "Directory containing data to include in the bundle")
 
 	return &cmd
 }
 
-func pushBundle(ctx context.Context, repository string, path string) (*ocispec.Descriptor, error) {
+func pushBundle(ctx context.Context, repository, policyPath, dataPath string) (*ocispec.Descriptor, error) {
 	cli, err := dockerauth.NewClient()
 	if err != nil {
 		return nil, fmt.Errorf("get auth client: %w", err)
@@ -119,7 +127,7 @@ func pushBundle(ctx context.Context, repository string, path string) (*ocispec.D
 	registry := content.Registry{Resolver: resolver}
 
 	memoryStore := content.NewMemory()
-	layers, err := buildLayers(ctx, memoryStore, path)
+	layers, err := buildLayers(ctx, memoryStore, policyPath, dataPath)
 	if err != nil {
 		return nil, fmt.Errorf("building layers: %w", err)
 	}
@@ -141,8 +149,8 @@ func pushBundle(ctx context.Context, repository string, path string) (*ocispec.D
 	return &manifest, nil
 }
 
-func buildLayers(ctx context.Context, memoryStore *content.Memory, path string) ([]ocispec.Descriptor, error) {
-	engine, err := policy.LoadWithData(ctx, []string{path}, []string{path}, "")
+func buildLayers(ctx context.Context, memoryStore *content.Memory, policyPath, dataPath string) ([]ocispec.Descriptor, error) {
+	engine, err := policy.LoadWithData(ctx, []string{policyPath}, []string{dataPath}, "")
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}

--- a/scripts/push-pull-e2e.sh
+++ b/scripts/push-pull-e2e.sh
@@ -27,19 +27,37 @@ fi
 # Give the registry container some time to spin up and initialize.
 sleep 5
 
-$CONFTEST push localhost:5000/test -p examples/data
+$CONFTEST push localhost:5000/testpush -p examples/data
 if [ $? != 0 ]; then
     echo "ERROR PUSHING BUNDLE"
     exit 1
 fi
 
-$CONFTEST pull localhost:5000/test -p tmp
+$CONFTEST pull localhost:5000/testpush -p testpush
 if [ $? != 0 ]; then
     echo "ERROR PULLING BUNDLE"
     exit 1
 fi
 
-$CONFTEST verify -p tmp/examples/data/policy -d tmp/examples/data/exclusions tmp/examples/data/service.yaml
+$CONFTEST verify -p testpush/examples/data/policy -d testpush/examples/data/exclusions testpush/examples/data/service.yaml
+if [ $? != 0 ]; then
+    echo "POLICIES WERE NOT SUCCESSFULLY VERIFIED"
+    exit 1
+fi
+
+$CONFTEST push localhost:5000/testdatadirectory -p examples/data/policy -d examples/data/exclusions
+if [ $? != 0 ]; then
+    echo "ERROR PUSHING BUNDLE"
+    exit 1
+fi
+
+$CONFTEST pull localhost:5000/testdatadirectory -p testdatadirectory
+if [ $? != 0 ]; then
+    echo "ERROR PULLING BUNDLE"
+    exit 1
+fi
+
+$CONFTEST verify -p testdatadirectory/examples/data/policy -d testdatadirectory/examples/data/exclusions testdatadirectory/examples/data/service.yaml
 if [ $? != 0 ]; then
     echo "POLICIES WERE NOT SUCCESSFULLY VERIFIED"
     exit 1


### PR DESCRIPTION
Adds the `data` flag to the `conftest push` command. Allows for adding data to the bundle that's located in a separate directory. 

Threw this together, let me know if this is worth merging. 