### PR TITLE
fix: pretty print the built-in err structure

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -447,7 +447,7 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 	}
 
 	if len(*builtInErrors) > 0 {
-		return output.QueryResult{}, fmt.Errorf("built-in error: %s", (*builtInErrors))
+		return output.QueryResult{}, fmt.Errorf("built-in error: %+v", (*builtInErrors))
 	}
 
 	// After the evaluation of the policy, the results of the trace (stdout) will be populated


### PR DESCRIPTION
this is to fix the linter issue reported in the dependabot PR: https://github.com/open-policy-agent/conftest/actions/runs/5425401141/jobs/9866098968?pr=838
Also, it pretty prints the whole array structure, perhaps better than using `%s`

e.g
```shell
./conftest test -p examples/builtin-errors/invalid-dns.rego examples/kubernetes/deployment.yaml
Error: running test: query rule: check: query rule: built-in error: [{Code:eval_builtin_error Message:net.lookup_ip_addr: lookup not-real-domain.xyz: no such host Location:examples/builtin-errors/invalid-dns.rego:4}]
```