### PR TITLE
fix: add output and tests for GitHub and Azure DevOps

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -71,5 +71,6 @@ func Outputs() []string {
 		OutputTable,
 		OutputJUnit,
 		OutputGitHub,
+		OutputAzureDevOps,
 	}
 }

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -32,6 +32,14 @@ func TestGetOutputter(t *testing.T) {
 			expected: NewJUnit(os.Stdout, false),
 		},
 		{
+			input:    OutputGitHub,
+			expected: NewGitHub(os.Stdout),
+		},
+		{
+			input:    OutputAzureDevOps,
+			expected: NewAzureDevOps(os.Stdout),
+		},
+		{
 			input:    "unknown_format",
 			expected: NewStandard(os.Stdout),
 		},


### PR DESCRIPTION
I noticed the Azure DevOps output format is missing from the list of available test outputs:

```
  -o, --output string             Output format for conftest results - valid options are: [stdout json tap table junit github] (default "stdout")
```

Added it to the list of available output formats in `Outputs()`. Also added missing test cases for both GitHub and Azure DevOps output formats in `output_test.go`.