### PR TITLE
s390x architecture added in the goarch list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
   - amd64
   - arm64
   - ppc64le
+  - s390x
   ldflags:
   - "-s"
   - "-w"


### PR DESCRIPTION
s390x architecture is added in the goarch list. This is required to use conftest on a IBM Z based machine.