### PR TITLE
tests: extend hcl cases: tag verification

### DIFF
--- a/examples/hcl2/policy/deny.rego
+++ b/examples/hcl2/policy/deny.rego
@@ -26,3 +26,17 @@ deny[msg] {
 	disk.encryption_settings.enabled != true
 	msg = sprintf("Azure disk `%v` is not encrypted", [name])
 }
+
+# Required tags for all AWS resources
+required_tags := {"environment", "owner"}
+missing_tags(resource) := {tag | tag := required_tags[_]; not resource.tags[tag]}
+
+deny[msg] {
+	some aws_resource, name
+	resource := input.resource[aws_resource][name] # all resources
+	startswith(aws_resource, "aws_") # only AWS resources
+	missing := missing_tags(resource)
+	count(missing) > 0
+
+	msg = sprintf("AWS resource: \"%s\" named \"%s\" is missing required tags: %v", [aws_resource, name, missing])
+}

--- a/examples/hcl2/policy/deny.rego
+++ b/examples/hcl2/policy/deny.rego
@@ -38,5 +38,5 @@ deny[msg] {
 	missing := missing_tags(resource)
 	count(missing) > 0
 
-	msg = sprintf("AWS resource: \"%s\" named \"%s\" is missing required tags: %v", [aws_resource, name, missing])
+	msg = sprintf("AWS resource: %q named %q is missing required tags: %v", [aws_resource, name, missing])
 }

--- a/examples/hcl2/policy/deny_test.rego
+++ b/examples/hcl2/policy/deny_test.rego
@@ -31,3 +31,17 @@ test_fails_with_http_alb {
 	`)
 	deny["ALB `name` is using HTTP rather than HTTPS"] with input as cfg
 }
+
+test_fails_with_aws_resource_is_missing_required_tags {
+	cfg := parse_config("hcl2", `
+		resource "aws_s3_bucket" "invalid" {
+			bucket = "InvalidBucket"
+			acl    = "private"
+
+			tags = {
+				environment = "prod"
+			}
+		}
+	`)
+	deny["AWS resource: \"aws_s3_bucket\" named \"invalid\" is missing required tags: {\"owner\"}"] with input as cfg
+}

--- a/examples/hcl2/terraform.tf
+++ b/examples/hcl2/terraform.tf
@@ -17,3 +17,13 @@ resource "azurerm_managed_disk" "source" {
     enabled = false
   }
 }
+
+resource "aws_s3_bucket" "valid" {
+  bucket = "validBucket"
+  acl    = "private"
+
+  tags = {
+    environment = "prod"
+    owner = "devops"
+  }
+}


### PR DESCRIPTION
This one extends the HCL tests with a scenario: "using rego, making sure all AWS resources are tagged so we can use them for tracking purposes/cost calculations". It was one of the cases that I'll present on [devconf.cz](https://www.devconf.info/cz/) which will be about OPA