### PR TITLE
fix: prevent policy file overwrite on downloads

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -3,6 +3,8 @@ package downloader
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	getter "github.com/hashicorp/go-getter"
@@ -36,6 +38,13 @@ func Download(ctx context.Context, dst string, urls []string) error {
 		detectedURL, err := Detect(url, dst)
 		if err != nil {
 			return fmt.Errorf("detecting url: %w", err)
+		}
+
+		// Check if file already exists
+		filename := filepath.Base(detectedURL)
+		targetPath := filepath.Join(dst, filename)
+		if _, err := os.Stat(targetPath); err == nil {
+			return fmt.Errorf("policy file already exists at %s, refusing to overwrite", targetPath)
 		}
 
 		client := &getter.Client{

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -1,0 +1,62 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestDownloadFailsWhenFileExists(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a file that would conflict with the download
+	existingFile := filepath.Join(tmpDir, "policy.rego")
+	if err := os.WriteFile(existingFile, []byte("existing content"), os.FileMode(0600)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start a test HTTP server on an ephemeral port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			fmt.Fprint(w, "new content")
+		}),
+		ReadHeaderTimeout: 1 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- server.Serve(listener)
+	}()
+	defer server.Close()
+
+	// Try to download a policy file with the same name
+	urls := []string{fmt.Sprintf("http://%s/policy.rego", listener.Addr().String())}
+	downloadErr := Download(context.Background(), tmpDir, urls)
+
+	// Verify that download fails with the expected error
+	if downloadErr == nil {
+		t.Error("Expected download to fail when file exists, but it succeeded")
+	}
+	if downloadErr != nil && !filepath.IsAbs(existingFile) {
+		t.Errorf("Expected error message to contain absolute path, got: %v", downloadErr)
+	}
+
+	// Verify the original file is unchanged
+	content, err := os.ReadFile(existingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "existing content" {
+		t.Error("Existing file was modified")
+	}
+}


### PR DESCRIPTION
File existence check before downloading policies. Errors out and no overwrites. Maintains data integrity by preventing accidental policy overwrites.

Added a test which verifies the behaviour.

Fixes #957 