### PR TITLE
fix : Missing space causing printing error on azuredevops.

### DIFF
--- a/output/azuredevops.go
+++ b/output/azuredevops.go
@@ -45,7 +45,7 @@ func (t *AzureDevOps) Output(checkResults []CheckResult) error {
 		}
 
 		for _, exception := range result.Exceptions {
-			fmt.Fprintf(t.writer, "##vso[task.logissuetype=warning] file=%v --> %v\n", result.FileName, exception.Message)
+			fmt.Fprintf(t.writer, "##vso[task.logissue type=warning] file=%v --> %v\n", result.FileName, exception.Message)
 		}
 
 		for _, skipped := range result.Skipped {


### PR DESCRIPTION
## Pull Request

### Description

I have identified a missing space that is causing a printing error on Azure DevOps. In the original file output\azuredevops.go, the message is ##vso[task.logissuetype=warning] without a space. My fix is to add a space, resulting in ##vso[task.logissue type=warning]. This should resolve the printing error on Azure DevOps.

**Changes proposed in this pull request:**
- Corrected the typo in output\azuredevops.go.

