### PR TITLE
ci: Bump golangci-lint action to v6

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,7 @@ jobs:
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 


### PR DESCRIPTION
https://github.com/open-policy-agent/conftest/pull/972 is currently blocked due to an issue with the linter.