### PR TITLE
fix: no policies found

### DIFF
--- a/output/standard.go
+++ b/output/standard.go
@@ -75,12 +75,6 @@ func (s *Standard) Output(results []CheckResult) error {
 			namespace = fmt.Sprintf("- %s -", result.Namespace)
 		}
 
-		totalPolicies := result.Successes + len(result.Warnings) + len(result.Failures) + len(result.Exceptions) + len(result.Skipped)
-		if totalPolicies == 0 {
-			fmt.Fprintln(s.Writer, colorizer.Colorize("?", aurora.WhiteFg), indicator, namespace, "no policies found")
-			continue
-		}
-
 		for _, warning := range result.Warnings {
 			fmt.Fprintln(s.Writer, colorizer.Colorize("WARN", aurora.YellowFg), indicator, namespace, warning.Message)
 		}


### PR DESCRIPTION
Fix: #558
Correlates: #785 and #769

Seems like no-policies-found was added as of https://github.com/open-policy-agent/conftest/blob/v0.22.0/output/standard.go
because it doesn't exist in https://github.com/open-policy-agent/conftest/blob/v0.21.0/output/standard.go
I'm not sure for what reason it was added here or due to which requirement but seems it's not considered for some of the users. Also in my tests, I didn't see any action on `totalPolicies` other than just printing info so discarded this

Thanks for the review in advance
