### PR TITLE
fix: detect regardless of port and loopback

### DIFF
--- a/downloader/oci_detector.go
+++ b/downloader/oci_detector.go
@@ -47,7 +47,9 @@ func containsOCIRegistry(src string) bool {
 }
 
 func containsLocalRegistry(src string) bool {
-	return strings.Contains(src, "127.0.0.1:5000") || strings.Contains(src, "localhost:5000")
+	matched, err := regexp.MatchString(`(?:::1|127\.0\.0\.1|(?i:localhost)):\d{1,5}`, src)
+
+	return err == nil && matched
 }
 
 func detectHTTP(src string) (string, error) {

--- a/downloader/oci_detector_test.go
+++ b/downloader/oci_detector_test.go
@@ -53,6 +53,21 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"quay.io/conftest/policies:tag",
 			"oci://quay.io/conftest/policies:tag",
 		},
+		{
+			"should detect localhost:32123/policies:tag as most likely being an OCI registry",
+			"localhost:32123/policies:tag",
+			"oci://localhost:32123/policies:tag",
+		},
+		{
+			"should detect 127.0.0.1:32123/policies:tag as most likely being an OCI registry",
+			"127.0.0.1:32123/policies:tag",
+			"oci://127.0.0.1:32123/policies:tag",
+		},
+		{
+			"should detect ::1:32123/policies:tag as most likely being an OCI registry",
+			"::1:32123/policies:tag",
+			"oci://::1:32123/policies:tag",
+		},
 	}
 	pwd := "/pwd"
 	d := &OCIDetector{}


### PR DESCRIPTION
When detecting OCI go-getter strings, the detector can look at any port number and any loopback interface address and consider it to be a local OCI registry.