### PR TITLE
fix: tune jsonnet VM stack trace logging and add test coverage

### DIFF
--- a/parser/jsonnet/jsonnet.go
+++ b/parser/jsonnet/jsonnet.go
@@ -13,6 +13,8 @@ type Parser struct{}
 // Unmarshal unmarshals Jsonnet files.
 func (p *Parser) Unmarshal(data []byte, v interface{}) error {
 	vm := jsonnet.MakeVM()
+	vm.MaxStack = 500
+	vm.ErrorFormatter.SetMaxStackTraceSize(20)
 	snippetStream, err := vm.EvaluateAnonymousSnippet("", string(data))
 	if err != nil {
 		return fmt.Errorf("evaluate anonymous snippet: %w", err)

--- a/parser/jsonnet/jsonnet.go
+++ b/parser/jsonnet/jsonnet.go
@@ -13,7 +13,6 @@ type Parser struct{}
 // Unmarshal unmarshals Jsonnet files.
 func (p *Parser) Unmarshal(data []byte, v interface{}) error {
 	vm := jsonnet.MakeVM()
-	vm.MaxStack = 500
 	vm.ErrorFormatter.SetMaxStackTraceSize(20)
 	snippetStream, err := vm.EvaluateAnonymousSnippet("", string(data))
 	if err != nil {

--- a/parser/jsonnet/jsonnet_test.go
+++ b/parser/jsonnet/jsonnet_test.go
@@ -1,34 +1,125 @@
 package jsonnet
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestJsonnetParser(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    map[string]interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "basic jsonnet with self reference",
+			input: `{
+				person1: {
+					name: "Alice",
+					welcome: "Hello " + self.name + "!",
+				},
+				person2: self.person1 { name: "Bob" },
+			}`,
+			want: map[string]interface{}{
+				"person1": map[string]interface{}{
+					"name":    "Alice",
+					"welcome": "Hello Alice!",
+				},
+				"person2": map[string]interface{}{
+					"name":    "Bob",
+					"welcome": "Hello Bob!",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "arithmetic operations",
+			input: `{
+				a: 1 + 2,
+				b: 6 * 3,
+				c: 10 - 5,
+				d: 15 / 3,
+			}`,
+			want: map[string]interface{}{
+				"a": float64(3),
+				"b": float64(18),
+				"c": float64(5),
+				"d": float64(5),
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid jsonnet",
+			input:   `{ invalid syntax `,
+			want:    nil,
+			wantErr: true,
+			errMsg:  "evaluate anonymous snippet:",
+		},
+		{
+			name: "array and nested objects",
+			input: `{
+				numbers: [1, 2, 3],
+				nested: {
+					a: { b: { c: "deep" } },
+				},
+			}`,
+			want: map[string]interface{}{
+				"numbers": []interface{}{float64(1), float64(2), float64(3)},
+				"nested": map[string]interface{}{
+					"a": map[string]interface{}{
+						"b": map[string]interface{}{
+							"c": "deep",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "stack overflow prevention",
+			input: `
+				local recurse(x) =
+					if x == 0 then
+						0
+					else
+						recurse(x-1) + 1;
+				{ result: recurse(1000) }
+			`,
+			want:    nil,
+			wantErr: true,
+			errMsg:  "max stack frames exceeded",
+		},
+	}
+
 	parser := &Parser{}
 
-	// Example from Jsonnet(https://jsonnet.org/)
-	sample := `// Edit me!
-{
-  person1: {
-    name: "Alice",
-    welcome: "Hello " + self.name + "!",
-  },
-  person2: self.person1 { name: "Bob" },
-}`
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got interface{}
+			err := parser.Unmarshal([]byte(tt.input), &got)
 
-	var input interface{}
-	if err := parser.Unmarshal([]byte(sample), &input); err != nil {
-		t.Fatalf("parser should not have thrown an error: %v", err)
-	}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parser.Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 
-	if input == nil {
-		t.Error("there should be information parsed but its nil")
-	}
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error but got none")
+					return
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+				return
+			}
 
-	item := input.(map[string]interface{})
-
-	if len(item) == 0 {
-		t.Error("there should be at least one item defined in the parsed file, but none found")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parser.Unmarshal() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Set MaxStackTraceSize to 20 for cleaner errors
- Add test for stack overflow prevention
- Improve test structure with table-driven pattern