### PR TITLE
fix: `--strict` flag when using `conftest verify`

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -470,6 +470,15 @@ EOF"
   [[ "$output" =~ "rego_compile_error: unused argument y" ]]
 }
 
+@test "Should fail when verifying if strict is set and there are unused variables in the policy" {
+  run ./conftest verify -p examples/strict-rules/policy/ examples/kubernetes/deployment.yaml --strict
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "rego_compile_error: assigned var b unused" ]]
+  [[ "$output" =~ "rego_compile_error: assigned var x unused" ]]
+  [[ "$output" =~ "rego_compile_error: assigned var c unused" ]]
+  [[ "$output" =~ "rego_compile_error: unused argument y" ]]
+}
+
 @test "Should fail if an opa function is not defined given capabilities file" {
   run ./conftest test examples/kubernetes/deployment.yaml -p examples/kubernetes/policy/ -p examples/capabilities/malicious.rego --capabilities examples/capabilities/capabilities.json
   [ "$status" -eq 1 ]

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -78,6 +78,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				"quiet",
 				"junit-hide-message",
 				"capabilities",
+				"strict",
 				"proto-file-dirs",
 			}
 			for _, name := range flagNames {


### PR DESCRIPTION
Without this `conftest verify --strict` does not fail in situations where running `conftest test --strict` would.

I think this was probably an oversight with #798 and it was expected that `conftest verify --strict` should behave the same as `conftest test --strict`.

Without this change the behaviour is:

```
$ go run . verify --policy examples/strict-rules/policy --strict

0 tests, 0 passed, 0 warnings, 0 failures, 0 exceptions, 0 skipped
```

With this change the behaviour is:

```
$ go run . verify --policy examples/strict-rules/policy --strict
Error: running verification: load: loading policies: get compiler: 4 errors occurred:
examples/strict-rules/policy/lenient.rego:6: rego_compile_error: assigned var b unused
examples/strict-rules/policy/lenient.rego:7: rego_compile_error: assigned var x unused
examples/strict-rules/policy/lenient.rego:11: rego_compile_error: assigned var c unused
examples/strict-rules/policy/lenient.rego:14: rego_compile_error: unused argument y. (hint: use _ (wildcard variable) instead)
exit status 1
```