### PR TITLE
ci: Pin Goreleaser to v1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,10 @@ jobs:
       # Dockerhub to avoid having mismatches between what is in Dockerhub
       # and GitHub releases.
       - name: check releaser config
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: check
+          version: "~> v1"
 
       - name: login to docker hub
         uses: docker/login-action@v1
@@ -46,8 +47,9 @@ jobs:
           go-version: "1.22.x"
 
       - name: release
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           args: release --clean
+          version: "~> v1"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 1
+
 before:
   hooks:
   - go mod download


### PR DESCRIPTION
Goreleaser released v2 last month which is throwing warnings in CI. This pins us to v1 until we review the upgrade instructions.

https://goreleaser.com/blog/goreleaser-v2/#upgrading