### PR TITLE
docs: Bump actions/checkout to v3

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -290,7 +290,7 @@ jobs:
     container: openpolicyagent/conftest:latest
     steps:
       - name: Code checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate Kubernetes policy
         run: |
           conftest test -o github -p examples/kubernetes/policy examples/kubernetes/deployment.yaml


### PR DESCRIPTION
Update docs to use the latest Github action 