### PR TITLE
fix: update regex to excape the dot in it

### DIFF
--- a/downloader/oci_detector.go
+++ b/downloader/oci_detector.go
@@ -30,12 +30,12 @@ func (d *OCIDetector) Detect(src, _ string) (string, bool, error) {
 
 func containsOCIRegistry(src string) bool {
 	matchRegistries := []*regexp.Regexp{
-		regexp.MustCompile("azurecr.io"),
-		regexp.MustCompile("gcr.io"),
-		regexp.MustCompile("registry.gitlab.com"),
-		regexp.MustCompile("pkg.dev"),
-		regexp.MustCompile("[0-9]{12}.dkr.ecr.[a-z0-9-]*.amazonaws.com"),
-		regexp.MustCompile("^quay.io"),
+		regexp.MustCompile(`azurecr\.io`),
+		regexp.MustCompile(`gcr\.io`),
+		regexp.MustCompile(`registry\.gitlab\.com`),
+		regexp.MustCompile(`pkg\.dev`),
+		regexp.MustCompile(`[0-9]{12}\.dkr\.ecr\.[a-z0-9-]*\.amazonaws\.com`),
+		regexp.MustCompile(`^quay\.io`),
 	}
 
 	for _, matchRegistry := range matchRegistries {


### PR DESCRIPTION
This is a PR to fix https://github.com/open-policy-agent/conftest/issues/971

The regex in oci_detector.go is not in correct format.

In regex, the dot . in domain should be escaped.
For example: ***.**, should be ***\.**

So that it'll match the . as a . string, but not any single character in regex.