### PR TITLE
ci: Allow Dependabot to update github.com/hashicorp/go-getter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
       - dependency-name: "github.com/moby/buildkit"
       - dependency-name: "github.com/spdx/tools-golang"
       - dependency-name: "github.com/subosito/gotenv"
+      # go-getter is used to fetch remote policies from various sources which occasionally has security fixes
+      - dependency-name: "github.com/hashicorp/go-getter"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
Dependabot is currently blocked from updating this library, which has a known vulnerability (https://github.com/open-policy-agent/conftest/issues/942).