### PR TITLE
bump: update go to 1.22 to get on par with toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-policy-agent/conftest
 
-go 1.21.0
+go 1.22
 
 toolchain go1.22.5
 


### PR DESCRIPTION
This updates _go_ version to `1.22`
It might also fix https://github.com/open-policy-agent/conftest/pull/994 as it was the only one diff if I clone the dependabot branch, then run `go mod tidy`

