### PR TITLE
Require commits to have conventional commit prefix

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,19 @@ permissions:
   statuses: none
 
 jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout all PR branch and commits
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: ${{ github.event.pull_request.commits }}
+
+    - name: validate conventional commit prefix
+      working-directory: scripts
+      run: ./validate-conventional-commit-prefix.sh
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,7 @@ If you are contributing code, please consider the following:
 - Most changes should be accompanied by tests.
 - All commits must be signed off (see next section).
 - Related commits must be squashed before they are merged.
+- All commits must have a [conventional commit prefix](https://www.conventionalcommits.org/en/v1.0.0/#summary), such as `feat:`, `fix:`, etc.
 - All tests must pass.
 
 If you are new to Go, consider reading [Effective
@@ -45,7 +46,7 @@ guidance on writing idiomatic Go code.
 Commit messages should explain *why* the changes were made and should probably look like this:
 
 ```
-Description of the change in 50 characters or less
+fix: Description of a bug fix in 50 characters or less
 
 More detail on what was changed. Provide some background on the issue
 and describe how the changes address the issue. Feel free to use multiple

--- a/scripts/validate-conventional-commit-prefix.sh
+++ b/scripts/validate-conventional-commit-prefix.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+code=0
+while read -r commit; do
+    match=$(echo "${commit}" | grep -o -h -E "^[a-z]+(\([a-z]+\))?: " || true)
+    if [[ -z "${match}" ]]; then
+        echo "::error::Commit \"${commit}\" does not have the required conventional commit prefix. See https://www.conventionalcommits.org/ for more info."
+        code=1
+    else
+        echo "Commit \"${commit}\" has conventional commit prefix \"${match}\"."
+    fi
+done < <(git --no-pager log --pretty=format:%s && echo "") # git log does not include newline after last commit
+
+exit ${code}


### PR DESCRIPTION
This helps reviewers and automation quickly categorize the change.