### PR TITLE
 fix: Conftest can now successfully load files using a file URL (e.g., `file:///C:/path/to/data.yaml`) on windows

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -134,7 +134,9 @@ func LoadWithData(policyPaths []string, dataPaths []string, capabilities string,
 		return nil, fmt.Errorf("filter data paths: %w", err)
 	}
 
-	documents, err := loader.NewFileLoader().All(allDocumentPaths)
+	documents, err := loader.NewFileLoader().WithProcessAnnotation(true).Filtered(dataPaths, func(_ string, info os.FileInfo, _ int) bool {
+		return !info.IsDir() && !contains([]string{".yaml", ".yml", ".json"}, filepath.Ext(info.Name()))
+	})
 	if err != nil {
 		return nil, fmt.Errorf("load documents: %w", err)
 	}

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -134,7 +134,7 @@ func LoadWithData(policyPaths []string, dataPaths []string, capabilities string,
 		return nil, fmt.Errorf("filter data paths: %w", err)
 	}
 
-	documents, err := loader.NewFileLoader().WithProcessAnnotation(true).Filtered(dataPaths, func(_ string, info os.FileInfo, _ int) bool {
+	documents, err := loader.NewFileLoader().Filtered(dataPaths, func(_ string, info os.FileInfo, _ int) bool {
 		return !info.IsDir() && !contains([]string{".yaml", ".yml", ".json"}, filepath.Ext(info.Name()))
 	})
 	if err != nil {


### PR DESCRIPTION
  Conftest encounters errors on Windows when loading file paths that include drive letters (e.g., `C:/path/to/data.yaml`). Even when using a file URL (e.g., `file:///C:/path/to/data.yaml`), we still face issues.

![Screenshot 2024-08-30 at 10 31 39 AM](https://github.com/user-attachments/assets/90205133-54c4-4923-aaa9-16e37c61eae4)


 With these code changes, Conftest can now successfully load files using a file URL (e.g., `file:///C:/path/to/data.yaml`).
<img width="1093" alt="Screenshot 2024-09-03 at 5 10 00 PM" src="https://github.com/user-attachments/assets/8f525d0d-3575-4c42-802d-fc1a5f5405cd">


 We opted for file URLs(e.g., `file:///C:/path/to/data.yaml`) instead of paths with drive letters (e.g., `C:/path/to/data.yaml`) because OPA does not support file paths with drive letters. For more details, see [this issue comment](https://github.com/open-policy-agent/opa/pull/6922#issuecomment-2312969000).

Resolves: https://github.com/open-policy-agent/conftest/issues/979

@boranx Can you please review this changes? Thank you