### PR TITLE
ci: Bump Docker login to v3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
           args: check
 
       - name: login to docker hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_LOGIN }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
The current v1 is throwing warnings about using the deprecated `save-state` verb in GH Actions.