### PR TITLE
fix: remove redundant error check in push command

### DIFF
--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -141,9 +141,6 @@ func pushBundle(ctx context.Context, repository, policyPath, dataPath string) (*
 
 	configBytes := []byte("{}")
 	configDesc := content.NewDescriptorFromBytes(oras.MediaTypeUnknownConfig, configBytes)
-	if err != nil {
-		return nil, fmt.Errorf("serializing manifest conifg: %w", err)
-	}
 
 	if err := dest.Push(ctx, configDesc, bytes.NewReader(configBytes)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return nil, fmt.Errorf("pushing manifest conifg: %w", err)


### PR DESCRIPTION
Remove an unnecessary error check for configDesc creation in the push command. The NewDescriptorFromBytes function does not return an error, so checking for one was redundant and could never be triggered.