### PR TITLE
fix: examples/compose - a deny rule was incorrectly implemented

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -378,6 +378,18 @@ EOF"
   [[ "$output" =~ "No images tagged latest" ]]
 }
 
+@test "Can validate a docker-compose file that does not conform to the policy" {
+  run ./conftest test -p examples/compose/policy examples/compose/docker-compose.yml --no-color
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "2 tests, 0 passed, 0 warnings, 2 failures, 0 exceptions" ]]
+}
+
+@test "Can validate a docker-compose file that conforms to the policy" {
+  run ./conftest test -p examples/compose/policy examples/compose/docker-compose-valid.yml --no-color
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions" ]]
+}
+
 @test "The number of tests run is accurate" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/service.yaml --no-color
   [ "$status" -eq 0 ]

--- a/examples/compose/docker-compose-valid.yml
+++ b/examples/compose/docker-compose-valid.yml
@@ -1,0 +1,8 @@
+version: '3.5'
+services:
+  web:
+    build: .
+    ports:
+     - "5000:5000"
+  redis:
+    image: "redis:some-hash"

--- a/examples/compose/policy/deny.rego
+++ b/examples/compose/policy/deny.rego
@@ -1,8 +1,6 @@
 package main
 
-version {
-	to_number(input.version)
-}
+version := to_number(input.version)
 
 deny[msg] {
 	endswith(input.services[_].image, ":latest")


### PR DESCRIPTION
The conversion to a number of the version string evaluated to a boolean. Subsequently the boolean was compared to a number, which always resulted in a failure to comply to that rule.

This PR fixes the conversion error so that the comparison now works as expected. This PR also adds some tests to prevent regression.