### PR TITLE
feat: Raise error when problematic use of the if keyword is encountered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ site
 # IDEs
 .vscode
 .DS*
-
 .idea
+
+# NodeJS files/dirs created when installing bats
+node_modules/
+package.json
+package-lock.json

--- a/internal/testing/memfs/memfs.go
+++ b/internal/testing/memfs/memfs.go
@@ -1,0 +1,75 @@
+// Package memfs implements the fs.FS interface.
+package memfs
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"time"
+)
+
+type FS struct {
+	files map[string][]byte
+}
+
+func New(files map[string][]byte) *FS {
+	return &FS{files: files}
+}
+
+func (f *FS) Open(name string) (fs.File, error) {
+	data, ok := f.files[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", fs.ErrNotExist, name)
+	}
+	return &File{name: name, data: data}, nil
+}
+
+type File struct {
+	name string
+	data []byte
+}
+
+func (f *File) Stat() (fs.FileInfo, error) {
+	return &FileInfo{
+		name: f.name,
+		size: int64(len(f.data)),
+	}, nil
+}
+
+func (f *File) Read(out []byte) (int, error) {
+	n := copy(out, f.data)
+	return n, io.EOF
+}
+
+func (f *File) Close() error {
+	return nil
+}
+
+type FileInfo struct {
+	name string
+	size int64
+}
+
+func (fi *FileInfo) Name() string {
+	return fi.name
+}
+
+func (fi *FileInfo) Size() int64 {
+	return fi.size
+}
+
+func (fi *FileInfo) Mode() fs.FileMode {
+	return fs.FileMode(0644)
+}
+
+func (fi *FileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (fi *FileInfo) IsDir() bool {
+	return false
+}
+
+func (fi *FileInfo) Sys() any {
+	return nil
+}

--- a/tests/problematic-if/policy/invalid.rego
+++ b/tests/problematic-if/policy/invalid.rego
@@ -1,0 +1,7 @@
+package main
+
+import future.keywords.if
+
+deny[msg] if {
+    msg := "foo"
+}

--- a/tests/problematic-if/policy/valid.rego
+++ b/tests/problematic-if/policy/valid.rego
@@ -1,0 +1,8 @@
+package main
+
+import future.keywords.contains
+import future.keywords.if
+
+deny contains msg if {
+    msg := "foo"
+}

--- a/tests/problematic-if/test.bats
+++ b/tests/problematic-if/test.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+@test "Test works as expected using contains and if" {
+  run $CONFTEST test --policy=policy/valid.rego data.yaml
+
+  [ "$status" -eq 1 ]
+  echo $output
+  [[ "$output" =~ "1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions" ]]
+}
+
+@test "Error is raised when if is used without contains" {
+  run $CONFTEST test --policy=policy/invalid.rego data.yaml
+
+  [ "$status" -eq 1 ]
+  echo $output
+  [[ "$output" =~ "'if' keyword without 'contains' keyword" ]]
+}


### PR DESCRIPTION
Using the if keyword without also using the contains keyword makes the rule name in the OPA AST an emptry string, which causes conftest to inadvertently skip over tests leading to inaccurate results.

https://github.com/open-policy-agent/opa/issues/6509