### PR TITLE
fix: Use docker buildx for multi-platform builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,6 @@ examples: ## Builds the examples Docker image.
 .PHONY: push
 push: ## Pushes the examples and Conftest image to DockerHub. Requires `TAG` parameter.
 	@test -n "$(TAG)" || (echo "TAG parameter not set." && exit 1)
-	@$(DOCKER) build . --build-arg VERSION="$(TAG)" -t $(IMAGE):$(TAG) --platform $(DOCKER_PLATFORMS)
-	@$(DOCKER) build . --target examples -t $(IMAGE):examples
-	@$(DOCKER) tag $(IMAGE):$(TAG) $(IMAGE):latest
-	@$(DOCKER) push $(IMAGE):$(TAG)
-	@$(DOCKER) push $(IMAGE):latest
-	@$(DOCKER) push $(IMAGE):examples
+	@$(DOCKER) buildx build . --push --build-arg VERSION="$(TAG)" -t $(IMAGE):$(TAG) --platform $(DOCKER_PLATFORMS)
+	@$(DOCKER) buildx build . --push --build-arg VERSION="$(TAG)" -t $(IMAGE):latest --platform $(DOCKER_PLATFORMS)
+	@$(DOCKER) buildx build . --push --target examples -t $(IMAGE):examples --platform $(DOCKER_PLATFORMS)


### PR DESCRIPTION
The 'docker build' command does not support more than one platform at a time.