### PR TITLE
fix: Fix regexp for Goreleaser groups

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,10 +46,10 @@ changelog:
   use: github
   groups:
   - title: New Features
-    regexp: '^feat(ure)?:'
+    regexp: '^.*?feat(ure)?(\([[:word:]]+\))??!?:.+$'
     order: 0
   - title: Bug Fixes
-    regexp: '^(bug|fix):'
+    regexp: '^.*?(bug|fix)(\([[:word:]]+\))??!?:.+$'
     order: 1
   - title: OPA Changes
     regexp: '(?i)bump (opa|github.com/open-policy-agent/opa)'
@@ -59,10 +59,10 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
-    - '^misc:'
-    - '^typo:'
+    - '^.*?docs(\([[:word:]]+\))??!?:.+$'
+    - '^.*?test(\([[:word:]]+\))??!?:.+$'
+    - '^.*?misc(\([[:word:]]+\))??!?:.+$'
+    - '^.*?typo(\([[:word:]]+\))??!?:.+$'
     - '(?i) typo( |\.|\r?\n)'
 
 # Publishes the deb and rpm files to the GitHub releases page.


### PR DESCRIPTION
Goreleaser includes the short SHA1 commit before the commit message, so the previous patterns matching only on the beginning of the line were not matching when they should have.