### PR TITLE
build: Bump Go to 1.22.x

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21.x"
+          go-version: "1.22.x"
 
       - name: release
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This matches the version now used in the container https://github.com/open-policy-agent/conftest/pull/913.