### PR TITLE
s390x architecture added in the goarch list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
   - amd64
   - arm64
   - ppc64le
+  - s390x
   ldflags:
   - "-s"
   - "-w"


### PR DESCRIPTION
s390x architecture added in the goarch list. This is to use conftest on IBM Z machine.