### PR TITLE
feat: Implement SARIF output

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -173,6 +173,7 @@ As of today Conftest supports the following output types:
 - JUnit `--output=junit`
 - GitHub `--output=github`
 - AzureDevOps `--output=azuredevops`
+- SARIF `--output=sarif`
 
 ### Plaintext
 
@@ -320,6 +321,71 @@ $ conftest test -o azuredevops -p examples/kubernetes/policy examples/kubernetes
 success file=examples/kubernetes/deployment.yaml 1
 ##[endgroup]
 5 tests, 1 passed, 0 warnings, 4 failures, 0 exceptions
+```
+
+### SARIF
+
+```console
+$ conftest test --proto-file-dirs examples/textproto/protos -p examples/textproto/policy examples/textproto/fail.textproto -o sarif
+{
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "conftest",
+          "informationUri": "https://github.com/open-policy-agent/conftest",
+          "rules": [
+            {
+              "id": "conftest-failure-main-deny",
+              "shortDescription": {
+                "text": "fail: Power level must be over 9000"
+              },
+              "properties": {
+                "namespace": "main",
+                "query": "data.main.deny"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "conftest-failure-main-deny",
+          "ruleIndex": 0,
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "text": "fail: Power level must be over 9000"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "examples/textproto/fail.textproto"
+                }
+              }
+            }
+          ],
+          "properties": {
+            "namespace": "main",
+            "query": "data.main.deny"
+          }
+        }
+      ],
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "exitCode": 1,
+          "exitCodeDescription": "Policy violations found",
+          "startTimeUtc": "2025-01-19T13:14:11Z",
+          "endTimeUtc": "2025-01-19T13:14:11Z"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ## `--parser`

--- a/docs/options.md
+++ b/docs/options.md
@@ -327,65 +327,7 @@ success file=examples/kubernetes/deployment.yaml 1
 
 ```console
 $ conftest test --proto-file-dirs examples/textproto/protos -p examples/textproto/policy examples/textproto/fail.textproto -o sarif
-{
-  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
-  "version": "2.1.0",
-  "runs": [
-    {
-      "tool": {
-        "driver": {
-          "name": "conftest",
-          "informationUri": "https://github.com/open-policy-agent/conftest",
-          "rules": [
-            {
-              "id": "conftest-failure-main-deny",
-              "shortDescription": {
-                "text": "fail: Power level must be over 9000"
-              },
-              "properties": {
-                "namespace": "main",
-                "query": "data.main.deny"
-              }
-            }
-          ]
-        }
-      },
-      "results": [
-        {
-          "ruleId": "conftest-failure-main-deny",
-          "ruleIndex": 0,
-          "kind": "fail",
-          "level": "error",
-          "message": {
-            "text": "fail: Power level must be over 9000"
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "examples/textproto/fail.textproto"
-                }
-              }
-            }
-          ],
-          "properties": {
-            "namespace": "main",
-            "query": "data.main.deny"
-          }
-        }
-      ],
-      "invocations": [
-        {
-          "executionSuccessful": true,
-          "exitCode": 1,
-          "exitCodeDescription": "Policy violations found",
-          "startTimeUtc": "2025-01-19T13:14:11Z",
-          "endTimeUtc": "2025-01-19T13:14:11Z"
-        }
-      ]
-    }
-  ]
-}
+{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"informationUri":"https://github.com/open-policy-agent/conftest","name":"conftest","rules":[{"id":"main/deny","shortDescription":{"text":"Policy violation"}}]}},"invocations":[{"executionSuccessful":true,"exitCode":1,"exitCodeDescription":"Policy violations found"}],"results":[{"ruleId":"main/deny","ruleIndex":0,"level":"error","message":{"text":"fail: Power level must be over 9000"},"locations":[{"physicalLocation":{"artifactLocation":{"uri":"examples/textproto/fail.textproto"}}}]}]}]}
 ```
 
 ## `--parser`

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
@@ -96,6 +97,7 @@ require (
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -97,7 +97,6 @@ require (
 	github.com/rivo/uniseg v0.4.2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
-	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1010,6 +1010,10 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/owenrumney/go-sarif v1.1.1 h1:QNObu6YX1igyFKhdzd7vgzmw7XsWN3/6NMGuDzBgXmE=
+github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
+github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
+github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
@@ -1149,6 +1153,7 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.6.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
+github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
@@ -1870,6 +1875,7 @@ google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8i
 google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=

--- a/output/output.go
+++ b/output/output.go
@@ -34,6 +34,7 @@ const (
 	OutputJUnit       = "junit"
 	OutputGitHub      = "github"
 	OutputAzureDevOps = "azuredevops"
+	OutputSARIF       = "sarif"
 )
 
 // Get returns a type that can render output in the given format.
@@ -57,6 +58,8 @@ func Get(format string, options Options) Outputter {
 		return NewGitHub(options.File)
 	case OutputAzureDevOps:
 		return NewAzureDevOps(options.File)
+	case OutputSARIF:
+		return NewSARIF(options.File)
 	default:
 		return NewStandard(options.File)
 	}
@@ -72,5 +75,6 @@ func Outputs() []string {
 		OutputJUnit,
 		OutputGitHub,
 		OutputAzureDevOps,
+		OutputSARIF,
 	}
 }

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -40,6 +40,10 @@ func TestGetOutputter(t *testing.T) {
 			expected: NewAzureDevOps(os.Stdout),
 		},
 		{
+			input:    OutputSARIF,
+			expected: NewSARIF(os.Stdout),
+		},
+		{
 			input:    "unknown_format",
 			expected: NewStandard(os.Stdout),
 		},

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -1,0 +1,496 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/open-policy-agent/opa/tester"
+)
+
+const (
+	// SARIF schema and version
+	sarifSchemaURI = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+	sarifVersion   = "2.1.0"
+
+	// Tool information
+	toolName = "conftest"
+	toolURI  = "https://github.com/open-policy-agent/conftest"
+
+	// SARIF levels
+	levelError   = "error"
+	levelWarning = "warning"
+	levelNote    = "note"
+	levelNone    = "none"
+
+	// SARIF kinds
+	kindFail    = "fail"
+	kindReview  = "review"
+	kindInfo    = "informational"
+	kindPass    = "pass"
+	kindSkipped = "notApplicable"
+
+	// Rule ID prefixes
+	ruleFailureBase   = "conftest-failure"
+	ruleWarningBase   = "conftest-warning"
+	ruleExceptionBase = "conftest-exception"
+	rulePassBase      = "conftest-pass"
+	ruleSkippedBase   = "conftest-skipped"
+
+	// Result descriptions
+	successDesc   = "Policy was satisfied successfully"
+	skippedDesc   = "Policy check was skipped"
+	failureDesc   = "Policy violation"
+	warningDesc   = "Policy warning"
+	exceptionDesc = "Policy exception"
+
+	// Exit code descriptions
+	exitNoViolations = "No policy violations found"
+	exitViolations   = "Policy violations found"
+	exitWarnings     = "Policy warnings found"
+	exitExceptions   = "Policy exceptions found"
+)
+
+// SARIF represents an Outputter that outputs results in SARIF format.
+// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
+type SARIF struct {
+	writer io.Writer
+}
+
+// NewSARIF creates a new SARIF with the given writer.
+func NewSARIF(w io.Writer) *SARIF {
+	return &SARIF{
+		writer: w,
+	}
+}
+
+// sarifReport represents the root object of a SARIF log file
+type sarifReport struct {
+	Schema  string     `json:"$schema"`
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+// sarifRun represents a single run of a tool
+type sarifRun struct {
+	Tool        sarifTool         `json:"tool"`
+	Results     []sarifResult     `json:"results"`
+	Invocations []sarifInvocation `json:"invocations"`
+}
+
+// sarifTool represents the analysis tool that was run
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+// sarifDriver represents the analysis tool component that contains rule metadata
+type sarifDriver struct {
+	Name           string      `json:"name"`
+	Version        string      `json:"version,omitempty"`
+	InformationURI string      `json:"informationUri"`
+	Rules          []sarifRule `json:"rules"`
+}
+
+// sarifRule represents a rule that was evaluated during the scan
+type sarifRule struct {
+	ID               string                 `json:"id"`
+	ShortDescription sarifMessage           `json:"shortDescription"`
+	FullDescription  *sarifMessage          `json:"fullDescription,omitempty"`
+	Help             *sarifMessage          `json:"help,omitempty"`
+	HelpURI          string                 `json:"helpUri,omitempty"`
+	Properties       map[string]interface{} `json:"properties,omitempty"`
+}
+
+// sarifResult represents a single analysis result
+type sarifResult struct {
+	RuleID     string                 `json:"ruleId"`
+	RuleIndex  int                    `json:"ruleIndex"`
+	Kind       string                 `json:"kind"`
+	Level      string                 `json:"level"`
+	Message    sarifMessage           `json:"message"`
+	Locations  []sarifLocation        `json:"locations"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
+}
+
+// sarifLocation represents a location within a programming artifact
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+// sarifPhysicalLocation represents the physical location where the result was detected
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+}
+
+// sarifArtifactLocation represents the location of an artifact
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+// sarifMessage represents a message string or message with arguments
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+// sarifInvocation represents the runtime environment of the analysis tool run
+type sarifInvocation struct {
+	ExecutionSuccessful bool   `json:"executionSuccessful"`
+	ExitCode            int    `json:"exitCode"`
+	ExitCodeDescription string `json:"exitCodeDescription"`
+	StartTimeUtc        string `json:"startTimeUtc"`
+	EndTimeUtc          string `json:"endTimeUtc"`
+}
+
+// resultKind represents the type of result being processed
+type resultKind int
+
+const (
+	resultKindSuccess resultKind = iota
+	resultKindSkipped
+	resultKindException
+	resultKindFailure
+	resultKindWarning
+)
+
+// resultType represents the type of result being processed
+type resultType struct {
+	kind         resultKind
+	ruleIDPrefix string
+	kindStr      string
+	level        string
+	description  string
+}
+
+var (
+	failureResultType = resultType{
+		kind:         resultKindFailure,
+		ruleIDPrefix: ruleFailureBase,
+		kindStr:      kindFail,
+		level:        levelError,
+		description:  failureDesc,
+	}
+	warningResultType = resultType{
+		kind:         resultKindWarning,
+		ruleIDPrefix: ruleWarningBase,
+		kindStr:      kindReview,
+		level:        levelWarning,
+		description:  warningDesc,
+	}
+	exceptionResultType = resultType{
+		kind:         resultKindException,
+		ruleIDPrefix: ruleExceptionBase,
+		kindStr:      kindInfo,
+		level:        levelNote,
+		description:  exceptionDesc,
+	}
+	successResultType = resultType{
+		kind:         resultKindSuccess,
+		ruleIDPrefix: rulePassBase,
+		kindStr:      kindPass,
+		level:        levelNone,
+		description:  successDesc,
+	}
+	skippedResultType = resultType{
+		kind:         resultKindSkipped,
+		ruleIDPrefix: ruleSkippedBase,
+		kindStr:      kindSkipped,
+		level:        levelNone,
+		description:  skippedDesc,
+	}
+)
+
+// getRuleID generates a unique rule ID based on metadata and result type
+func getRuleID(result Result, rType resultType, namespace string) string {
+	// Always use base ID for success, skipped, and exception results
+	switch rType.kind {
+	case resultKindSuccess, resultKindSkipped, resultKindException:
+		return rType.ruleIDPrefix
+	}
+
+	// Use package and rule from metadata when available
+	if pkg, ok := result.Metadata["package"].(string); ok {
+		if rule, ok := result.Metadata["rule"].(string); ok {
+			return fmt.Sprintf("%s/%s/%s", namespace, pkg, rule)
+		}
+	}
+
+	// Use query path if available
+	if query, ok := result.Metadata["query"].(string); ok {
+		// Remove "data." prefix and convert dots to dashes
+		query = strings.TrimPrefix(query, "data.")
+		query = strings.ReplaceAll(query, ".", "-")
+		return fmt.Sprintf("%s-%s", rType.ruleIDPrefix, query)
+	}
+
+	// Use description if available
+	if desc, ok := result.Metadata["description"].(string); ok {
+		return fmt.Sprintf("%s/%s", rType.ruleIDPrefix, strings.ToLower(strings.ReplaceAll(desc, " ", "-")))
+	}
+
+	// Fallback to base ID if no identifying information is available
+	return rType.ruleIDPrefix
+}
+
+// createRule creates a new SARIF rule from a result
+func createRule(result Result, rType resultType, namespace string) sarifRule {
+	ruleID := getRuleID(result, rType, namespace)
+
+	rule := sarifRule{
+		ID: ruleID,
+		ShortDescription: sarifMessage{
+			Text: result.Message,
+		},
+		Properties: make(map[string]interface{}),
+	}
+
+	// Add policy metadata to rule properties
+	if pkg, ok := result.Metadata["package"].(string); ok {
+		rule.Properties["package"] = pkg
+	}
+	if ruleName, ok := result.Metadata["rule"].(string); ok {
+		rule.Properties["rule"] = ruleName
+	}
+	if query, ok := result.Metadata["query"].(string); ok {
+		rule.Properties["query"] = query
+	}
+	rule.Properties["namespace"] = namespace
+
+	// Add additional rule metadata if available
+	if desc, ok := result.Metadata["description"].(string); ok {
+		rule.FullDescription = &sarifMessage{Text: desc}
+	}
+	if url, ok := result.Metadata["url"].(string); ok {
+		rule.HelpURI = url
+	}
+	if help, ok := result.Metadata["help"].(string); ok {
+		rule.Help = &sarifMessage{Text: help}
+	}
+
+	// Add any remaining metadata to properties
+	for k, v := range result.Metadata {
+		switch k {
+		case "package", "rule", "description", "url", "help", "query":
+			// Skip already processed fields
+			continue
+		default:
+			rule.Properties[k] = v
+		}
+	}
+
+	return rule
+}
+
+// createLocation creates a new SARIF location from a file path
+func createLocation(filePath string) sarifLocation {
+	return sarifLocation{
+		PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{
+				URI: filepath.ToSlash(filePath),
+			},
+		},
+	}
+}
+
+// createProperties creates a new properties map with namespace information
+func createProperties(metadata map[string]interface{}, namespace string) map[string]interface{} {
+	properties := make(map[string]interface{})
+	for k, v := range metadata {
+		switch k {
+		case "package", "rule", "description", "url", "help":
+			// Skip rule-level metadata
+			continue
+		case "query", "traces", "outputs":
+			// Include query-related information
+			properties[k] = v
+		default:
+			properties[k] = v
+		}
+	}
+
+	// Always include namespace
+	properties["namespace"] = namespace
+
+	return properties
+}
+
+// processResults processes a slice of results and adds them to the SARIF run
+func processResults(run *sarifRun, results []Result, rType resultType, fileName, namespace string, ruleMap map[string]bool) error {
+	for _, result := range results {
+		// Create or get rule
+		rule := createRule(result, rType, namespace)
+		if !ruleMap[rule.ID] {
+			run.Tool.Driver.Rules = append(run.Tool.Driver.Rules, rule)
+			ruleMap[rule.ID] = true
+		}
+
+		// Find rule index
+		ruleIndex := -1
+		for i, r := range run.Tool.Driver.Rules {
+			if r.ID == rule.ID {
+				ruleIndex = i
+				break
+			}
+		}
+
+		if ruleIndex == -1 {
+			return fmt.Errorf("rule %s not found in rules array after being added", rule.ID)
+		}
+
+		// Create result
+		run.Results = append(run.Results, sarifResult{
+			RuleID:     rule.ID,
+			RuleIndex:  ruleIndex,
+			Kind:       rType.kindStr,
+			Level:      rType.level,
+			Message:    sarifMessage{Text: result.Message},
+			Locations:  []sarifLocation{createLocation(fileName)},
+			Properties: createProperties(result.Metadata, namespace),
+		})
+	}
+	return nil
+}
+
+// createSuccessResult creates a success result for a given file and namespace
+func createSuccessResult(run *sarifRun, fileName, namespace string, ruleMap map[string]bool) error {
+	result := Result{
+		Message: successResultType.description,
+	}
+	return processResults(run, []Result{result}, successResultType, fileName, namespace, ruleMap)
+}
+
+// createSkippedResult creates a skipped result for a given file and namespace
+func createSkippedResult(run *sarifRun, fileName, namespace string, ruleMap map[string]bool) error {
+	result := Result{
+		Message: skippedResultType.description,
+	}
+	return processResults(run, []Result{result}, skippedResultType, fileName, namespace, ruleMap)
+}
+
+// Output outputs the results in SARIF format.
+func (s *SARIF) Output(results []CheckResult) error {
+	startTime := time.Now().UTC()
+
+	// Create SARIF report structure
+	report := sarifReport{
+		Schema:  sarifSchemaURI,
+		Version: sarifVersion,
+		Runs: []sarifRun{
+			{
+				Tool: sarifTool{
+					Driver: sarifDriver{
+						Name:           toolName,
+						InformationURI: toolURI,
+						Rules:          []sarifRule{},
+					},
+				},
+				Results:     []sarifResult{},
+				Invocations: []sarifInvocation{},
+			},
+		},
+	}
+
+	run := &report.Runs[0]
+	ruleMap := make(map[string]bool)
+
+	// Process all results
+	for _, result := range results {
+		err := processResults(run, result.Failures, failureResultType, result.FileName, result.Namespace, ruleMap)
+		if err != nil {
+			return fmt.Errorf("process failures: %w", err)
+		}
+		err = processResults(run, result.Warnings, warningResultType, result.FileName, result.Namespace, ruleMap)
+		if err != nil {
+			return fmt.Errorf("process warnings: %w", err)
+		}
+		err = processResults(run, result.Exceptions, exceptionResultType, result.FileName, result.Namespace, ruleMap)
+		if err != nil {
+			return fmt.Errorf("process exceptions: %w", err)
+		}
+
+		// Add success result if no failures/warnings/exceptions
+		if len(result.Failures) == 0 && len(result.Warnings) == 0 && len(result.Exceptions) == 0 {
+			if result.Successes > 0 {
+				err = createSuccessResult(run, result.FileName, result.Namespace, ruleMap)
+				if err != nil {
+					return fmt.Errorf("create success result: %w", err)
+				}
+			} else {
+				err = createSkippedResult(run, result.FileName, result.Namespace, ruleMap)
+				if err != nil {
+					return fmt.Errorf("create skipped result: %w", err)
+				}
+			}
+		}
+	}
+
+	// Add invocation information
+	exitCode := 0
+	exitDesc := exitNoViolations
+	if hasFailures(results) {
+		exitCode = 1
+		exitDesc = exitViolations
+	} else if hasWarnings(results) {
+		exitCode = 0
+		exitDesc = exitWarnings
+	} else if hasExceptions(results) {
+		exitCode = 0
+		exitDesc = exitExceptions
+	}
+
+	run.Invocations = []sarifInvocation{
+		{
+			ExecutionSuccessful: true,
+			ExitCode:            exitCode,
+			ExitCodeDescription: exitDesc,
+			StartTimeUtc:        startTime.Format(time.RFC3339),
+			EndTimeUtc:          time.Now().UTC().Format(time.RFC3339),
+		},
+	}
+
+	// Marshal to JSON
+	encoder := json.NewEncoder(s.writer)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("encode sarif: %w", err)
+	}
+
+	return nil
+}
+
+// Report is not supported in SARIF output
+func (s *SARIF) Report(_ []*tester.Result, _ string) error {
+	return fmt.Errorf("report is not supported in SARIF output")
+}
+
+// hasFailures returns true if any of the results contain failures
+func hasFailures(results []CheckResult) bool {
+	for _, result := range results {
+		if len(result.Failures) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasWarnings returns true if any of the results contain warnings
+func hasWarnings(results []CheckResult) bool {
+	for _, result := range results {
+		if len(result.Warnings) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasExceptions returns true if any of the results contain exceptions
+func hasExceptions(results []CheckResult) bool {
+	for _, result := range results {
+		if len(result.Exceptions) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -1,44 +1,21 @@
 package output
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/open-policy-agent/opa/tester"
+	"github.com/owenrumney/go-sarif/v2/sarif"
+	"golang.org/x/exp/slices"
 )
 
 const (
-	// SARIF schema and version
-	sarifSchemaURI = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
-	sarifVersion   = "2.1.0"
-
 	// Tool information
-	toolName = "conftest"
-	toolURI  = "https://github.com/open-policy-agent/conftest"
-
-	// SARIF levels
-	levelError   = "error"
-	levelWarning = "warning"
-	levelNote    = "note"
-	levelNone    = "none"
-
-	// SARIF kinds
-	kindFail    = "fail"
-	kindReview  = "review"
-	kindInfo    = "informational"
-	kindPass    = "pass"
-	kindSkipped = "notApplicable"
-
-	// Rule ID prefixes
-	ruleFailureBase   = "conftest-failure"
-	ruleWarningBase   = "conftest-warning"
-	ruleExceptionBase = "conftest-exception"
-	rulePassBase      = "conftest-pass"
-	ruleSkippedBase   = "conftest-skipped"
+	toolName     = "conftest"
+	toolURI      = "https://github.com/open-policy-agent/conftest"
+	sarifVersion = sarif.Version210
 
 	// Result descriptions
 	successDesc   = "Policy was satisfied successfully"
@@ -55,7 +32,6 @@ const (
 )
 
 // SARIF represents an Outputter that outputs results in SARIF format.
-// https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html
 type SARIF struct {
 	writer io.Writer
 }
@@ -67,397 +43,206 @@ func NewSARIF(w io.Writer) *SARIF {
 	}
 }
 
-// sarifReport represents the root object of a SARIF log file
-type sarifReport struct {
-	Schema  string     `json:"$schema"`
-	Version string     `json:"version"`
-	Runs    []sarifRun `json:"runs"`
+// getRuleID generates a stable rule ID based on namespace and rule type
+func getRuleID(namespace string, ruleType string) string {
+	return fmt.Sprintf("%s/%s", namespace, ruleType)
 }
 
-// sarifRun represents a single run of a tool
-type sarifRun struct {
-	Tool        sarifTool         `json:"tool"`
-	Results     []sarifResult     `json:"results"`
-	Invocations []sarifInvocation `json:"invocations"`
-}
-
-// sarifTool represents the analysis tool that was run
-type sarifTool struct {
-	Driver sarifDriver `json:"driver"`
-}
-
-// sarifDriver represents the analysis tool component that contains rule metadata
-type sarifDriver struct {
-	Name           string      `json:"name"`
-	Version        string      `json:"version,omitempty"`
-	InformationURI string      `json:"informationUri"`
-	Rules          []sarifRule `json:"rules"`
-}
-
-// sarifRule represents a rule that was evaluated during the scan
-type sarifRule struct {
-	ID               string                 `json:"id"`
-	ShortDescription sarifMessage           `json:"shortDescription"`
-	FullDescription  *sarifMessage          `json:"fullDescription,omitempty"`
-	Help             *sarifMessage          `json:"help,omitempty"`
-	HelpURI          string                 `json:"helpUri,omitempty"`
-	Properties       map[string]interface{} `json:"properties,omitempty"`
-}
-
-// sarifResult represents a single analysis result
-type sarifResult struct {
-	RuleID     string                 `json:"ruleId"`
-	RuleIndex  int                    `json:"ruleIndex"`
-	Kind       string                 `json:"kind"`
-	Level      string                 `json:"level"`
-	Message    sarifMessage           `json:"message"`
-	Locations  []sarifLocation        `json:"locations"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
-}
-
-// sarifLocation represents a location within a programming artifact
-type sarifLocation struct {
-	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
-}
-
-// sarifPhysicalLocation represents the physical location where the result was detected
-type sarifPhysicalLocation struct {
-	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
-}
-
-// sarifArtifactLocation represents the location of an artifact
-type sarifArtifactLocation struct {
-	URI string `json:"uri"`
-}
-
-// sarifMessage represents a message string or message with arguments
-type sarifMessage struct {
-	Text string `json:"text"`
-}
-
-// sarifInvocation represents the runtime environment of the analysis tool run
-type sarifInvocation struct {
-	ExecutionSuccessful bool   `json:"executionSuccessful"`
-	ExitCode            int    `json:"exitCode"`
-	ExitCodeDescription string `json:"exitCodeDescription"`
-	StartTimeUtc        string `json:"startTimeUtc"`
-	EndTimeUtc          string `json:"endTimeUtc"`
-}
-
-// resultKind represents the type of result being processed
-type resultKind int
-
-const (
-	resultKindSuccess resultKind = iota
-	resultKindSkipped
-	resultKindException
-	resultKindFailure
-	resultKindWarning
-)
-
-// resultType represents the type of result being processed
-type resultType struct {
-	kind         resultKind
-	ruleIDPrefix string
-	kindStr      string
-	level        string
-	description  string
-}
-
-var (
-	failureResultType = resultType{
-		kind:         resultKindFailure,
-		ruleIDPrefix: ruleFailureBase,
-		kindStr:      kindFail,
-		level:        levelError,
-		description:  failureDesc,
-	}
-	warningResultType = resultType{
-		kind:         resultKindWarning,
-		ruleIDPrefix: ruleWarningBase,
-		kindStr:      kindReview,
-		level:        levelWarning,
-		description:  warningDesc,
-	}
-	exceptionResultType = resultType{
-		kind:         resultKindException,
-		ruleIDPrefix: ruleExceptionBase,
-		kindStr:      kindInfo,
-		level:        levelNote,
-		description:  exceptionDesc,
-	}
-	successResultType = resultType{
-		kind:         resultKindSuccess,
-		ruleIDPrefix: rulePassBase,
-		kindStr:      kindPass,
-		level:        levelNone,
-		description:  successDesc,
-	}
-	skippedResultType = resultType{
-		kind:         resultKindSkipped,
-		ruleIDPrefix: ruleSkippedBase,
-		kindStr:      kindSkipped,
-		level:        levelNone,
-		description:  skippedDesc,
-	}
-)
-
-// getRuleID generates a unique rule ID based on metadata and result type
-func getRuleID(result Result, rType resultType, namespace string) string {
-	// Always use base ID for success, skipped, and exception results
-	switch rType.kind {
-	case resultKindSuccess, resultKindSkipped, resultKindException:
-		return rType.ruleIDPrefix
-	}
-
-	// Use package and rule from metadata when available
-	if pkg, ok := result.Metadata["package"].(string); ok {
-		if rule, ok := result.Metadata["rule"].(string); ok {
-			return fmt.Sprintf("%s/%s/%s", namespace, pkg, rule)
-		}
-	}
-
-	// Use query path if available
-	if query, ok := result.Metadata["query"].(string); ok {
-		// Remove "data." prefix and convert dots to dashes
-		query = strings.TrimPrefix(query, "data.")
-		query = strings.ReplaceAll(query, ".", "-")
-		return fmt.Sprintf("%s-%s", rType.ruleIDPrefix, query)
-	}
-
-	// Use description if available
-	if desc, ok := result.Metadata["description"].(string); ok {
-		return fmt.Sprintf("%s/%s", rType.ruleIDPrefix, strings.ToLower(strings.ReplaceAll(desc, " ", "-")))
-	}
-
-	// Fallback to base ID if no identifying information is available
-	return rType.ruleIDPrefix
-}
-
-// createRule creates a new SARIF rule from a result
-func createRule(result Result, rType resultType, namespace string) sarifRule {
-	ruleID := getRuleID(result, rType, namespace)
-
-	rule := sarifRule{
-		ID: ruleID,
-		ShortDescription: sarifMessage{
-			Text: result.Message,
-		},
-		Properties: make(map[string]interface{}),
-	}
-
-	// Add policy metadata to rule properties
-	if pkg, ok := result.Metadata["package"].(string); ok {
-		rule.Properties["package"] = pkg
-	}
-	if ruleName, ok := result.Metadata["rule"].(string); ok {
-		rule.Properties["rule"] = ruleName
-	}
-	if query, ok := result.Metadata["query"].(string); ok {
-		rule.Properties["query"] = query
-	}
-	rule.Properties["namespace"] = namespace
-
-	// Add additional rule metadata if available
-	if desc, ok := result.Metadata["description"].(string); ok {
-		rule.FullDescription = &sarifMessage{Text: desc}
-	}
-	if url, ok := result.Metadata["url"].(string); ok {
-		rule.HelpURI = url
-	}
-	if help, ok := result.Metadata["help"].(string); ok {
-		rule.Help = &sarifMessage{Text: help}
-	}
-
-	// Add any remaining metadata to properties
-	for k, v := range result.Metadata {
-		switch k {
-		case "package", "rule", "description", "url", "help", "query":
-			// Skip already processed fields
-			continue
-		default:
-			rule.Properties[k] = v
-		}
-	}
-
-	return rule
-}
-
-// createLocation creates a new SARIF location from a file path
-func createLocation(filePath string) sarifLocation {
-	return sarifLocation{
-		PhysicalLocation: sarifPhysicalLocation{
-			ArtifactLocation: sarifArtifactLocation{
-				URI: filepath.ToSlash(filePath),
-			},
-		},
+// getRuleDescription returns the appropriate description based on the rule type
+func getRuleDescription(ruleID string) string {
+	switch {
+	case strings.HasSuffix(ruleID, "/success"):
+		return successDesc
+	case strings.HasSuffix(ruleID, "/skip"):
+		return skippedDesc
+	case strings.HasSuffix(ruleID, "/allow"):
+		return exceptionDesc
+	case strings.HasSuffix(ruleID, "/warn"):
+		return warningDesc
+	default:
+		return failureDesc
 	}
 }
 
-// createProperties creates a new properties map with namespace information
-func createProperties(metadata map[string]interface{}, namespace string) map[string]interface{} {
-	properties := make(map[string]interface{})
-	for k, v := range metadata {
-		switch k {
-		case "package", "rule", "description", "url", "help":
-			// Skip rule-level metadata
-			continue
-		case "query", "traces", "outputs":
-			// Include query-related information
-			properties[k] = v
-		default:
-			properties[k] = v
-		}
-	}
-
-	// Always include namespace
-	properties["namespace"] = namespace
-
-	return properties
+// getRuleIndex returns the index for a rule if it exists in the indices map.
+// The bool return indicates if the rule was found.
+func getRuleIndex(ruleID string, indices map[string]int) (int, bool) {
+	idx, ok := indices[ruleID]
+	return idx, ok
 }
 
-// processResults processes a slice of results and adds them to the SARIF run
-func processResults(run *sarifRun, results []Result, rType resultType, fileName, namespace string, ruleMap map[string]bool) error {
-	for _, result := range results {
-		// Create or get rule
-		rule := createRule(result, rType, namespace)
-		if !ruleMap[rule.ID] {
-			run.Tool.Driver.Rules = append(run.Tool.Driver.Rules, rule)
-			ruleMap[rule.ID] = true
-		}
+// addRuleIndex adds a new rule to the SARIF run and returns its index.
+func addRuleIndex(run *sarif.Run, ruleID string, result Result, indices map[string]int) int {
+	addRule(run, ruleID, result)
+	idx := len(run.Tool.Driver.Rules) - 1
+	indices[ruleID] = idx
+	return idx
+}
 
-		// Find rule index
-		ruleIndex := -1
-		for i, r := range run.Tool.Driver.Rules {
-			if r.ID == rule.ID {
-				ruleIndex = i
-				break
-			}
-		}
-
-		if ruleIndex == -1 {
-			return fmt.Errorf("rule %s not found in rules array after being added", rule.ID)
-		}
-
-		// Create result
-		run.Results = append(run.Results, sarifResult{
-			RuleID:     rule.ID,
-			RuleIndex:  ruleIndex,
-			Kind:       rType.kindStr,
-			Level:      rType.level,
-			Message:    sarifMessage{Text: result.Message},
-			Locations:  []sarifLocation{createLocation(fileName)},
-			Properties: createProperties(result.Metadata, namespace),
+// addRule adds a new rule to the SARIF run with the given ID and result metadata.
+func addRule(run *sarif.Run, ruleID string, result Result) {
+	desc := getRuleDescription(ruleID)
+	rule := run.AddRule(ruleID).
+		WithDescription(desc).
+		WithShortDescription(&sarif.MultiformatMessageString{
+			Text: &desc,
 		})
-	}
-	return nil
-}
 
-// createSuccessResult creates a success result for a given file and namespace
-func createSuccessResult(run *sarifRun, fileName, namespace string, ruleMap map[string]bool) error {
-	result := Result{
-		Message: successResultType.description,
+	if result.Metadata != nil {
+		props := sarif.NewPropertyBag()
+		for k, v := range result.Metadata {
+			props.Add(k, v)
+		}
+		rule.WithProperties(props.Properties)
 	}
-	return processResults(run, []Result{result}, successResultType, fileName, namespace, ruleMap)
-}
-
-// createSkippedResult creates a skipped result for a given file and namespace
-func createSkippedResult(run *sarifRun, fileName, namespace string, ruleMap map[string]bool) error {
-	result := Result{
-		Message: skippedResultType.description,
-	}
-	return processResults(run, []Result{result}, skippedResultType, fileName, namespace, ruleMap)
 }
 
 // Output outputs the results in SARIF format.
 func (s *SARIF) Output(results []CheckResult) error {
-	startTime := time.Now().UTC()
-
-	// Create SARIF report structure
-	report := sarifReport{
-		Schema:  sarifSchemaURI,
-		Version: sarifVersion,
-		Runs: []sarifRun{
-			{
-				Tool: sarifTool{
-					Driver: sarifDriver{
-						Name:           toolName,
-						InformationURI: toolURI,
-						Rules:          []sarifRule{},
-					},
-				},
-				Results:     []sarifResult{},
-				Invocations: []sarifInvocation{},
-			},
-		},
+	report, err := sarif.New(sarifVersion)
+	if err != nil {
+		return fmt.Errorf("create sarif report: %w", err)
 	}
 
-	run := &report.Runs[0]
-	ruleMap := make(map[string]bool)
+	run := sarif.NewRunWithInformationURI(toolName, toolURI)
+	indices := make(map[string]int)
 
-	// Process all results
 	for _, result := range results {
-		err := processResults(run, result.Failures, failureResultType, result.FileName, result.Namespace, ruleMap)
-		if err != nil {
-			return fmt.Errorf("process failures: %w", err)
-		}
-		err = processResults(run, result.Warnings, warningResultType, result.FileName, result.Namespace, ruleMap)
-		if err != nil {
-			return fmt.Errorf("process warnings: %w", err)
-		}
-		err = processResults(run, result.Exceptions, exceptionResultType, result.FileName, result.Namespace, ruleMap)
-		if err != nil {
-			return fmt.Errorf("process exceptions: %w", err)
+		// Process failures
+		for _, failure := range result.Failures {
+			ruleID := getRuleID(result.Namespace, "deny")
+			var idx int
+			if existingIdx, ok := getRuleIndex(ruleID, indices); ok {
+				idx = existingIdx
+			} else {
+				idx = addRuleIndex(run, ruleID, failure, indices)
+			}
+
+			run.CreateResultForRule(ruleID).
+				WithRuleIndex(idx).
+				WithLevel("error").
+				WithMessage(sarif.NewTextMessage(failure.Message)).
+				AddLocation(
+					sarif.NewLocationWithPhysicalLocation(
+						sarif.NewPhysicalLocation().
+							WithArtifactLocation(
+								sarif.NewSimpleArtifactLocation(filepath.ToSlash(result.FileName)),
+							),
+					),
+				)
 		}
 
-		// Add success result if no failures/warnings/exceptions
-		if len(result.Failures) == 0 && len(result.Warnings) == 0 && len(result.Exceptions) == 0 {
-			if result.Successes > 0 {
-				err = createSuccessResult(run, result.FileName, result.Namespace, ruleMap)
-				if err != nil {
-					return fmt.Errorf("create success result: %w", err)
-				}
+		// Process warnings
+		for _, warning := range result.Warnings {
+			ruleID := getRuleID(result.Namespace, "warn")
+			var idx int
+			if existingIdx, ok := getRuleIndex(ruleID, indices); ok {
+				idx = existingIdx
 			} else {
-				err = createSkippedResult(run, result.FileName, result.Namespace, ruleMap)
-				if err != nil {
-					return fmt.Errorf("create skipped result: %w", err)
-				}
+				idx = addRuleIndex(run, ruleID, warning, indices)
 			}
+
+			run.CreateResultForRule(ruleID).
+				WithRuleIndex(idx).
+				WithLevel("warning").
+				WithMessage(sarif.NewTextMessage(warning.Message)).
+				AddLocation(
+					sarif.NewLocationWithPhysicalLocation(
+						sarif.NewPhysicalLocation().
+							WithArtifactLocation(
+								sarif.NewSimpleArtifactLocation(filepath.ToSlash(result.FileName)),
+							),
+					),
+				)
+		}
+
+		// Process exceptions
+		for _, exception := range result.Exceptions {
+			ruleID := getRuleID(result.Namespace, "allow")
+			var idx int
+			if existingIdx, ok := getRuleIndex(ruleID, indices); ok {
+				idx = existingIdx
+			} else {
+				idx = addRuleIndex(run, ruleID, exception, indices)
+			}
+
+			run.CreateResultForRule(ruleID).
+				WithRuleIndex(idx).
+				WithLevel("note").
+				WithMessage(sarif.NewTextMessage(exception.Message)).
+				AddLocation(
+					sarif.NewLocationWithPhysicalLocation(
+						sarif.NewPhysicalLocation().
+							WithArtifactLocation(
+								sarif.NewSimpleArtifactLocation(filepath.ToSlash(result.FileName)),
+							),
+					),
+				)
+		}
+
+		// Add success or skipped result if no other results
+		if len(result.Failures) == 0 && len(result.Warnings) == 0 && len(result.Exceptions) == 0 {
+			text := successDesc
+			ruleType := "success"
+			if result.Successes == 0 {
+				text = skippedDesc
+				ruleType = "skip"
+			}
+
+			emptyResult := Result{
+				Message: text,
+				Metadata: map[string]interface{}{
+					"description": text,
+				},
+			}
+			ruleID := getRuleID(result.Namespace, ruleType)
+			var idx int
+			if existingIdx, ok := getRuleIndex(ruleID, indices); ok {
+				idx = existingIdx
+			} else {
+				idx = addRuleIndex(run, ruleID, emptyResult, indices)
+			}
+
+			run.CreateResultForRule(ruleID).
+				WithRuleIndex(idx).
+				WithLevel("none").
+				WithMessage(sarif.NewTextMessage(text)).
+				AddLocation(
+					sarif.NewLocationWithPhysicalLocation(
+						sarif.NewPhysicalLocation().
+							WithArtifactLocation(
+								sarif.NewSimpleArtifactLocation(filepath.ToSlash(result.FileName)),
+							),
+					),
+				)
 		}
 	}
 
-	// Add invocation information
+	// Add run metadata
 	exitCode := 0
 	exitDesc := exitNoViolations
 	if hasFailures(results) {
 		exitCode = 1
 		exitDesc = exitViolations
 	} else if hasWarnings(results) {
-		exitCode = 0
 		exitDesc = exitWarnings
 	} else if hasExceptions(results) {
-		exitCode = 0
 		exitDesc = exitExceptions
 	}
 
-	run.Invocations = []sarifInvocation{
-		{
-			ExecutionSuccessful: true,
-			ExitCode:            exitCode,
-			ExitCodeDescription: exitDesc,
-			StartTimeUtc:        startTime.Format(time.RFC3339),
-			EndTimeUtc:          time.Now().UTC().Format(time.RFC3339),
-		},
-	}
+	successful := true
+	invocation := sarif.NewInvocation()
+	invocation.ExecutionSuccessful = &successful
+	invocation.ExitCode = &exitCode
+	invocation.ExitCodeDescription = &exitDesc
 
-	// Marshal to JSON
-	encoder := json.NewEncoder(s.writer)
-	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(report); err != nil {
-		return fmt.Errorf("encode sarif: %w", err)
-	}
+	run.Invocations = []*sarif.Invocation{invocation}
 
-	return nil
+	// Add the run to the report
+	report.AddRun(run)
+
+	// Write the report
+	return report.Write(s.writer)
 }
 
 // Report is not supported in SARIF output
@@ -465,32 +250,33 @@ func (s *SARIF) Report(_ []*tester.Result, _ string) error {
 	return fmt.Errorf("report is not supported in SARIF output")
 }
 
+// hasResults returns true if any of the results contain items in the specified field
+func hasResults(results []CheckResult, field string) bool {
+	return slices.ContainsFunc(results, func(r CheckResult) bool {
+		switch field {
+		case "failures":
+			return len(r.Failures) > 0
+		case "warnings":
+			return len(r.Warnings) > 0
+		case "exceptions":
+			return len(r.Exceptions) > 0
+		default:
+			return false
+		}
+	})
+}
+
 // hasFailures returns true if any of the results contain failures
 func hasFailures(results []CheckResult) bool {
-	for _, result := range results {
-		if len(result.Failures) > 0 {
-			return true
-		}
-	}
-	return false
+	return hasResults(results, "failures")
 }
 
 // hasWarnings returns true if any of the results contain warnings
 func hasWarnings(results []CheckResult) bool {
-	for _, result := range results {
-		if len(result.Warnings) > 0 {
-			return true
-		}
-	}
-	return false
+	return hasResults(results, "warnings")
 }
 
 // hasExceptions returns true if any of the results contain exceptions
 func hasExceptions(results []CheckResult) bool {
-	for _, result := range results {
-		if len(result.Exceptions) > 0 {
-			return true
-		}
-	}
-	return false
+	return hasResults(results, "exceptions")
 }

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSARIF_Output(t *testing.T) {
@@ -18,29 +18,29 @@ func TestSARIF_Output(t *testing.T) {
 		{
 			name:    "empty results",
 			results: []CheckResult{},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": []
-							}
+								"name":           "conftest",
+								"rules":          []any{},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 0,
-								"exitCodeDescription": "No policy violations found"
-							}
-						],
-						"results": []
-					}
-				]
-			}`,
+								"exitCode":            0,
+								"exitCodeDescription": "No policy violations found",
+							},
+						},
+						"results": []any{},
+					},
+				},
+			}),
 		},
 		{
 			name: "single failure",
@@ -59,58 +59,58 @@ func TestSARIF_Output(t *testing.T) {
 					},
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/deny",
-										"shortDescription": {
-											"text": "Policy violation"
+										"shortDescription": map[string]any{
+											"text": "Policy violation",
 										},
-										"properties": {
+										"properties": map[string]any{
 											"package": "test",
-											"rule": "rule1"
-										}
-									}
-								]
-							}
+											"rule":    "rule1",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 1,
-								"exitCodeDescription": "Policy violations found"
-							}
-						],
-						"results": [
+								"exitCode":            1,
+								"exitCodeDescription": "Policy violations found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/deny",
+								"ruleId":    "main/deny",
 								"ruleIndex": 0,
-								"level": "error",
-								"message": {
-									"text": "test failure"
+								"level":     "error",
+								"message": map[string]any{
+									"text": "test failure",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		{
 			name: "single warning",
@@ -128,57 +128,57 @@ func TestSARIF_Output(t *testing.T) {
 					},
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/warn",
-										"shortDescription": {
-											"text": "Policy warning"
+										"shortDescription": map[string]any{
+											"text": "Policy warning",
 										},
-										"properties": {
-											"foo": "bar"
-										}
-									}
-								]
-							}
+										"properties": map[string]any{
+											"foo": "bar",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 0,
-								"exitCodeDescription": "Policy warnings found"
-							}
-						],
-						"results": [
+								"exitCode":            0,
+								"exitCodeDescription": "Policy warnings found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/warn",
+								"ruleId":    "main/warn",
 								"ruleIndex": 0,
-								"level": "warning",
-								"message": {
-									"text": "test warning"
+								"level":     "warning",
+								"message": map[string]any{
+									"text": "test warning",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		{
 			name: "single exception",
@@ -196,57 +196,83 @@ func TestSARIF_Output(t *testing.T) {
 					},
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/allow",
-										"shortDescription": {
-											"text": "Policy exception"
+										"shortDescription": map[string]any{
+											"text": "Policy exception",
 										},
-										"properties": {
-											"description": "test exception description"
-										}
-									}
-								]
-							}
+										"properties": map[string]any{
+											"description": "test exception description",
+										},
+									},
+									{
+										"id": "main/success",
+										"shortDescription": map[string]any{
+											"text": "Policy was satisfied successfully",
+										},
+										"properties": map[string]any{
+											"description": "Policy was satisfied successfully",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 0,
-								"exitCodeDescription": "Policy exceptions found"
-							}
-						],
-						"results": [
+								"exitCode":            0,
+								"exitCodeDescription": "No policy violations found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/allow",
+								"ruleId":    "main/allow",
 								"ruleIndex": 0,
-								"level": "note",
-								"message": {
-									"text": "test exception"
+								"level":     "note",
+								"message": map[string]any{
+									"text": "test exception",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+							{
+								"ruleId":    "main/success",
+								"ruleIndex": 1,
+								"level":     "none",
+								"message": map[string]any{
+									"text": "Policy was satisfied successfully",
+								},
+								"locations": []map[string]any{
+									{
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		{
 			name: "skipped result",
@@ -257,57 +283,57 @@ func TestSARIF_Output(t *testing.T) {
 					Successes: 0,
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/skip",
-										"shortDescription": {
-											"text": "Policy check was skipped"
+										"shortDescription": map[string]any{
+											"text": "Policy check was skipped",
 										},
-										"properties": {
-											"description": "Policy check was skipped"
-										}
-									}
-								]
-							}
+										"properties": map[string]any{
+											"description": "Policy check was skipped",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 0,
-								"exitCodeDescription": "No policy violations found"
-							}
-						],
-						"results": [
+								"exitCode":            0,
+								"exitCodeDescription": "No policy violations found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/skip",
+								"ruleId":    "main/skip",
 								"ruleIndex": 0,
-								"level": "none",
-								"message": {
-									"text": "Policy check was skipped"
+								"level":     "none",
+								"message": map[string]any{
+									"text": "Policy check was skipped",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		{
 			name: "multiple results same rule",
@@ -333,75 +359,75 @@ func TestSARIF_Output(t *testing.T) {
 					},
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/deny",
-										"shortDescription": {
-											"text": "Policy violation"
+										"shortDescription": map[string]any{
+											"text": "Policy violation",
 										},
-										"properties": {
+										"properties": map[string]any{
 											"package": "test",
-											"rule": "rule1"
-										}
-									}
-								]
-							}
+											"rule":    "rule1",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 1,
-								"exitCodeDescription": "Policy violations found"
-							}
-						],
-						"results": [
+								"exitCode":            1,
+								"exitCodeDescription": "Policy violations found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/deny",
+								"ruleId":    "main/deny",
 								"ruleIndex": 0,
-								"level": "error",
-								"message": {
-									"text": "test failure 1"
+								"level":     "error",
+								"message": map[string]any{
+									"text": "test failure 1",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test1.yaml"
-											}
-										}
-									}
-								]
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test1.yaml",
+											},
+										},
+									},
+								},
 							},
 							{
-								"ruleId": "main/deny",
+								"ruleId":    "main/deny",
 								"ruleIndex": 0,
-								"level": "error",
-								"message": {
-									"text": "test failure 2"
+								"level":     "error",
+								"message": map[string]any{
+									"text": "test failure 2",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test1.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test1.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 		{
 			name: "successful policy check",
@@ -412,57 +438,57 @@ func TestSARIF_Output(t *testing.T) {
 					Successes: 1,
 				},
 			},
-			wantJSON: `{
+			wantJSON: mustJSON(t, map[string]any{
 				"version": "2.1.0",
 				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-				"runs": [
+				"runs": []map[string]any{
 					{
-						"tool": {
-							"driver": {
+						"tool": map[string]any{
+							"driver": map[string]any{
 								"informationUri": "https://github.com/open-policy-agent/conftest",
-								"name": "conftest",
-								"rules": [
+								"name":           "conftest",
+								"rules": []map[string]any{
 									{
 										"id": "main/success",
-										"shortDescription": {
-											"text": "Policy was satisfied successfully"
+										"shortDescription": map[string]any{
+											"text": "Policy was satisfied successfully",
 										},
-										"properties": {
-											"description": "Policy was satisfied successfully"
-										}
-									}
-								]
-							}
+										"properties": map[string]any{
+											"description": "Policy was satisfied successfully",
+										},
+									},
+								},
+							},
 						},
-						"invocations": [
+						"invocations": []map[string]any{
 							{
 								"executionSuccessful": true,
-								"exitCode": 0,
-								"exitCodeDescription": "No policy violations found"
-							}
-						],
-						"results": [
+								"exitCode":            0,
+								"exitCodeDescription": "No policy violations found",
+							},
+						},
+						"results": []map[string]any{
 							{
-								"ruleId": "main/success",
+								"ruleId":    "main/success",
 								"ruleIndex": 0,
-								"level": "none",
-								"message": {
-									"text": "Policy was satisfied successfully"
+								"level":     "none",
+								"message": map[string]any{
+									"text": "Policy was satisfied successfully",
 								},
-								"locations": [
+								"locations": []map[string]any{
 									{
-										"physicalLocation": {
-											"artifactLocation": {
-												"uri": "test.yaml"
-											}
-										}
-									}
-								]
-							}
-						]
-					}
-				]
-			}`,
+										"physicalLocation": map[string]any{
+											"artifactLocation": map[string]any{
+												"uri": "test.yaml",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}),
 		},
 	}
 
@@ -557,12 +583,17 @@ func compareJSON(t *testing.T, got, want string) {
 		t.Fatalf("failed to unmarshal expected JSON: %v", err)
 	}
 
-	gotBytes, _ := json.Marshal(gotJSON)
-	wantBytes, _ := json.Marshal(wantJSON)
-
-	if string(gotBytes) != string(wantBytes) {
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(want, got, false)
-		t.Errorf("JSON mismatch:\n%s", dmp.DiffPrettyText(diffs))
+	if diff := cmp.Diff(wantJSON, gotJSON); diff != "" {
+		t.Errorf("JSON mismatch (-want +got):\n%s", diff)
 	}
+}
+
+// mustJSON converts a value to a JSON string, failing the test if marshaling fails
+func mustJSON(t *testing.T, value map[string]any) string {
+	t.Helper()
+	b, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -3,1122 +3,466 @@ package output
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
-	"strings"
 	"testing"
-	"time"
+
+	"github.com/sergi/go-diff/diffmatchpatch"
 )
 
-const (
-	// Test file and namespace
-	testFileName  = "examples/kubernetes/service.yaml"
-	testNamespace = "namespace"
-
-	// Test messages
-	testFailureMsg = "first failure"
-	testWarningMsg = "first warning"
-	testSecondWarn = "second warning"
-
-	// Test metadata
-	testFailureDesc = "A detailed description of the failure"
-	testFailureURL  = "https://example.com/docs"
-	testFailureHelp = "How to fix this failure"
-	testWarnDesc    = "A detailed description of the warning"
-	testWarnURL     = "https://example.com/warnings"
-	testWarnHelp    = "How to fix this warning"
-
-	// Test policy metadata
-	testPackage  = "security.container"
-	testRuleName = "no_root_user"
-)
-
-func TestSARIF(t *testing.T) {
+func TestSARIF_Output(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
-		validate func(t *testing.T, output string)
+		results  []CheckResult
+		wantErr  bool
+		wantJSON string
 	}{
 		{
-			name: "success path - no violations",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result (skipped), got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelNone,
-					kind:      kindSkipped,
-					message:   skippedDesc,
-					ruleID:    ruleSkippedBase,
-					namespace: testNamespace,
-				})
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   0,
-					exitDesc:   exitNoViolations,
-				})
-
-				validateTimestamps(t, run.Invocations[0])
-			},
-		},
-		{
-			name: "single failure with basic result structure",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures:  []Result{{Message: testFailureMsg}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    ruleFailureBase,
-					namespace: testNamespace,
-				})
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
-		},
-		{
-			name: "multiple warnings and failures",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Warnings:  []Result{{Message: testWarningMsg}, {Message: testSecondWarn}},
-					Failures:  []Result{{Message: testFailureMsg}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 3 {
-					t.Errorf("expected 3 results, got %d", len(run.Results))
-				}
-
-				// Count warnings and failures while validating each result
-				warningCount := 0
-				failureCount := 0
-				for _, result := range run.Results {
-					switch result.Level {
-					case levelWarning:
-						warningCount++
-						validateResult(t, result, struct {
-							level     string
-							kind      string
-							message   string
-							ruleID    string
-							namespace string
-						}{
-							level:     levelWarning,
-							kind:      kindReview,
-							message:   result.Message.Text,
-							ruleID:    ruleWarningBase,
-							namespace: testNamespace,
-						})
-					case levelError:
-						failureCount++
-						validateResult(t, result, struct {
-							level     string
-							kind      string
-							message   string
-							ruleID    string
-							namespace string
-						}{
-							level:     levelError,
-							kind:      kindFail,
-							message:   testFailureMsg,
-							ruleID:    ruleFailureBase,
-							namespace: testNamespace,
-						})
-					}
-				}
-
-				if warningCount != 2 {
-					t.Errorf("expected 2 warnings, got %d", warningCount)
-				}
-				if failureCount != 1 {
-					t.Errorf("expected 1 failure, got %d", failureCount)
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
-		},
-		{
-			name: "handles stdin input",
-			input: []CheckResult{
-				{
-					FileName:  "-",
-					Namespace: testNamespace,
-					Failures:  []Result{{Message: testFailureMsg}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				result := run.Results[0]
-				validateResult(t, result, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    ruleFailureBase,
-					namespace: testNamespace,
-				})
-
-				// Verify location URI for stdin
-				if result.Locations[0].PhysicalLocation.ArtifactLocation.URI != "-" {
-					t.Errorf("expected URI '-' for stdin, got '%s'", result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
-		},
-		{
-			name: "includes metadata in rules and results",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures: []Result{{
-						Message: testFailureMsg,
-						Metadata: map[string]interface{}{
-							"description": testFailureDesc,
-							"url":         testFailureURL,
-							"help":        testFailureHelp,
-						},
-					}},
-					Warnings: []Result{{
-						Message: testWarningMsg,
-						Metadata: map[string]interface{}{
-							"description": testWarnDesc,
-							"url":         testWarnURL,
-							"help":        testWarnHelp,
-						},
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 2 {
-					t.Errorf("expected 2 results, got %d", len(run.Results))
-				}
-
-				// Find and validate failure rule/result
-				expectedFailureRuleID := fmt.Sprintf("%s/%s", ruleFailureBase, strings.ToLower(strings.ReplaceAll(testFailureDesc, " ", "-")))
-				failureRule, failureResult, err := findRule(run, expectedFailureRuleID)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				validateRuleMetadata(t, failureRule, struct {
-					description string
-					helpURI     string
-					helpText    string
-					namespace   string
-				}{
-					description: testFailureDesc,
-					helpURI:     testFailureURL,
-					helpText:    testFailureHelp,
-					namespace:   testNamespace,
-				})
-
-				validateResult(t, *failureResult, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    expectedFailureRuleID,
-					namespace: testNamespace,
-				})
-
-				// Find and validate warning rule/result
-				expectedWarningRuleID := fmt.Sprintf("%s/%s", ruleWarningBase, strings.ToLower(strings.ReplaceAll(testWarnDesc, " ", "-")))
-				warningRule, warningResult, err := findRule(run, expectedWarningRuleID)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				validateRuleMetadata(t, warningRule, struct {
-					description string
-					helpURI     string
-					helpText    string
-					namespace   string
-				}{
-					description: testWarnDesc,
-					helpURI:     testWarnURL,
-					helpText:    testWarnHelp,
-					namespace:   testNamespace,
-				})
-
-				validateResult(t, *warningResult, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelWarning,
-					kind:      kindReview,
-					message:   testWarningMsg,
-					ruleID:    expectedWarningRuleID,
-					namespace: testNamespace,
-				})
-			},
-		},
-		{
-			name: "handles exceptions",
-			input: []CheckResult{
-				{
-					FileName:  "examples/exceptions/deployments.yaml",
-					Namespace: "main",
-					Failures: []Result{{
-						Message: "Containers must not run as root",
-					}},
-					Exceptions: []Result{{
-						Message: "data.main.exception[_][_] == \"run_as_root\"",
-						Metadata: map[string]interface{}{
-							"description": "Exception for running as root",
-							"error":       "run_as_root",
-							"code":        "policy_exception",
-						},
-					}},
-				},
-				{
-					FileName:  "examples/exceptions/other.yaml",
-					Namespace: "main",
-					Exceptions: []Result{{
-						Message: "data.main.exception[_][_] == \"other\"",
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 3 {
-					t.Errorf("expected 3 results (1 failure, 2 exceptions), got %d", len(run.Results))
-				}
-
-				exceptionCount := 0
-				failureCount := 0
-				for _, result := range run.Results {
-					switch result.Kind {
-					case kindInfo:
-						exceptionCount++
-						validateResult(t, result, struct {
-							level     string
-							kind      string
-							message   string
-							ruleID    string
-							namespace string
-						}{
-							level:     levelNote,
-							kind:      kindInfo,
-							message:   result.Message.Text,
-							ruleID:    ruleExceptionBase,
-							namespace: "main",
-						})
-
-						// Verify error details if present
-						if result.Message.Text == "data.main.exception[_][_] == \"run_as_root\"" {
-							if errType, ok := result.Properties["error"].(string); !ok || errType != "run_as_root" {
-								t.Error("expected error type in properties")
+			name:    "empty results",
+			results: []CheckResult{},
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": []
 							}
-							if code, ok := result.Properties["code"].(string); !ok || code != "policy_exception" {
-								t.Error("expected error code in properties")
+						},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 0,
+								"exitCodeDescription": "No policy violations found"
 							}
-						}
-
-					case kindFail:
-						failureCount++
-						validateResult(t, result, struct {
-							level     string
-							kind      string
-							message   string
-							ruleID    string
-							namespace string
-						}{
-							level:     levelError,
-							kind:      kindFail,
-							message:   "Containers must not run as root",
-							ruleID:    ruleFailureBase,
-							namespace: "main",
-						})
+						],
+						"results": []
 					}
-				}
-
-				if exceptionCount != 2 {
-					t.Errorf("expected 2 exceptions, got %d", exceptionCount)
-				}
-				if failureCount != 1 {
-					t.Errorf("expected 1 failure, got %d", failureCount)
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
+				]
+			}`,
 		},
 		{
-			name: "success result when checks pass",
-			input: []CheckResult{
+			name: "single failure",
+			results: []CheckResult{
 				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Successes: 1,
+					FileName:  "test.yaml",
+					Namespace: "main",
+					Failures: []Result{
+						{
+							Message: "test failure",
+							Metadata: map[string]interface{}{
+								"package": "test",
+								"rule":    "rule1",
+							},
+						},
+					},
 				},
 			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelNone,
-					kind:      kindPass,
-					message:   successDesc,
-					ruleID:    rulePassBase,
-					namespace: testNamespace,
-				})
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   0,
-					exitDesc:   exitNoViolations,
-				})
-			},
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/deny",
+										"shortDescription": {
+											"text": "Policy violation"
+										},
+										"properties": {
+											"package": "test",
+											"rule": "rule1"
+										}
+									}
+								]
+							}
+						},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 1,
+								"exitCodeDescription": "Policy violations found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/deny",
+								"ruleIndex": 0,
+								"level": "error",
+								"message": {
+									"text": "test failure"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}`,
 		},
 		{
-			name: "skipped result when no checks run",
-			input: []CheckResult{
+			name: "single warning",
+			results: []CheckResult{
 				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
+					FileName:  "test.yaml",
+					Namespace: "main",
+					Warnings: []Result{
+						{
+							Message: "test warning",
+							Metadata: map[string]interface{}{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			},
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/warn",
+										"shortDescription": {
+											"text": "Policy warning"
+										},
+										"properties": {
+											"foo": "bar"
+										}
+									}
+								]
+							}
+						},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 0,
+								"exitCodeDescription": "Policy warnings found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/warn",
+								"ruleIndex": 0,
+								"level": "warning",
+								"message": {
+									"text": "test warning"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}`,
+		},
+		{
+			name: "single exception",
+			results: []CheckResult{
+				{
+					FileName:  "test.yaml",
+					Namespace: "main",
+					Exceptions: []Result{
+						{
+							Message: "test exception",
+							Metadata: map[string]interface{}{
+								"description": "test exception description",
+							},
+						},
+					},
+				},
+			},
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/allow",
+										"shortDescription": {
+											"text": "Policy exception"
+										},
+										"properties": {
+											"description": "test exception description"
+										}
+									}
+								]
+							}
+						},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 0,
+								"exitCodeDescription": "Policy exceptions found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/allow",
+								"ruleIndex": 0,
+								"level": "note",
+								"message": {
+									"text": "test exception"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}`,
+		},
+		{
+			name: "skipped result",
+			results: []CheckResult{
+				{
+					FileName:  "test.yaml",
+					Namespace: "main",
 					Successes: 0,
 				},
 			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelNone,
-					kind:      kindSkipped,
-					message:   skippedDesc,
-					ruleID:    ruleSkippedBase,
-					namespace: testNamespace,
-				})
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   0,
-					exitDesc:   exitNoViolations,
-				})
-			},
-		},
-		{
-			name: "no success/skipped result when failures exist",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Successes: 5,
-					Failures:  []Result{{Message: testFailureMsg}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result (failure only), got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    ruleFailureBase,
-					namespace: testNamespace,
-				})
-			},
-		},
-		{
-			name: "rule ID generation with policy metadata",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures: []Result{{
-						Message: testFailureMsg,
-						Metadata: map[string]interface{}{
-							"package":     testPackage,
-							"rule":        testRuleName,
-							"description": testFailureDesc,
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/skip",
+										"shortDescription": {
+											"text": "Policy check was skipped"
+										},
+										"properties": {
+											"description": "Policy check was skipped"
+										}
+									}
+								]
+							}
 						},
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				result := run.Results[0]
-				expectedRuleID := fmt.Sprintf("%s/%s/%s", testNamespace, testPackage, testRuleName)
-				if result.RuleID != expectedRuleID {
-					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
-				}
-
-				// Find and validate the rule
-				rule, foundResult, err := findRule(run, expectedRuleID)
-				if err != nil {
-					t.Fatal(err)
-				}
-				if foundResult == nil {
-					t.Fatal("no result found for rule")
-				}
-				result = *foundResult
-
-				// Verify package and rule in rule properties
-				if pkg, ok := rule.Properties["package"].(string); !ok || pkg != testPackage {
-					t.Errorf("expected package '%s' in rule properties, got '%v'", testPackage, rule.Properties["package"])
-				}
-				if ruleName, ok := rule.Properties["rule"].(string); !ok || ruleName != testRuleName {
-					t.Errorf("expected rule name '%s' in rule properties, got '%v'", testRuleName, rule.Properties["rule"])
-				}
-
-				validateResult(t, result, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    expectedRuleID,
-					namespace: testNamespace,
-				})
-			},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 0,
+								"exitCodeDescription": "No policy violations found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/skip",
+								"ruleIndex": 0,
+								"level": "none",
+								"message": {
+									"text": "Policy check was skipped"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				]
+			}`,
 		},
 		{
-			name: "rule ID generation with description fallback",
-			input: []CheckResult{
+			name: "multiple results same rule",
+			results: []CheckResult{
 				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures: []Result{{
-						Message: testFailureMsg,
-						Metadata: map[string]interface{}{
-							"description": testFailureDesc,
-						},
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				result := run.Results[0]
-				expectedRuleID := fmt.Sprintf("%s/%s", ruleFailureBase, strings.ToLower(strings.ReplaceAll(testFailureDesc, " ", "-")))
-				if result.RuleID != expectedRuleID {
-					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
-				}
-
-				validateResult(t, result, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    expectedRuleID,
-					namespace: testNamespace,
-				})
-			},
-		},
-		{
-			name: "rule ID generation with no metadata",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures: []Result{{
-						Message:  testFailureMsg,
-						Metadata: map[string]interface{}{},
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   testFailureMsg,
-					ruleID:    ruleFailureBase,
-					namespace: testNamespace,
-				})
-			},
-		},
-		{
-			name: "rule ID generation with message hash",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Failures: []Result{{
-						Message: testFailureMsg,
-						Metadata: map[string]interface{}{
-							"severity": "HIGH",
-						},
-					}},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				var report sarifReport
-				if err := json.NewDecoder(strings.NewReader(output)).Decode(&report); err != nil {
-					t.Fatalf("failed to decode SARIF output: %v", err)
-				}
-
-				run := report.Runs[0]
-				result := run.Results[0]
-				expectedRuleID := ruleFailureBase
-				if result.RuleID != expectedRuleID {
-					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
-				}
-			},
-		},
-		{
-			name: "multiple violations from same rule",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
+					FileName:  "test1.yaml",
+					Namespace: "main",
 					Failures: []Result{
 						{
-							Message: "Container 'app1' runs as privileged",
+							Message: "test failure 1",
 							Metadata: map[string]interface{}{
-								"rule":      "no_privileged",
-								"container": "app1",
-								"query":     "data.kubernetes.deny_privileged_container",
+								"package": "test",
+								"rule":    "rule1",
 							},
 						},
 						{
-							Message: "Container 'app2' runs as privileged",
+							Message: "test failure 2",
 							Metadata: map[string]interface{}{
-								"rule":      "no_privileged",
-								"container": "app2",
-								"query":     "data.kubernetes.deny_privileged_container",
+								"package": "test",
+								"rule":    "rule1",
 							},
 						},
 					},
 				},
 			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 2 {
-					t.Errorf("expected 2 results, got %d", len(run.Results))
-				}
-
-				// Both results should have the same ruleId and ruleIndex
-				firstResult := run.Results[0]
-				secondResult := run.Results[1]
-				if firstResult.RuleID != secondResult.RuleID {
-					t.Errorf("expected same rule ID, got '%s' and '%s'", firstResult.RuleID, secondResult.RuleID)
-				}
-				if firstResult.RuleIndex != secondResult.RuleIndex {
-					t.Errorf("expected same rule index, got %d and %d", firstResult.RuleIndex, secondResult.RuleIndex)
-				}
-
-				// Validate each result
-				for _, result := range run.Results {
-					validateResult(t, result, struct {
-						level     string
-						kind      string
-						message   string
-						ruleID    string
-						namespace string
-					}{
-						level:     levelError,
-						kind:      kindFail,
-						message:   result.Message.Text,
-						ruleID:    fmt.Sprintf("%s-kubernetes-deny_privileged_container", ruleFailureBase),
-						namespace: testNamespace,
-					})
-
-					// Verify query path in properties
-					if query, ok := result.Properties["query"].(string); !ok || query != "data.kubernetes.deny_privileged_container" {
-						t.Errorf("unexpected query: %v", result.Properties["query"])
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/deny",
+										"shortDescription": {
+											"text": "Policy violation"
+										},
+										"properties": {
+											"package": "test",
+											"rule": "rule1"
+										}
+									}
+								]
+							}
+						},
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 1,
+								"exitCodeDescription": "Policy violations found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/deny",
+								"ruleIndex": 0,
+								"level": "error",
+								"message": {
+									"text": "test failure 1"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test1.yaml"
+											}
+										}
+									}
+								]
+							},
+							{
+								"ruleId": "main/deny",
+								"ruleIndex": 0,
+								"level": "error",
+								"message": {
+									"text": "test failure 2"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test1.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
 					}
-
-					// Verify container in properties
-					if container, ok := result.Properties["container"].(string); !ok || (container != "app1" && container != "app2") {
-						t.Errorf("unexpected container: %v", result.Properties["container"])
-					}
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
+				]
+			}`,
 		},
 		{
-			name: "cross package rules",
-			input: []CheckResult{
+			name: "successful policy check",
+			results: []CheckResult{
 				{
-					FileName:  testFileName,
-					Namespace: "kubernetes",
-					Failures: []Result{
-						{
-							Message: "Container runs as privileged",
-							Metadata: map[string]interface{}{
-								"query": "data.kubernetes.deny_privileged_container",
-							},
-						},
-					},
-				},
-				{
-					FileName:  testFileName,
-					Namespace: "custom",
-					Failures: []Result{
-						{
-							Message: "Custom rule violation",
-							Metadata: map[string]interface{}{
-								"query": "data.custom.deny_custom",
-							},
-						},
-					},
+					FileName:  "test.yaml",
+					Namespace: "main",
+					Successes: 1,
 				},
 			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 2 {
-					t.Errorf("expected 2 results, got %d", len(run.Results))
-				}
-
-				// Validate kubernetes rule result
-				validateResult(t, run.Results[0], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   "Container runs as privileged",
-					ruleID:    fmt.Sprintf("%s-kubernetes-deny_privileged_container", ruleFailureBase),
-					namespace: "kubernetes",
-				})
-
-				// Validate custom rule result
-				validateResult(t, run.Results[1], struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   "Custom rule violation",
-					ruleID:    fmt.Sprintf("%s-custom-deny_custom", ruleFailureBase),
-					namespace: "custom",
-				})
-
-				// Verify query paths in properties
-				if query, ok := run.Results[0].Properties["query"].(string); !ok || query != "data.kubernetes.deny_privileged_container" {
-					t.Errorf("unexpected query in first result: %v", run.Results[0].Properties["query"])
-				}
-				if query, ok := run.Results[1].Properties["query"].(string); !ok || query != "data.custom.deny_custom" {
-					t.Errorf("unexpected query in second result: %v", run.Results[1].Properties["query"])
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   1,
-					exitDesc:   exitViolations,
-				})
-			},
-		},
-		{
-			name: "exception handling",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: testNamespace,
-					Exceptions: []Result{
-						{
-							Message: "Division by zero in policy evaluation",
-							Metadata: map[string]interface{}{
-								"error": "divide by zero",
-								"code":  "rego_type_error",
-							},
+			wantJSON: `{
+				"version": "2.1.0",
+				"$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+				"runs": [
+					{
+						"tool": {
+							"driver": {
+								"informationUri": "https://github.com/open-policy-agent/conftest",
+								"name": "conftest",
+								"rules": [
+									{
+										"id": "main/success",
+										"shortDescription": {
+											"text": "Policy was satisfied successfully"
+										},
+										"properties": {
+											"description": "Policy was satisfied successfully"
+										}
+									}
+								]
+							}
 						},
-					},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				result := run.Results[0]
-				validateResult(t, result, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelNote,
-					kind:      kindInfo,
-					message:   "Division by zero in policy evaluation",
-					ruleID:    ruleExceptionBase,
-					namespace: testNamespace,
-				})
-
-				// Verify error details in properties
-				if errMsg, ok := result.Properties["error"].(string); !ok || errMsg != "divide by zero" {
-					t.Errorf("expected error 'divide by zero', got '%v'", result.Properties["error"])
-				}
-				if code, ok := result.Properties["code"].(string); !ok || code != "rego_type_error" {
-					t.Errorf("expected code 'rego_type_error', got '%v'", result.Properties["code"])
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   0,
-					exitDesc:   exitExceptions,
-				})
-			},
-		},
-		{
-			name: "query path inclusion",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: "kubernetes.security",
-					Failures: []Result{
-						{
-							Message: "Security violation",
-							Metadata: map[string]interface{}{
-								"query":   "data.kubernetes.security.deny_privileged",
-								"package": "kubernetes.security",
-								"rule":    "deny_privileged",
-							},
-						},
-					},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 1 {
-					t.Errorf("expected 1 result, got %d", len(run.Results))
-				}
-
-				result := run.Results[0]
-				expectedRuleID := fmt.Sprintf("%s/%s/%s", "kubernetes.security", "kubernetes.security", "deny_privileged")
-
-				validateResult(t, result, struct {
-					level     string
-					kind      string
-					message   string
-					ruleID    string
-					namespace string
-				}{
-					level:     levelError,
-					kind:      kindFail,
-					message:   "Security violation",
-					ruleID:    expectedRuleID,
-					namespace: "kubernetes.security",
-				})
-
-				// Verify query path in properties
-				if query, ok := result.Properties["query"].(string); !ok || query != "data.kubernetes.security.deny_privileged" {
-					t.Errorf("unexpected query path: %v", result.Properties["query"])
-				}
-
-				// Find and validate the rule
-				rule, _, err := findRule(run, expectedRuleID)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				// Verify package and rule in rule properties
-				if pkg, ok := rule.Properties["package"].(string); !ok || pkg != "kubernetes.security" {
-					t.Errorf("unexpected package: %v", rule.Properties["package"])
-				}
-				if ruleName, ok := rule.Properties["rule"].(string); !ok || ruleName != "deny_privileged" {
-					t.Errorf("unexpected rule: %v", rule.Properties["rule"])
-				}
-			},
-		},
-		{
-			name: "policy warnings",
-			input: []CheckResult{
-				{
-					FileName:  testFileName,
-					Namespace: "kubernetes",
-					Warnings: []Result{
-						{
-							Message: "Memory limits not set",
-							Metadata: map[string]interface{}{
-								"query":     "data.kubernetes.warn_no_memory_limits",
-								"package":   "kubernetes",
-								"rule":      "warn_memory_limits",
-								"container": "app",
-							},
-						},
-						{
-							Message: "CPU limits not set",
-							Metadata: map[string]interface{}{
-								"query":     "data.kubernetes.warn_no_cpu_limits",
-								"package":   "kubernetes",
-								"rule":      "warn_cpu_limits",
-								"container": "app",
-							},
-						},
-					},
-				},
-			},
-			validate: func(t *testing.T, output string) {
-				report := decodeSARIFReport(t, output)
-				run := report.Runs[0]
-
-				if len(run.Results) != 2 {
-					t.Errorf("expected 2 warning results, got %d", len(run.Results))
-				}
-
-				// Expected rule IDs based on package and rule names
-				expectedRuleIDs := map[string]bool{
-					"kubernetes/kubernetes/warn_memory_limits": false,
-					"kubernetes/kubernetes/warn_cpu_limits":    false,
-				}
-
-				for _, result := range run.Results {
-					// Mark rule ID as found
-					expectedRuleIDs[result.RuleID] = true
-
-					validateResult(t, result, struct {
-						level     string
-						kind      string
-						message   string
-						ruleID    string
-						namespace string
-					}{
-						level:     levelWarning,
-						kind:      kindReview,
-						message:   result.Message.Text,
-						ruleID:    result.RuleID,
-						namespace: "kubernetes",
-					})
-
-					// Find and validate the rule
-					rule, _, err := findRule(run, result.RuleID)
-					if err != nil {
-						t.Fatalf("rule not found: %s", result.RuleID)
+						"invocations": [
+							{
+								"executionSuccessful": true,
+								"exitCode": 0,
+								"exitCodeDescription": "No policy violations found"
+							}
+						],
+						"results": [
+							{
+								"ruleId": "main/success",
+								"ruleIndex": 0,
+								"level": "none",
+								"message": {
+									"text": "Policy was satisfied successfully"
+								},
+								"locations": [
+									{
+										"physicalLocation": {
+											"artifactLocation": {
+												"uri": "test.yaml"
+											}
+										}
+									}
+								]
+							}
+						]
 					}
-
-					// Verify rule properties
-					if pkg, ok := rule.Properties["package"].(string); !ok || pkg != "kubernetes" {
-						t.Errorf("unexpected package in rule: %v", rule.Properties["package"])
-					}
-					if ruleName, ok := rule.Properties["rule"].(string); !ok || !strings.HasPrefix(ruleName, "warn_") {
-						t.Errorf("unexpected rule name: %v", rule.Properties["rule"])
-					}
-
-					// Verify query path and container in properties
-					if query, ok := result.Properties["query"].(string); !ok || !strings.HasPrefix(query, "data.kubernetes.warn_") {
-						t.Errorf("unexpected query: %v", result.Properties["query"])
-					}
-					if container, ok := result.Properties["container"].(string); !ok || container != "app" {
-						t.Errorf("unexpected container: %v", result.Properties["container"])
-					}
-				}
-
-				// Verify all expected rule IDs were found
-				for ruleID, found := range expectedRuleIDs {
-					if !found {
-						t.Errorf("expected rule ID not found: %s", ruleID)
-					}
-				}
-
-				validateInvocation(t, run.Invocations[0], struct {
-					successful bool
-					exitCode   int
-					exitDesc   string
-				}{
-					successful: true,
-					exitCode:   0,
-					exitDesc:   exitWarnings,
-				})
-			},
+				]
+			}`,
 		},
 	}
 
@@ -1127,322 +471,98 @@ func TestSARIF(t *testing.T) {
 			var buf bytes.Buffer
 			s := NewSARIF(&buf)
 
-			if err := s.Output(tt.input); err != nil {
-				t.Fatalf("failed to output SARIF: %v", err)
+			err := s.Output(tt.results)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SARIF.Output() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
 
-			tt.validate(t, buf.String())
+			if !tt.wantErr {
+				compareJSON(t, buf.String(), tt.wantJSON)
+			}
 		})
-	}
-}
-
-func TestSARIFReport(t *testing.T) {
-	var buf bytes.Buffer
-	sarif := NewSARIF(&buf)
-
-	err := sarif.Report(nil, "")
-	if err == nil {
-		t.Error("expected error for Report call")
-	}
-
-	wantErrMsg := "report is not supported in SARIF output"
-	if !strings.Contains(err.Error(), wantErrMsg) {
-		t.Errorf("expected error containing '%s', got: %v", wantErrMsg, err)
 	}
 }
 
 func TestGetRuleID(t *testing.T) {
 	tests := []struct {
 		name      string
-		result    Result
-		rType     resultType
 		namespace string
+		ruleType  string
 		want      string
 	}{
 		{
-			name: "success result uses base ID",
-			result: Result{
-				Message: "success",
-				Metadata: map[string]interface{}{
-					"query": "data.main.deny",
-				},
-			},
-			rType:     successResultType,
+			name:      "failure",
 			namespace: "main",
-			want:      "conftest-pass",
+			ruleType:  "deny",
+			want:      "main/deny",
 		},
 		{
-			name: "skipped result uses base ID",
-			result: Result{
-				Message: "skipped",
-				Metadata: map[string]interface{}{
-					"query": "data.main.deny",
-				},
-			},
-			rType:     skippedResultType,
+			name:      "warning",
 			namespace: "main",
-			want:      "conftest-skipped",
+			ruleType:  "warn",
+			want:      "main/warn",
 		},
 		{
-			name: "uses package and rule from metadata when available",
-			result: Result{
-				Message: "violation",
-				Metadata: map[string]interface{}{
-					"package": "kubernetes",
-					"rule":    "deny_privileged",
-					"query":   "data.kubernetes.deny",
-				},
-			},
-			rType:     failureResultType,
+			name:      "success",
 			namespace: "main",
-			want:      "main/kubernetes/deny_privileged",
+			ruleType:  "success",
+			want:      "main/success",
 		},
 		{
-			name: "uses query path when package/rule not available",
-			result: Result{
-				Message: "violation",
-				Metadata: map[string]interface{}{
-					"query": "data.kubernetes.deny",
-				},
-			},
-			rType:     failureResultType,
+			name:      "skipped",
 			namespace: "main",
-			want:      "conftest-failure-kubernetes-deny",
+			ruleType:  "skip",
+			want:      "main/skip",
 		},
 		{
-			name: "uses description when no query or package/rule",
-			result: Result{
-				Message: "violation",
-				Metadata: map[string]interface{}{
-					"description": "No privileged containers allowed",
-				},
-			},
-			rType:     failureResultType,
-			namespace: "main",
-			want:      "conftest-failure/no-privileged-containers-allowed",
-		},
-		{
-			name: "falls back to base ID when no identifying information",
-			result: Result{
-				Message:  "violation",
-				Metadata: map[string]interface{}{},
-			},
-			rType:     failureResultType,
-			namespace: "main",
-			want:      "conftest-failure",
+			name:      "different namespace",
+			namespace: "kubernetes",
+			ruleType:  "deny",
+			want:      "kubernetes/deny",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getRuleID(tt.result, tt.rType, tt.namespace)
-			if got != tt.want {
+			if got := getRuleID(tt.namespace, tt.ruleType); got != tt.want {
 				t.Errorf("getRuleID() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestQueryInformation(t *testing.T) {
+func TestSARIF_Report(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSARIF(&buf)
-
-	results := []CheckResult{
-		{
-			FileName:  "test.yaml",
-			Namespace: "main",
-			Failures: []Result{
-				{
-					Message: "violation found",
-					Metadata: map[string]interface{}{
-						"query":   "data.main.deny",
-						"traces":  []string{"trace1", "trace2"},
-						"outputs": []string{"output1", "output2"},
-						"package": "main",
-						"rule":    "deny",
-					},
-				},
-			},
-		},
+	err := s.Report(nil, "test")
+	if err == nil {
+		t.Error("SARIF.Report() should return error")
 	}
-
-	if err := s.Output(results); err != nil {
-		t.Fatal(err)
+	const expectedErr = "report is not supported in SARIF output"
+	if err.Error() != expectedErr {
+		t.Errorf("expected '%v', got: '%v'", expectedErr, err)
 	}
-
-	report := decodeSARIFReport(t, buf.String())
-	run := report.Runs[0]
-
-	if len(run.Results) != 1 {
-		t.Errorf("expected 1 result, got %d", len(run.Results))
-	}
-
-	expectedRuleID := "main/main/deny"
-	validateResult(t, run.Results[0], struct {
-		level     string
-		kind      string
-		message   string
-		ruleID    string
-		namespace string
-	}{
-		level:     levelError,
-		kind:      kindFail,
-		message:   "violation found",
-		ruleID:    expectedRuleID,
-		namespace: "main",
-	})
-
-	// Find and validate the rule
-	_, foundResult, err := findRule(run, expectedRuleID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if foundResult == nil {
-		t.Fatal("no result found for rule")
-	}
-	result := *foundResult
-
-	// Verify query information in properties
-	if query, ok := result.Properties["query"].(string); !ok || query != "data.main.deny" {
-		t.Errorf("unexpected query: %v", result.Properties["query"])
-	}
-
-	// Verify traces and outputs are preserved
-	if traces, ok := result.Properties["traces"].([]interface{}); !ok || len(traces) != 2 {
-		t.Errorf("unexpected traces: %v", result.Properties["traces"])
-	}
-	if outputs, ok := result.Properties["outputs"].([]interface{}); !ok || len(outputs) != 2 {
-		t.Errorf("unexpected outputs: %v", result.Properties["outputs"])
-	}
-
-	validateInvocation(t, run.Invocations[0], struct {
-		successful bool
-		exitCode   int
-		exitDesc   string
-	}{
-		successful: true,
-		exitCode:   1,
-		exitDesc:   exitViolations,
-	})
 }
 
-// Helper functions for testing
-func decodeSARIFReport(t *testing.T, output string) sarifReport {
+// compareJSON normalizes and compares two JSON strings.
+// JSON strings are normalised to their canonical form without whitespace.
+func compareJSON(t *testing.T, got, want string) {
 	t.Helper()
-	var report sarifReport
-	if err := json.NewDecoder(strings.NewReader(output)).Decode(&report); err != nil {
-		t.Fatalf("failed to decode SARIF output: %v", err)
+	var gotJSON, wantJSON interface{}
+	if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
+		t.Fatalf("failed to unmarshal actual JSON: %v", err)
 	}
-	return report
-}
+	if err := json.Unmarshal([]byte(want), &wantJSON); err != nil {
+		t.Fatalf("failed to unmarshal expected JSON: %v", err)
+	}
 
-// validateResult validates that a SARIF result matches the expected values for level, kind,
-// message, rule ID and namespace
-func validateResult(t *testing.T, result sarifResult, expected struct {
-	level     string
-	kind      string
-	message   string
-	ruleID    string
-	namespace string
-}) {
-	t.Helper()
-	if result.Level != expected.level {
-		t.Errorf("expected level '%s', got '%s'", expected.level, result.Level)
-	}
-	if result.Kind != expected.kind {
-		t.Errorf("expected kind '%s', got '%s'", expected.kind, result.Kind)
-	}
-	if result.Message.Text != expected.message {
-		t.Errorf("expected message '%s', got '%s'", expected.message, result.Message.Text)
-	}
-	if result.RuleID != expected.ruleID {
-		t.Errorf("expected rule ID '%s', got '%s'", expected.ruleID, result.RuleID)
-	}
-	if ns, ok := result.Properties["namespace"].(string); !ok || ns != expected.namespace {
-		t.Errorf("expected namespace '%s' in properties, got '%v'", expected.namespace, result.Properties["namespace"])
-	}
-}
+	gotBytes, _ := json.Marshal(gotJSON)
+	wantBytes, _ := json.Marshal(wantJSON)
 
-// validateInvocation validates that a SARIF invocation matches the expected values for
-// execution success, exit code and exit code description.
-func validateInvocation(t *testing.T, invocation sarifInvocation, expected struct {
-	successful bool
-	exitCode   int
-	exitDesc   string
-}) {
-	t.Helper()
-	if invocation.ExecutionSuccessful != expected.successful {
-		t.Error("unexpected execution success state")
-	}
-	if invocation.ExitCode != expected.exitCode {
-		t.Errorf("expected exit code %d, got %d", expected.exitCode, invocation.ExitCode)
-	}
-	if invocation.ExitCodeDescription != expected.exitDesc {
-		t.Errorf("unexpected exit code description: %s", invocation.ExitCodeDescription)
-	}
-}
-
-// validateTimestamps validates that the start and end times in a SARIF invocation
-// are valid RFC3339 timestamps and chronologically ordered.
-func validateTimestamps(t *testing.T, invocation sarifInvocation) {
-	t.Helper()
-	startTime, err := time.Parse(time.RFC3339, invocation.StartTimeUtc)
-	if err != nil {
-		t.Errorf("invalid start time format: %v", err)
-	}
-	endTime, err := time.Parse(time.RFC3339, invocation.EndTimeUtc)
-	if err != nil {
-		t.Errorf("invalid end time format: %v", err)
-	}
-	if endTime.Before(startTime) {
-		t.Error("end time should not be before start time")
-	}
-}
-
-// findRule returns the rule and its associated result for a given rule ID.
-// If the rule is not found, it returns an error.
-func findRule(run sarifRun, ruleID string) (rule *sarifRule, result *sarifResult, err error) {
-	for i := range run.Tool.Driver.Rules {
-		r := run.Tool.Driver.Rules[i] // Take reference to array element, not loop variable
-		if r.ID == ruleID {
-			rule = &r
-			// Find the first result that references this rule
-			for j := range run.Results {
-				res := run.Results[j] // Take reference to array element, not loop variable
-				if res.RuleIndex == i {
-					result = &res
-					return rule, result, nil
-				}
-			}
-			// Rule found but no results reference it
-			return rule, nil, nil
-		}
-	}
-	return nil, nil, fmt.Errorf("rule not found: %s", ruleID)
-}
-
-// validateRuleMetadata validates that a SARIF rule matches the expected values for description, help URI,
-// help text and namespace.
-func validateRuleMetadata(t *testing.T, rule *sarifRule, expected struct {
-	description string
-	helpURI     string
-	helpText    string
-	namespace   string
-}) {
-	t.Helper()
-	if rule == nil {
-		t.Fatal("rule is nil")
-	}
-	if rule.FullDescription == nil || rule.FullDescription.Text != expected.description {
-		t.Error("invalid rule description")
-	}
-	if rule.HelpURI != expected.helpURI {
-		t.Error("invalid help URI")
-	}
-	if rule.Help == nil || rule.Help.Text != expected.helpText {
-		t.Error("invalid help text")
-	}
-	if ns, ok := rule.Properties["namespace"].(string); !ok || ns != expected.namespace {
-		t.Errorf("expected namespace '%s' in rule properties, got '%v'", expected.namespace, ns)
+	if string(gotBytes) != string(wantBytes) {
+		dmp := diffmatchpatch.New()
+		diffs := dmp.DiffMain(want, got, false)
+		t.Errorf("JSON mismatch:\n%s", dmp.DiffPrettyText(diffs))
 	}
 }

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -1,0 +1,1448 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	// Test file and namespace
+	testFileName  = "examples/kubernetes/service.yaml"
+	testNamespace = "namespace"
+
+	// Test messages
+	testFailureMsg = "first failure"
+	testWarningMsg = "first warning"
+	testSecondWarn = "second warning"
+
+	// Test metadata
+	testFailureDesc = "A detailed description of the failure"
+	testFailureURL  = "https://example.com/docs"
+	testFailureHelp = "How to fix this failure"
+	testWarnDesc    = "A detailed description of the warning"
+	testWarnURL     = "https://example.com/warnings"
+	testWarnHelp    = "How to fix this warning"
+
+	// Test policy metadata
+	testPackage  = "security.container"
+	testRuleName = "no_root_user"
+)
+
+func TestSARIF(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []CheckResult
+		validate func(t *testing.T, output string)
+	}{
+		{
+			name: "success path - no violations",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result (skipped), got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelNone,
+					kind:      kindSkipped,
+					message:   skippedDesc,
+					ruleID:    ruleSkippedBase,
+					namespace: testNamespace,
+				})
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   0,
+					exitDesc:   exitNoViolations,
+				})
+
+				validateTimestamps(t, run.Invocations[0])
+			},
+		},
+		{
+			name: "single failure with basic result structure",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures:  []Result{{Message: testFailureMsg}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    ruleFailureBase,
+					namespace: testNamespace,
+				})
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "multiple warnings and failures",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Warnings:  []Result{{Message: testWarningMsg}, {Message: testSecondWarn}},
+					Failures:  []Result{{Message: testFailureMsg}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 3 {
+					t.Errorf("expected 3 results, got %d", len(run.Results))
+				}
+
+				// Count warnings and failures while validating each result
+				warningCount := 0
+				failureCount := 0
+				for _, result := range run.Results {
+					switch result.Level {
+					case levelWarning:
+						warningCount++
+						validateResult(t, result, struct {
+							level     string
+							kind      string
+							message   string
+							ruleID    string
+							namespace string
+						}{
+							level:     levelWarning,
+							kind:      kindReview,
+							message:   result.Message.Text,
+							ruleID:    ruleWarningBase,
+							namespace: testNamespace,
+						})
+					case levelError:
+						failureCount++
+						validateResult(t, result, struct {
+							level     string
+							kind      string
+							message   string
+							ruleID    string
+							namespace string
+						}{
+							level:     levelError,
+							kind:      kindFail,
+							message:   testFailureMsg,
+							ruleID:    ruleFailureBase,
+							namespace: testNamespace,
+						})
+					}
+				}
+
+				if warningCount != 2 {
+					t.Errorf("expected 2 warnings, got %d", warningCount)
+				}
+				if failureCount != 1 {
+					t.Errorf("expected 1 failure, got %d", failureCount)
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "handles stdin input",
+			input: []CheckResult{
+				{
+					FileName:  "-",
+					Namespace: testNamespace,
+					Failures:  []Result{{Message: testFailureMsg}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				result := run.Results[0]
+				validateResult(t, result, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    ruleFailureBase,
+					namespace: testNamespace,
+				})
+
+				// Verify location URI for stdin
+				if result.Locations[0].PhysicalLocation.ArtifactLocation.URI != "-" {
+					t.Errorf("expected URI '-' for stdin, got '%s'", result.Locations[0].PhysicalLocation.ArtifactLocation.URI)
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "includes metadata in rules and results",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{{
+						Message: testFailureMsg,
+						Metadata: map[string]interface{}{
+							"description": testFailureDesc,
+							"url":         testFailureURL,
+							"help":        testFailureHelp,
+						},
+					}},
+					Warnings: []Result{{
+						Message: testWarningMsg,
+						Metadata: map[string]interface{}{
+							"description": testWarnDesc,
+							"url":         testWarnURL,
+							"help":        testWarnHelp,
+						},
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 2 {
+					t.Errorf("expected 2 results, got %d", len(run.Results))
+				}
+
+				// Find and validate failure rule/result
+				expectedFailureRuleID := fmt.Sprintf("%s/%s", ruleFailureBase, strings.ToLower(strings.ReplaceAll(testFailureDesc, " ", "-")))
+				failureRule, failureResult, err := findRule(run, expectedFailureRuleID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				validateRuleMetadata(t, failureRule, struct {
+					description string
+					helpURI     string
+					helpText    string
+					namespace   string
+				}{
+					description: testFailureDesc,
+					helpURI:     testFailureURL,
+					helpText:    testFailureHelp,
+					namespace:   testNamespace,
+				})
+
+				validateResult(t, *failureResult, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    expectedFailureRuleID,
+					namespace: testNamespace,
+				})
+
+				// Find and validate warning rule/result
+				expectedWarningRuleID := fmt.Sprintf("%s/%s", ruleWarningBase, strings.ToLower(strings.ReplaceAll(testWarnDesc, " ", "-")))
+				warningRule, warningResult, err := findRule(run, expectedWarningRuleID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				validateRuleMetadata(t, warningRule, struct {
+					description string
+					helpURI     string
+					helpText    string
+					namespace   string
+				}{
+					description: testWarnDesc,
+					helpURI:     testWarnURL,
+					helpText:    testWarnHelp,
+					namespace:   testNamespace,
+				})
+
+				validateResult(t, *warningResult, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelWarning,
+					kind:      kindReview,
+					message:   testWarningMsg,
+					ruleID:    expectedWarningRuleID,
+					namespace: testNamespace,
+				})
+			},
+		},
+		{
+			name: "handles exceptions",
+			input: []CheckResult{
+				{
+					FileName:  "examples/exceptions/deployments.yaml",
+					Namespace: "main",
+					Failures: []Result{{
+						Message: "Containers must not run as root",
+					}},
+					Exceptions: []Result{{
+						Message: "data.main.exception[_][_] == \"run_as_root\"",
+						Metadata: map[string]interface{}{
+							"description": "Exception for running as root",
+							"error":       "run_as_root",
+							"code":        "policy_exception",
+						},
+					}},
+				},
+				{
+					FileName:  "examples/exceptions/other.yaml",
+					Namespace: "main",
+					Exceptions: []Result{{
+						Message: "data.main.exception[_][_] == \"other\"",
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 3 {
+					t.Errorf("expected 3 results (1 failure, 2 exceptions), got %d", len(run.Results))
+				}
+
+				exceptionCount := 0
+				failureCount := 0
+				for _, result := range run.Results {
+					switch result.Kind {
+					case kindInfo:
+						exceptionCount++
+						validateResult(t, result, struct {
+							level     string
+							kind      string
+							message   string
+							ruleID    string
+							namespace string
+						}{
+							level:     levelNote,
+							kind:      kindInfo,
+							message:   result.Message.Text,
+							ruleID:    ruleExceptionBase,
+							namespace: "main",
+						})
+
+						// Verify error details if present
+						if result.Message.Text == "data.main.exception[_][_] == \"run_as_root\"" {
+							if errType, ok := result.Properties["error"].(string); !ok || errType != "run_as_root" {
+								t.Error("expected error type in properties")
+							}
+							if code, ok := result.Properties["code"].(string); !ok || code != "policy_exception" {
+								t.Error("expected error code in properties")
+							}
+						}
+
+					case kindFail:
+						failureCount++
+						validateResult(t, result, struct {
+							level     string
+							kind      string
+							message   string
+							ruleID    string
+							namespace string
+						}{
+							level:     levelError,
+							kind:      kindFail,
+							message:   "Containers must not run as root",
+							ruleID:    ruleFailureBase,
+							namespace: "main",
+						})
+					}
+				}
+
+				if exceptionCount != 2 {
+					t.Errorf("expected 2 exceptions, got %d", exceptionCount)
+				}
+				if failureCount != 1 {
+					t.Errorf("expected 1 failure, got %d", failureCount)
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "success result when checks pass",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Successes: 1,
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelNone,
+					kind:      kindPass,
+					message:   successDesc,
+					ruleID:    rulePassBase,
+					namespace: testNamespace,
+				})
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   0,
+					exitDesc:   exitNoViolations,
+				})
+			},
+		},
+		{
+			name: "skipped result when no checks run",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Successes: 0,
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelNone,
+					kind:      kindSkipped,
+					message:   skippedDesc,
+					ruleID:    ruleSkippedBase,
+					namespace: testNamespace,
+				})
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   0,
+					exitDesc:   exitNoViolations,
+				})
+			},
+		},
+		{
+			name: "no success/skipped result when failures exist",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Successes: 5,
+					Failures:  []Result{{Message: testFailureMsg}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result (failure only), got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    ruleFailureBase,
+					namespace: testNamespace,
+				})
+			},
+		},
+		{
+			name: "rule ID generation with policy metadata",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{{
+						Message: testFailureMsg,
+						Metadata: map[string]interface{}{
+							"package":     testPackage,
+							"rule":        testRuleName,
+							"description": testFailureDesc,
+						},
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				result := run.Results[0]
+				expectedRuleID := fmt.Sprintf("%s/%s/%s", testNamespace, testPackage, testRuleName)
+				if result.RuleID != expectedRuleID {
+					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
+				}
+
+				// Find and validate the rule
+				rule, foundResult, err := findRule(run, expectedRuleID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if foundResult == nil {
+					t.Fatal("no result found for rule")
+				}
+				result = *foundResult
+
+				// Verify package and rule in rule properties
+				if pkg, ok := rule.Properties["package"].(string); !ok || pkg != testPackage {
+					t.Errorf("expected package '%s' in rule properties, got '%v'", testPackage, rule.Properties["package"])
+				}
+				if ruleName, ok := rule.Properties["rule"].(string); !ok || ruleName != testRuleName {
+					t.Errorf("expected rule name '%s' in rule properties, got '%v'", testRuleName, rule.Properties["rule"])
+				}
+
+				validateResult(t, result, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    expectedRuleID,
+					namespace: testNamespace,
+				})
+			},
+		},
+		{
+			name: "rule ID generation with description fallback",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{{
+						Message: testFailureMsg,
+						Metadata: map[string]interface{}{
+							"description": testFailureDesc,
+						},
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				result := run.Results[0]
+				expectedRuleID := fmt.Sprintf("%s/%s", ruleFailureBase, strings.ToLower(strings.ReplaceAll(testFailureDesc, " ", "-")))
+				if result.RuleID != expectedRuleID {
+					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
+				}
+
+				validateResult(t, result, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    expectedRuleID,
+					namespace: testNamespace,
+				})
+			},
+		},
+		{
+			name: "rule ID generation with no metadata",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{{
+						Message:  testFailureMsg,
+						Metadata: map[string]interface{}{},
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   testFailureMsg,
+					ruleID:    ruleFailureBase,
+					namespace: testNamespace,
+				})
+			},
+		},
+		{
+			name: "rule ID generation with message hash",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{{
+						Message: testFailureMsg,
+						Metadata: map[string]interface{}{
+							"severity": "HIGH",
+						},
+					}},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				var report sarifReport
+				if err := json.NewDecoder(strings.NewReader(output)).Decode(&report); err != nil {
+					t.Fatalf("failed to decode SARIF output: %v", err)
+				}
+
+				run := report.Runs[0]
+				result := run.Results[0]
+				expectedRuleID := ruleFailureBase
+				if result.RuleID != expectedRuleID {
+					t.Errorf("expected rule ID '%s', got '%s'", expectedRuleID, result.RuleID)
+				}
+			},
+		},
+		{
+			name: "multiple violations from same rule",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Failures: []Result{
+						{
+							Message: "Container 'app1' runs as privileged",
+							Metadata: map[string]interface{}{
+								"rule":      "no_privileged",
+								"container": "app1",
+								"query":     "data.kubernetes.deny_privileged_container",
+							},
+						},
+						{
+							Message: "Container 'app2' runs as privileged",
+							Metadata: map[string]interface{}{
+								"rule":      "no_privileged",
+								"container": "app2",
+								"query":     "data.kubernetes.deny_privileged_container",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 2 {
+					t.Errorf("expected 2 results, got %d", len(run.Results))
+				}
+
+				// Both results should have the same ruleId and ruleIndex
+				firstResult := run.Results[0]
+				secondResult := run.Results[1]
+				if firstResult.RuleID != secondResult.RuleID {
+					t.Errorf("expected same rule ID, got '%s' and '%s'", firstResult.RuleID, secondResult.RuleID)
+				}
+				if firstResult.RuleIndex != secondResult.RuleIndex {
+					t.Errorf("expected same rule index, got %d and %d", firstResult.RuleIndex, secondResult.RuleIndex)
+				}
+
+				// Validate each result
+				for _, result := range run.Results {
+					validateResult(t, result, struct {
+						level     string
+						kind      string
+						message   string
+						ruleID    string
+						namespace string
+					}{
+						level:     levelError,
+						kind:      kindFail,
+						message:   result.Message.Text,
+						ruleID:    fmt.Sprintf("%s-kubernetes-deny_privileged_container", ruleFailureBase),
+						namespace: testNamespace,
+					})
+
+					// Verify query path in properties
+					if query, ok := result.Properties["query"].(string); !ok || query != "data.kubernetes.deny_privileged_container" {
+						t.Errorf("unexpected query: %v", result.Properties["query"])
+					}
+
+					// Verify container in properties
+					if container, ok := result.Properties["container"].(string); !ok || (container != "app1" && container != "app2") {
+						t.Errorf("unexpected container: %v", result.Properties["container"])
+					}
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "cross package rules",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: "kubernetes",
+					Failures: []Result{
+						{
+							Message: "Container runs as privileged",
+							Metadata: map[string]interface{}{
+								"query": "data.kubernetes.deny_privileged_container",
+							},
+						},
+					},
+				},
+				{
+					FileName:  testFileName,
+					Namespace: "custom",
+					Failures: []Result{
+						{
+							Message: "Custom rule violation",
+							Metadata: map[string]interface{}{
+								"query": "data.custom.deny_custom",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 2 {
+					t.Errorf("expected 2 results, got %d", len(run.Results))
+				}
+
+				// Validate kubernetes rule result
+				validateResult(t, run.Results[0], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   "Container runs as privileged",
+					ruleID:    fmt.Sprintf("%s-kubernetes-deny_privileged_container", ruleFailureBase),
+					namespace: "kubernetes",
+				})
+
+				// Validate custom rule result
+				validateResult(t, run.Results[1], struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   "Custom rule violation",
+					ruleID:    fmt.Sprintf("%s-custom-deny_custom", ruleFailureBase),
+					namespace: "custom",
+				})
+
+				// Verify query paths in properties
+				if query, ok := run.Results[0].Properties["query"].(string); !ok || query != "data.kubernetes.deny_privileged_container" {
+					t.Errorf("unexpected query in first result: %v", run.Results[0].Properties["query"])
+				}
+				if query, ok := run.Results[1].Properties["query"].(string); !ok || query != "data.custom.deny_custom" {
+					t.Errorf("unexpected query in second result: %v", run.Results[1].Properties["query"])
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   1,
+					exitDesc:   exitViolations,
+				})
+			},
+		},
+		{
+			name: "exception handling",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: testNamespace,
+					Exceptions: []Result{
+						{
+							Message: "Division by zero in policy evaluation",
+							Metadata: map[string]interface{}{
+								"error": "divide by zero",
+								"code":  "rego_type_error",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				result := run.Results[0]
+				validateResult(t, result, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelNote,
+					kind:      kindInfo,
+					message:   "Division by zero in policy evaluation",
+					ruleID:    ruleExceptionBase,
+					namespace: testNamespace,
+				})
+
+				// Verify error details in properties
+				if errMsg, ok := result.Properties["error"].(string); !ok || errMsg != "divide by zero" {
+					t.Errorf("expected error 'divide by zero', got '%v'", result.Properties["error"])
+				}
+				if code, ok := result.Properties["code"].(string); !ok || code != "rego_type_error" {
+					t.Errorf("expected code 'rego_type_error', got '%v'", result.Properties["code"])
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   0,
+					exitDesc:   exitExceptions,
+				})
+			},
+		},
+		{
+			name: "query path inclusion",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: "kubernetes.security",
+					Failures: []Result{
+						{
+							Message: "Security violation",
+							Metadata: map[string]interface{}{
+								"query":   "data.kubernetes.security.deny_privileged",
+								"package": "kubernetes.security",
+								"rule":    "deny_privileged",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 1 {
+					t.Errorf("expected 1 result, got %d", len(run.Results))
+				}
+
+				result := run.Results[0]
+				expectedRuleID := fmt.Sprintf("%s/%s/%s", "kubernetes.security", "kubernetes.security", "deny_privileged")
+
+				validateResult(t, result, struct {
+					level     string
+					kind      string
+					message   string
+					ruleID    string
+					namespace string
+				}{
+					level:     levelError,
+					kind:      kindFail,
+					message:   "Security violation",
+					ruleID:    expectedRuleID,
+					namespace: "kubernetes.security",
+				})
+
+				// Verify query path in properties
+				if query, ok := result.Properties["query"].(string); !ok || query != "data.kubernetes.security.deny_privileged" {
+					t.Errorf("unexpected query path: %v", result.Properties["query"])
+				}
+
+				// Find and validate the rule
+				rule, _, err := findRule(run, expectedRuleID)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Verify package and rule in rule properties
+				if pkg, ok := rule.Properties["package"].(string); !ok || pkg != "kubernetes.security" {
+					t.Errorf("unexpected package: %v", rule.Properties["package"])
+				}
+				if ruleName, ok := rule.Properties["rule"].(string); !ok || ruleName != "deny_privileged" {
+					t.Errorf("unexpected rule: %v", rule.Properties["rule"])
+				}
+			},
+		},
+		{
+			name: "policy warnings",
+			input: []CheckResult{
+				{
+					FileName:  testFileName,
+					Namespace: "kubernetes",
+					Warnings: []Result{
+						{
+							Message: "Memory limits not set",
+							Metadata: map[string]interface{}{
+								"query":     "data.kubernetes.warn_no_memory_limits",
+								"package":   "kubernetes",
+								"rule":      "warn_memory_limits",
+								"container": "app",
+							},
+						},
+						{
+							Message: "CPU limits not set",
+							Metadata: map[string]interface{}{
+								"query":     "data.kubernetes.warn_no_cpu_limits",
+								"package":   "kubernetes",
+								"rule":      "warn_cpu_limits",
+								"container": "app",
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, output string) {
+				report := decodeSARIFReport(t, output)
+				run := report.Runs[0]
+
+				if len(run.Results) != 2 {
+					t.Errorf("expected 2 warning results, got %d", len(run.Results))
+				}
+
+				// Expected rule IDs based on package and rule names
+				expectedRuleIDs := map[string]bool{
+					"kubernetes/kubernetes/warn_memory_limits": false,
+					"kubernetes/kubernetes/warn_cpu_limits":    false,
+				}
+
+				for _, result := range run.Results {
+					// Mark rule ID as found
+					expectedRuleIDs[result.RuleID] = true
+
+					validateResult(t, result, struct {
+						level     string
+						kind      string
+						message   string
+						ruleID    string
+						namespace string
+					}{
+						level:     levelWarning,
+						kind:      kindReview,
+						message:   result.Message.Text,
+						ruleID:    result.RuleID,
+						namespace: "kubernetes",
+					})
+
+					// Find and validate the rule
+					rule, _, err := findRule(run, result.RuleID)
+					if err != nil {
+						t.Fatalf("rule not found: %s", result.RuleID)
+					}
+
+					// Verify rule properties
+					if pkg, ok := rule.Properties["package"].(string); !ok || pkg != "kubernetes" {
+						t.Errorf("unexpected package in rule: %v", rule.Properties["package"])
+					}
+					if ruleName, ok := rule.Properties["rule"].(string); !ok || !strings.HasPrefix(ruleName, "warn_") {
+						t.Errorf("unexpected rule name: %v", rule.Properties["rule"])
+					}
+
+					// Verify query path and container in properties
+					if query, ok := result.Properties["query"].(string); !ok || !strings.HasPrefix(query, "data.kubernetes.warn_") {
+						t.Errorf("unexpected query: %v", result.Properties["query"])
+					}
+					if container, ok := result.Properties["container"].(string); !ok || container != "app" {
+						t.Errorf("unexpected container: %v", result.Properties["container"])
+					}
+				}
+
+				// Verify all expected rule IDs were found
+				for ruleID, found := range expectedRuleIDs {
+					if !found {
+						t.Errorf("expected rule ID not found: %s", ruleID)
+					}
+				}
+
+				validateInvocation(t, run.Invocations[0], struct {
+					successful bool
+					exitCode   int
+					exitDesc   string
+				}{
+					successful: true,
+					exitCode:   0,
+					exitDesc:   exitWarnings,
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			s := NewSARIF(&buf)
+
+			if err := s.Output(tt.input); err != nil {
+				t.Fatalf("failed to output SARIF: %v", err)
+			}
+
+			tt.validate(t, buf.String())
+		})
+	}
+}
+
+func TestSARIFReport(t *testing.T) {
+	var buf bytes.Buffer
+	sarif := NewSARIF(&buf)
+
+	err := sarif.Report(nil, "")
+	if err == nil {
+		t.Error("expected error for Report call")
+	}
+
+	wantErrMsg := "report is not supported in SARIF output"
+	if !strings.Contains(err.Error(), wantErrMsg) {
+		t.Errorf("expected error containing '%s', got: %v", wantErrMsg, err)
+	}
+}
+
+func TestGetRuleID(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    Result
+		rType     resultType
+		namespace string
+		want      string
+	}{
+		{
+			name: "success result uses base ID",
+			result: Result{
+				Message: "success",
+				Metadata: map[string]interface{}{
+					"query": "data.main.deny",
+				},
+			},
+			rType:     successResultType,
+			namespace: "main",
+			want:      "conftest-pass",
+		},
+		{
+			name: "skipped result uses base ID",
+			result: Result{
+				Message: "skipped",
+				Metadata: map[string]interface{}{
+					"query": "data.main.deny",
+				},
+			},
+			rType:     skippedResultType,
+			namespace: "main",
+			want:      "conftest-skipped",
+		},
+		{
+			name: "uses package and rule from metadata when available",
+			result: Result{
+				Message: "violation",
+				Metadata: map[string]interface{}{
+					"package": "kubernetes",
+					"rule":    "deny_privileged",
+					"query":   "data.kubernetes.deny",
+				},
+			},
+			rType:     failureResultType,
+			namespace: "main",
+			want:      "main/kubernetes/deny_privileged",
+		},
+		{
+			name: "uses query path when package/rule not available",
+			result: Result{
+				Message: "violation",
+				Metadata: map[string]interface{}{
+					"query": "data.kubernetes.deny",
+				},
+			},
+			rType:     failureResultType,
+			namespace: "main",
+			want:      "conftest-failure-kubernetes-deny",
+		},
+		{
+			name: "uses description when no query or package/rule",
+			result: Result{
+				Message: "violation",
+				Metadata: map[string]interface{}{
+					"description": "No privileged containers allowed",
+				},
+			},
+			rType:     failureResultType,
+			namespace: "main",
+			want:      "conftest-failure/no-privileged-containers-allowed",
+		},
+		{
+			name: "falls back to base ID when no identifying information",
+			result: Result{
+				Message:  "violation",
+				Metadata: map[string]interface{}{},
+			},
+			rType:     failureResultType,
+			namespace: "main",
+			want:      "conftest-failure",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getRuleID(tt.result, tt.rType, tt.namespace)
+			if got != tt.want {
+				t.Errorf("getRuleID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryInformation(t *testing.T) {
+	var buf bytes.Buffer
+	s := NewSARIF(&buf)
+
+	results := []CheckResult{
+		{
+			FileName:  "test.yaml",
+			Namespace: "main",
+			Failures: []Result{
+				{
+					Message: "violation found",
+					Metadata: map[string]interface{}{
+						"query":   "data.main.deny",
+						"traces":  []string{"trace1", "trace2"},
+						"outputs": []string{"output1", "output2"},
+						"package": "main",
+						"rule":    "deny",
+					},
+				},
+			},
+		},
+	}
+
+	if err := s.Output(results); err != nil {
+		t.Fatal(err)
+	}
+
+	report := decodeSARIFReport(t, buf.String())
+	run := report.Runs[0]
+
+	if len(run.Results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(run.Results))
+	}
+
+	expectedRuleID := "main/main/deny"
+	validateResult(t, run.Results[0], struct {
+		level     string
+		kind      string
+		message   string
+		ruleID    string
+		namespace string
+	}{
+		level:     levelError,
+		kind:      kindFail,
+		message:   "violation found",
+		ruleID:    expectedRuleID,
+		namespace: "main",
+	})
+
+	// Find and validate the rule
+	_, foundResult, err := findRule(run, expectedRuleID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if foundResult == nil {
+		t.Fatal("no result found for rule")
+	}
+	result := *foundResult
+
+	// Verify query information in properties
+	if query, ok := result.Properties["query"].(string); !ok || query != "data.main.deny" {
+		t.Errorf("unexpected query: %v", result.Properties["query"])
+	}
+
+	// Verify traces and outputs are preserved
+	if traces, ok := result.Properties["traces"].([]interface{}); !ok || len(traces) != 2 {
+		t.Errorf("unexpected traces: %v", result.Properties["traces"])
+	}
+	if outputs, ok := result.Properties["outputs"].([]interface{}); !ok || len(outputs) != 2 {
+		t.Errorf("unexpected outputs: %v", result.Properties["outputs"])
+	}
+
+	validateInvocation(t, run.Invocations[0], struct {
+		successful bool
+		exitCode   int
+		exitDesc   string
+	}{
+		successful: true,
+		exitCode:   1,
+		exitDesc:   exitViolations,
+	})
+}
+
+// Helper functions for testing
+func decodeSARIFReport(t *testing.T, output string) sarifReport {
+	t.Helper()
+	var report sarifReport
+	if err := json.NewDecoder(strings.NewReader(output)).Decode(&report); err != nil {
+		t.Fatalf("failed to decode SARIF output: %v", err)
+	}
+	return report
+}
+
+// validateResult validates that a SARIF result matches the expected values for level, kind,
+// message, rule ID and namespace
+func validateResult(t *testing.T, result sarifResult, expected struct {
+	level     string
+	kind      string
+	message   string
+	ruleID    string
+	namespace string
+}) {
+	t.Helper()
+	if result.Level != expected.level {
+		t.Errorf("expected level '%s', got '%s'", expected.level, result.Level)
+	}
+	if result.Kind != expected.kind {
+		t.Errorf("expected kind '%s', got '%s'", expected.kind, result.Kind)
+	}
+	if result.Message.Text != expected.message {
+		t.Errorf("expected message '%s', got '%s'", expected.message, result.Message.Text)
+	}
+	if result.RuleID != expected.ruleID {
+		t.Errorf("expected rule ID '%s', got '%s'", expected.ruleID, result.RuleID)
+	}
+	if ns, ok := result.Properties["namespace"].(string); !ok || ns != expected.namespace {
+		t.Errorf("expected namespace '%s' in properties, got '%v'", expected.namespace, result.Properties["namespace"])
+	}
+}
+
+// validateInvocation validates that a SARIF invocation matches the expected values for
+// execution success, exit code and exit code description.
+func validateInvocation(t *testing.T, invocation sarifInvocation, expected struct {
+	successful bool
+	exitCode   int
+	exitDesc   string
+}) {
+	t.Helper()
+	if invocation.ExecutionSuccessful != expected.successful {
+		t.Error("unexpected execution success state")
+	}
+	if invocation.ExitCode != expected.exitCode {
+		t.Errorf("expected exit code %d, got %d", expected.exitCode, invocation.ExitCode)
+	}
+	if invocation.ExitCodeDescription != expected.exitDesc {
+		t.Errorf("unexpected exit code description: %s", invocation.ExitCodeDescription)
+	}
+}
+
+// validateTimestamps validates that the start and end times in a SARIF invocation
+// are valid RFC3339 timestamps and chronologically ordered.
+func validateTimestamps(t *testing.T, invocation sarifInvocation) {
+	t.Helper()
+	startTime, err := time.Parse(time.RFC3339, invocation.StartTimeUtc)
+	if err != nil {
+		t.Errorf("invalid start time format: %v", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, invocation.EndTimeUtc)
+	if err != nil {
+		t.Errorf("invalid end time format: %v", err)
+	}
+	if endTime.Before(startTime) {
+		t.Error("end time should not be before start time")
+	}
+}
+
+// findRule returns the rule and its associated result for a given rule ID.
+// If the rule is not found, it returns an error.
+func findRule(run sarifRun, ruleID string) (rule *sarifRule, result *sarifResult, err error) {
+	for i := range run.Tool.Driver.Rules {
+		r := run.Tool.Driver.Rules[i] // Take reference to array element, not loop variable
+		if r.ID == ruleID {
+			rule = &r
+			// Find the first result that references this rule
+			for j := range run.Results {
+				res := run.Results[j] // Take reference to array element, not loop variable
+				if res.RuleIndex == i {
+					result = &res
+					return rule, result, nil
+				}
+			}
+			// Rule found but no results reference it
+			return rule, nil, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("rule not found: %s", ruleID)
+}
+
+// validateRuleMetadata validates that a SARIF rule matches the expected values for description, help URI,
+// help text and namespace.
+func validateRuleMetadata(t *testing.T, rule *sarifRule, expected struct {
+	description string
+	helpURI     string
+	helpText    string
+	namespace   string
+}) {
+	t.Helper()
+	if rule == nil {
+		t.Fatal("rule is nil")
+	}
+	if rule.FullDescription == nil || rule.FullDescription.Text != expected.description {
+		t.Error("invalid rule description")
+	}
+	if rule.HelpURI != expected.helpURI {
+		t.Error("invalid help URI")
+	}
+	if rule.Help == nil || rule.Help.Text != expected.helpText {
+		t.Error("invalid help text")
+	}
+	if ns, ok := rule.Properties["namespace"].(string); !ok || ns != expected.namespace {
+		t.Errorf("expected namespace '%s' in rule properties, got '%v'", expected.namespace, ns)
+	}
+}

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -478,6 +478,7 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 	var results []output.Result
 	for _, result := range resultSet {
 		for _, expression := range result.Expressions {
+
 			// Rego rules that are intended for evaluation should return a slice of values.
 			// For example, deny[msg] or violation[{"msg": msg}].
 			//
@@ -494,13 +495,11 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 
 			for _, v := range expressionValues {
 				switch val := v.(type) {
+
 				// Policies that only return a single string (e.g. deny[msg])
 				case string:
 					result := output.Result{
 						Message: val,
-						Metadata: map[string]interface{}{
-							"query": query,
-						},
 					}
 					results = append(results, result)
 
@@ -510,12 +509,6 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 					if err != nil {
 						return output.QueryResult{}, fmt.Errorf("new result: %w", err)
 					}
-
-					// Add query to metadata
-					if result.Metadata == nil {
-						result.Metadata = make(map[string]interface{})
-					}
-					result.Metadata["query"] = query
 
 					results = append(results, result)
 				}

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -478,7 +478,6 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 	var results []output.Result
 	for _, result := range resultSet {
 		for _, expression := range result.Expressions {
-
 			// Rego rules that are intended for evaluation should return a slice of values.
 			// For example, deny[msg] or violation[{"msg": msg}].
 			//
@@ -495,11 +494,13 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 
 			for _, v := range expressionValues {
 				switch val := v.(type) {
-
 				// Policies that only return a single string (e.g. deny[msg])
 				case string:
 					result := output.Result{
 						Message: val,
+						Metadata: map[string]interface{}{
+							"query": query,
+						},
 					}
 					results = append(results, result)
 
@@ -509,6 +510,12 @@ func (e *Engine) query(ctx context.Context, input interface{}, query string) (ou
 					if err != nil {
 						return output.QueryResult{}, fmt.Errorf("new result: %w", err)
 					}
+
+					// Add query to metadata
+					if result.Metadata == nil {
+						result.Metadata = make(map[string]interface{})
+					}
+					result.Metadata["query"] = query
 
 					results = append(results, result)
 				}


### PR DESCRIPTION
# Description

This pull request introduces `--output=sarif` feature that produces [SARIF 2.1.0](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) logs from Conftest policy evaluations using the [go-sarif](https://github.com/owenrumney/go-sarif) library. The implementation handles Conftest-specific logic, such as pass/fail/skipped/exception states, unique rule ID derivation, and multi-rule checks from single policy definitions.

## Implementation details

- Uses `go-sarif/v2` library to ensure proper SARIF schema compliance and maintainability
- `output/sarif.go` implements a dedicated outputter that:
  - Organizes policy evaluations into a SARIF run
  - Maps Conftest results to appropriate SARIF severity levels (error/warning/note/none)
  - Preserves rule metadata and properties in the SARIF output
  - Handles all result types: failures, warnings, exceptions, and successes
- SARIF 2.1.0 support chosen for optimal tooling coverage and compatibility

New pkg dependencies:

- [github.com/owenrumney/go-sarif](https://github.com/owenrumney/go-sarif)
- [github.com/sergi/go-diff](https://github.com/sergi/go-diff) for diffing JSON in tests

Documentation and comprehensive test coverage included. Output validated with [SARIF viewer](https://microsoft.github.io/sarif-web-component/) and other SARIF-compatible tools.

Happy to hear feedback and make this merged in!

## References

Fixes #885 