### PR TITLE
chore: Bump Go to 1.23

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.22.x"
+          go-version: "1.23.x"
 
       - name: release
         uses: goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/open-policy-agent/conftest
 
-go 1.22
+go 1.23
 
-toolchain go1.22.5
+toolchain go1.23.1
 
 require (
 	cuelang.org/go v0.10.0


### PR DESCRIPTION
This aligns the CI systems to match the container version that was updated
in 6dff941f378e4e7a287eca791206c728d261acbe.

Signed-off-by: James Alseth <james@jalseth.me>