### PR TITLE
fix: Catch Google Artifact Registry URL during OCI detection

### DIFF
--- a/downloader/oci_detector.go
+++ b/downloader/oci_detector.go
@@ -10,7 +10,7 @@ import (
 // them into URLs that the OCI getter can understand.
 type OCIDetector struct{}
 
-// Detect will detect if the source is an OCI registry
+// Detect will detect if the source is an OCI registry.
 func (d *OCIDetector) Detect(src, _ string) (string, bool, error) {
 	if len(src) == 0 {
 		return "", false, nil
@@ -33,6 +33,7 @@ func containsOCIRegistry(src string) bool {
 		regexp.MustCompile("azurecr.io"),
 		regexp.MustCompile("gcr.io"),
 		regexp.MustCompile("registry.gitlab.com"),
+		regexp.MustCompile("pkg.dev"),
 		regexp.MustCompile("[0-9]{12}.dkr.ecr.[a-z0-9-]*.amazonaws.com"),
 		regexp.MustCompile("^quay.io"),
 	}

--- a/downloader/oci_detector_test.go
+++ b/downloader/oci_detector_test.go
@@ -19,6 +19,11 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"oci://gcr.io/conftest/policies:tag",
 		},
 		{
+			"should detect google artifact registry",
+			"region-docker.pkg.dev/conftest/policies:tag",
+			"oci://region-docker.pkg.dev/conftest/policies:tag",
+		},
+		{
 			"should detect ecr",
 			"123456789012.dkr.ecr.us-east-1.amazonaws.com/conftest/policies:tag",
 			"oci://123456789012.dkr.ecr.us-east-1.amazonaws.com/conftest/policies:tag",
@@ -69,17 +74,21 @@ func TestOCIDetector_Detect(t *testing.T) {
 			"oci://::1:32123/policies:tag",
 		},
 	}
+
 	pwd := "/pwd"
 	d := &OCIDetector{}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, ok, err := d.Detect(tt.input, pwd)
 			if err != nil {
 				t.Fatalf("OCIDetector.Detect() error = %v", err)
 			}
+
 			if !ok {
 				t.Fatal("OCIDetector.Detect() not ok, should have detected")
 			}
+
 			if out != tt.expected {
 				t.Errorf("OCIDetector.Detect() output = %v, want %v", out, tt.expected)
 			}


### PR DESCRIPTION
Relates to https://github.com/open-policy-agent/conftest/issues/919 and https://github.com/open-policy-agent/conftest/pull/920

I'm not convinced we really need to utilize `regex` for URL detection (we should just be able to get by with string contains checking?), but to keep things as they are I just added another check for `pkg.dev`