### PR TITLE
fix: Use the right command to pull policies from oci registry

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -27,7 +27,7 @@ conftest pull git::https://<PersonalAccessToken>@github.com/<Organization>/<Repo
 ### OCI Registry
 
 ```console
-conftest pull opa.azurecr.io/test
+conftest pull oci://opa.azurecr.io/test
 ```
 
 See the [go-getter](https://github.com/hashicorp/go-getter) repository for more examples.

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -60,7 +60,7 @@ By default, it will use the regular stdout output. For a full list of available 
 The test command supports the '--update' flag to fetch the latest version of the policy at the given url.
 It expects one or more urls to fetch the latest policies from, e.g.:
 
-	$ conftest test --update opa.azurecr.io/test
+	$ conftest test --update oci://opa.azurecr.io/test
 
 See the pull command for more details on supported protocols for fetching policies.
 


### PR DESCRIPTION
Fixes #919 