### PR TITLE
chore: Update setup-regal and golangci-lint actions to latest

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -57,7 +57,7 @@ jobs:
         run: make test-examples
 
       - name: setup regal
-        uses: StyraInc/setup-regal@v0.2.0
+        uses: StyraInc/setup-regal@v1
         with:
           version: v0.11.0
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,9 +38,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.22.x"
+          cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 
@@ -52,6 +53,11 @@ jobs:
 
       - name: setup bats
         uses: bats-core/bats-action@1.5.4
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
 
       - name: test examples
         run: make test-examples


### PR DESCRIPTION
Updates the `setup-regal` linter to v1 and the `golangci-lint` action to v4 to help resolve the `node` deprecation warnings.

- Adding `false` to the install params on `bats-core`: I was seeing a ton of new warnings/errors that weren't there before (https://github.com/open-policy-agent/conftest/actions/runs/7901911540) when attempting to install these tools, but it doesn't look like we even use them.
- Adding `cache: false` to `setup-go`: I was seeing a ton of file exists errors (https://github.com/open-policy-agent/conftest/actions/runs/7902189087) and it looks like people were reporting similar problems when caching was enabled (https://github.com/golangci/golangci-lint-action/issues/807 and https://github.com/golangci/golangci-lint-action/issues/677). Resolution seems to be to disable the cache, albeit most agree it feels like a workaround. It does appear to resolve the issue, and build times don't seem to be impacted much if at all.

Last `node` deprecation warning to be resolved after https://github.com/bats-core/bats-action/pull/2 is merged and our action is updated.