### PR TITLE
Allow data-only bundles

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -84,9 +84,13 @@ func LoadWithData(ctx context.Context, policyPaths []string, dataPaths []string,
 		}
 	}
 
-	engine, err := Load(ctx, policyPaths, c)
-	if err != nil {
-		return nil, fmt.Errorf("loading policies: %w", err)
+	engine := &Engine{}
+	if len(policyPaths) > 0 {
+		var err error
+		engine, err = Load(ctx, policyPaths, c)
+		if err != nil {
+			return nil, fmt.Errorf("loading policies: %w", err)
+		}
 	}
 
 	// FilteredPaths will recursively find all file paths that contain a valid document

--- a/scripts/push-pull-e2e.sh
+++ b/scripts/push-pull-e2e.sh
@@ -63,6 +63,24 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
+$CONFTEST push localhost:5000/testdataonly -p '' -d examples/data/exclusions
+if [ $? != 0 ]; then
+    echo "ERROR PUSHING BUNDLE"
+    exit 1
+fi
+
+$CONFTEST pull localhost:5000/testdataonly -p testdataonly
+if [ $? != 0 ]; then
+    echo "ERROR PULLING BUNDLE"
+    exit 1
+fi
+
+$CONFTEST verify -p '' -d testdataonly/examples/data/exclusions
+if [ $? != 0 ]; then
+    echo "ERROR LOADING DATA BUNDLES"
+    exit 1
+fi
+
 $CONFTEST push localhost:5000/test-annotations -p tests/annotations
 if [ $? != 0 ]; then
     echo "ERROR PUSHING ANNOTATIONS BUNDLE"


### PR DESCRIPTION
This commit allows the command `conftest push` to create a bundle that contains data but no policies.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>