### PR TITLE
fix: cover built-in errors with a flag, suppress unless it's passed

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -505,7 +505,7 @@ EOF"
 }
 
 @test "Should fail evaluation if a builtin function returns error" {
-  run ./conftest test -p examples/builtin-errors/invalid-dns.rego examples/kubernetes/deployment.yaml
+  run ./conftest test --show-builtin-errors -p examples/builtin-errors/invalid-dns.rego examples/kubernetes/deployment.yaml
   [ "$status" -eq 1 ]
   [[ "$output" =~ "built-in error" ]]
 }

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -100,6 +100,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				"capabilities",
 				"trace",
 				"strict",
+				"show-builtin-errors",
 				"update",
 				"junit-hide-message",
 				"quiet",
@@ -168,6 +169,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().Bool("trace", false, "Enable more verbose trace output for Rego queries")
 	cmd.Flags().Bool("strict", false, "Enable strict mode for Rego policies")
+	cmd.Flags().Bool("show-builtin-errors", false, "Collect and return all encountered built-in errors")
 	cmd.Flags().Bool("combine", false, "Combine all config files to be evaluated together")
 
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -25,12 +25,13 @@ import (
 
 // Engine represents the policy engine.
 type Engine struct {
-	trace    bool
-	modules  map[string]*ast.Module
-	compiler *ast.Compiler
-	store    storage.Store
-	policies map[string]string
-	docs     map[string]string
+	trace         bool
+	builtinErrors bool
+	modules       map[string]*ast.Module
+	compiler      *ast.Compiler
+	store         storage.Store
+	policies      map[string]string
+	docs          map[string]string
 }
 
 type compilerOptions struct {
@@ -154,6 +155,10 @@ func LoadWithData(policyPaths []string, dataPaths []string, capabilities string,
 
 func (e *Engine) EnableTracing() {
 	e.trace = true
+}
+
+func (e *Engine) ShowBuiltinErrors() {
+	e.builtinErrors = true
 }
 
 // Check executes all of the loaded policies against the input and returns the results.
@@ -446,7 +451,7 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 		return output.QueryResult{}, fmt.Errorf("evaluating policy: %w", err)
 	}
 
-	if len(*builtInErrors) > 0 {
+	if e.builtinErrors && len(*builtInErrors) > 0 {
 		return output.QueryResult{}, fmt.Errorf("built-in error: %+v", (*builtInErrors))
 	}
 

--- a/runner/test.go
+++ b/runner/test.go
@@ -30,6 +30,7 @@ type TestRunner struct {
 	NoColor            bool `mapstructure:"no-color"`
 	NoFail             bool `mapstructure:"no-fail"`
 	SuppressExceptions bool `mapstructure:"suppress-exceptions"`
+	ShowBuiltinErrors  bool `mapstructure:"show-builtin-errors"`
 	Combine            bool
 	Quiet              bool
 	Output             string
@@ -68,6 +69,10 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 
 	if t.Trace {
 		engine.EnableTracing()
+	}
+
+	if t.ShowBuiltinErrors {
+		engine.ShowBuiltinErrors()
 	}
 
 	namespaces := t.Namespace


### PR DESCRIPTION
Fix: #840, #870 

This is to bring the user experience closer to opa when it comes to built-in errors. 
By default, OPA doesn't fail on built-in errors unless `--show-builtin-errors ` is explicitly passed, but conftest does. 
This PR introduces the same flag in conftest along with the same functionality as well