### PR TITLE
Added helper method to load combined config files for Rego unit tests

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -408,7 +408,7 @@
 
 @test "Can validate SPDX file" {
   run ./conftest test -p examples/spdx/policy examples/spdx/sbom.spdx
-  
+
   [ "$status" -eq 0 ]
   [[ "$output" =~ "1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions" ]] 
 }
@@ -438,4 +438,10 @@
   [ "$status" -eq 1 ]
   [[ "$output" =~ "undefined function opa.runtime" ]]
   [[ "$output" =~ "undefined function http.send" ]]
+}
+
+@test "Can verify rego tests that uses parse_combined_config_files" {
+  run ./conftest verify --policy ./examples/kubernetes/combine
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "2 tests, 2 passed" ]]
 }

--- a/examples/kubernetes/combine/combine.rego
+++ b/examples/kubernetes/combine/combine.rego
@@ -1,0 +1,14 @@
+package main
+
+violation[msg] {
+    input[i].contents.kind == "Deployment"
+    deployment := input[i].contents
+    not service_selects_app(deployment.spec.selector.matchLabels.app)
+    msg := sprintf("Deployment '%v' has no matching service", [deployment.metadata.name])
+}
+
+service_selects_app(app) {
+    input[i].contents.kind == "Service"
+    service := input[i].contents
+    service.spec.selector.app == app
+}

--- a/examples/kubernetes/combine/combine.yaml
+++ b/examples/kubernetes/combine/combine.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-kubernetes
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hello-kubernetes
+  template:
+    metadata:
+      labels:
+        app: hello-kubernetes
+    spec:
+      containers:
+      - name: hello-kubernetes
+        image: paulbouwer/hello-kubernetes:1.5
+        ports:
+        - containerPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goodbye-kubernetes
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: goodbye-kubernetes
+  template:
+    metadata:
+      labels:
+        app: goodbye-kubernetes
+    spec:
+      containers:
+      - name: goodbye-kubernetes
+        image: paulbouwer/hello-kubernetes:1.5
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-kubernetes
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: hello-kubernetes

--- a/examples/kubernetes/combine/combine_test.rego
+++ b/examples/kubernetes/combine/combine_test.rego
@@ -1,0 +1,9 @@
+package main
+
+test_parse_combined_config_file {
+	count(violation) == 1 with input as parse_combined_config_files(["combine.yaml"])
+}
+
+test_parse_combined_config_files {
+	count(violation) == 1 with input as parse_combined_config_files(["deployment.yaml", "service.yaml"])
+}

--- a/examples/kubernetes/combine/deployment.yaml
+++ b/examples/kubernetes/combine/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: goodbye-kubernetes
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: goodbye-kubernetes
+  template:
+    metadata:
+      labels:
+        app: goodbye-kubernetes
+    spec:
+      containers:
+      - name: goodbye-kubernetes
+        image: paulbouwer/hello-kubernetes:1.5
+        ports:
+        - containerPort: 8080

--- a/examples/kubernetes/combine/service.yaml
+++ b/examples/kubernetes/combine/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-kubernetes
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    targetPort: 8080
+  selector:
+    app: hello-kubernetes


### PR DESCRIPTION
This is similar to the existing parse_config and parse_config_file methods, but it'll work on combined config files instead.

With this, we can do something like this when unit testing rego files
```
test_parse_combined_config_files {
	count(violation) == 1 with input as parse_combined_config_files(["deployment.yaml", "service.yaml"])
}
```

Signed-off-by: Darren Dao <Darren_Dao@intuit.com>