### PR TITLE
Update workflow action versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout all PR branch and commits
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: ${{ github.event.pull_request.commits }}
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.21.x"
 
@@ -51,7 +51,7 @@ jobs:
         run: make test
 
       - name: setup bats
-        uses: mig4/setup-bats@v1
+        uses: bats-core/bats-action@1.5.4
 
       - name: test examples
         run: make test-examples
@@ -59,7 +59,7 @@ jobs:
       - name: setup regal
         uses: StyraInc/setup-regal@v0.2.0
         with:
-          version: v0.11.0
+          version: v0.16.0
 
       - name: lint examples
         run: regal lint --format github examples

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: setup regal
         uses: StyraInc/setup-regal@v0.2.0
         with:
-          version: v0.16.0
+          version: v0.11.0
 
       - name: lint examples
         run: regal lint --format github examples

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -31,7 +31,7 @@ func NewDefaultCommand() *cobra.Command {
 		Short:        "Test your configuration files using Open Policy Agent",
 		Version:      createVersionString(),
 		SilenceUsage: true,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := viper.BindPFlag("config-file", cmd.Flags().Lookup("config-file")); err != nil {
 				return fmt.Errorf("bind flag: %s", err)
 			}
@@ -80,7 +80,7 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 		Use:   p.Name,
 		Short: p.Usage,
 		Long:  p.Description,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			if err := p.Exec(ctx, args); err != nil {
 				return fmt.Errorf("execute plugin: %v", err)
 			}

--- a/internal/commands/fmt.go
+++ b/internal/commands/fmt.go
@@ -18,14 +18,14 @@ func NewFormatCommand() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "fmt <path> [path [...]]",
 		Short: "Format Rego files",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := viper.BindPFlag("check", cmd.Flags().Lookup("check")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
 			}
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, files []string) error {
+		RunE: func(_ *cobra.Command, files []string) error {
 			policies, err := loader.AllRegos(files)
 			if err != nil {
 				return fmt.Errorf("get rego files: %w", err)

--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -42,7 +42,7 @@ func NewParseCommand() *cobra.Command {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, files []string) error {
+		RunE: func(_ *cobra.Command, files []string) error {
 			var configurations map[string]interface{}
 			var err error
 			if viper.GetString("parser") != "" {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -50,7 +50,7 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 		Use:   "pull <repository>",
 		Short: "Download individual policies",
 		Long:  pullDesc,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := viper.BindPFlag("policy", cmd.Flags().Lookup("policy")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
 			}

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -59,7 +59,7 @@ func NewPushCommand(ctx context.Context, logger *log.Logger) *cobra.Command {
 		Use:   "push <repository>",
 		Short: "Push OPA bundles to an OCI registry",
 		Long:  pushDesc,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			if err := viper.BindPFlag("policy", cmd.Flags().Lookup("policy")); err != nil {
 				return fmt.Errorf("bind flag: %w", err)
 			}

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -82,7 +82,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 		Use:   "test <path> [path [...]]",
 		Short: "Test your configuration files using Open Policy Agent",
 		Long:  testDesc,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			flagNames := []string{
 				"all-namespaces",
 				"combine",

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -67,7 +67,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 		Use:   "verify <path> [path [...]]",
 		Short: "Verify Rego unit tests",
 		Long:  verifyDesc,
-		PreRunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			flagNames := []string{
 				"data",
 				"no-color",
@@ -90,7 +90,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 			return nil
 		},
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			var runner runner.VerifyRunner
 			if err := viper.Unmarshal(&runner); err != nil {
 				return fmt.Errorf("unmarshal parameters: %w", err)

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -22,7 +22,7 @@ func SetupClient(repository *remote.Repository) {
 
 	client := auth.DefaultClient
 	client.SetUserAgent("conftest")
-	client.Credential = func(ctx context.Context, registry string) (auth.Credential, error) {
+	client.Credential = func(_ context.Context, registry string) (auth.Credential, error) {
 		host := dockercfg.ResolveRegistryHost(registry)
 		username, password, err := dockercfg.GetRegistryCredentials(host)
 		if err != nil {

--- a/plugin/xdg_test.go
+++ b/plugin/xdg_test.go
@@ -99,7 +99,7 @@ func TestFind(t *testing.T) {
 				os.Unsetenv(XDGDataDirs)
 				return "/does/not/exist", nil
 			},
-			func(path string) error {
+			func(_ string) error {
 				return nil
 			},
 			func(_ string) string {

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -69,7 +69,7 @@ func newCompiler(c compilerOptions) *ast.Compiler {
 
 // Load returns an Engine after loading all of the specified policies.
 func Load(policyPaths []string, c compilerOptions) (*Engine, error) {
-	policies, err := loader.NewFileLoader().WithProcessAnnotation(true).Filtered(policyPaths, func(_ string, info os.FileInfo, depth int) bool {
+	policies, err := loader.NewFileLoader().WithProcessAnnotation(true).Filtered(policyPaths, func(_ string, info os.FileInfo, _ int) bool {
 		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
 	})
 
@@ -124,7 +124,7 @@ func LoadWithData(policyPaths []string, dataPaths []string, capabilities string,
 
 	// FilteredPaths will recursively find all file paths that contain a valid document
 	// extension from the given list of data paths.
-	allDocumentPaths, err := loader.FilteredPaths(dataPaths, func(abspath string, info os.FileInfo, depth int) bool {
+	allDocumentPaths, err := loader.FilteredPaths(dataPaths, func(_ string, info os.FileInfo, _ int) bool {
 		if info.IsDir() {
 			return false
 		}


### PR DESCRIPTION
Updating the actions in the PR workflow to resolve the `node` deprecation warnings. There is still one that remains from the `regal` linter, but we'll have to wait for @anderseknert to cut a new release.

Had to update our `bats` action to `bats-core/bats-action@1.5.4` because the one we're using no longer appears to be maintained. Regardless, should be for the best coming from the `core` team.

Some linting errors seemed to have popped up as well from this (or just bad timing with a release from the `golangci-lint` team) so those have been addressed as well.