### PR TITLE
fix: make sure lookup_ip_addr throwing builtin-err in test

### DIFF
--- a/examples/builtin-errors/invalid-dns.rego
+++ b/examples/builtin-errors/invalid-dns.rego
@@ -1,5 +1,5 @@
 package main
 
 deny_dnsresolution["testing DNS resolution"] {
-  net.lookup_ip_addr("not-real-domain.xyz")
+  net.lookup_ip_addr("not-real-domainxyz")
 }


### PR DESCRIPTION
It looks like non-existent domains are no longer causing built-in-err for `lookup_ip_addr`, except the parse-related issues.
This PR makes sure `lookup_ip_addr` used in tests throws a parse error which causes _builtin-err_

It seems there's a regression on our test when the underlying name-resolution libs behavior changed after an opa/golang version update: https://github.com/open-policy-agent/opa/blob/main/docs/content/policy-reference.md#notes-on-name-resolution-netlookup_ip_addr

Addresses CI errors on: #1016 #1015 #1009 #1008 
