### PR TITLE
fix: handle builtin errors returned from the rego evaluation

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -470,3 +470,9 @@ EOF"
   [ "$status" -eq 0 ]
   [[ "$output" =~ "2 tests, 2 passed" ]]
 }
+
+@test "Should fail evaluation if a builtin function returns error" {
+  run ./conftest test -p examples/builtin-errors/invalid-dns.rego examples/kubernetes/deployment.yaml
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "built-in error" ]]
+}

--- a/examples/builtin-errors/invalid-dns.rego
+++ b/examples/builtin-errors/invalid-dns.rego
@@ -1,0 +1,5 @@
+package main
+
+deny_dnsresolution["testing DNS resolution"] {
+  net.lookup_ip_addr("not-real-domain.xyz")
+}


### PR DESCRIPTION
Fix: #811
