### PR TITLE
fix: Only raise problematic if error when rule has no name set

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -538,7 +538,7 @@ func problematicIf(modules map[string]*ast.Module) error {
 	// https://github.com/open-policy-agent/opa/issues/6509
 	for _, module := range modules {
 		for _, rule := range module.Rules {
-			if rule.Head == nil || rule.Head.Value == nil || len(rule.Head.Reference) == 0 {
+			if rule.Head == nil || rule.Head.Name != "" || rule.Head.Value == nil || len(rule.Head.Reference) == 0 {
 				continue
 			}
 			refName := rule.Head.Reference[0].Value.String()

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -327,6 +327,10 @@ func TestProblematicIf(t *testing.T) {
 			body: "",
 		},
 		{
+			desc: "Bare deny",
+			body: "deny { true }\n",
+		},
+		{
 			desc: "Rule not using if statement",
 			body: "deny[msg] {\n 1 == 1\nmsg := \"foo\"\n}\n",
 		},

--- a/tests/problematic-if/policy/valid_bare_deny.rego
+++ b/tests/problematic-if/policy/valid_bare_deny.rego
@@ -1,0 +1,5 @@
+package main
+
+deny {
+    true
+}

--- a/tests/problematic-if/test.bats
+++ b/tests/problematic-if/test.bats
@@ -8,6 +8,14 @@
   [[ "$output" =~ "1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions" ]]
 }
 
+@test "Bare deny rule can be used without contains or if" {
+  run $CONFTEST test --policy=policy/valid_bare_deny.rego data.yaml
+
+  [ "$status" -eq 0 ]
+  echo $output
+  [[ "$output" =~ "1 test, 1 passed, 0 warnings, 0 failures, 0 exceptions" ]]
+}
+
 @test "Error is raised when if is used without contains" {
   run $CONFTEST test --policy=policy/invalid.rego data.yaml
 


### PR DESCRIPTION
If the rule has a name set, that means there isn't problematic use of the 'if' keyword without 'contains' so we can skip those.

---

Fixes #934