### PR TITLE
feat: enable relative jsonnet imports by setting a path-aware importer

### DIFF
--- a/parser/jsonnet/jsonnet.go
+++ b/parser/jsonnet/jsonnet.go
@@ -3,17 +3,34 @@ package jsonnet
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 
 	"github.com/google/go-jsonnet"
 )
 
 // Parser is a Jsonnet parser.
-type Parser struct{}
+type Parser struct {
+	path string
+}
+
+// SetPath sets the original file path for relative imports
+func (p *Parser) SetPath(path string) {
+	p.path = path
+}
 
 // Unmarshal unmarshals Jsonnet files.
 func (p *Parser) Unmarshal(data []byte, v interface{}) error {
 	vm := jsonnet.MakeVM()
 	vm.ErrorFormatter.SetMaxStackTraceSize(20)
+
+	// If path is set, configure import path to the file's directory
+	if p.path != "" {
+		dir := filepath.Dir(p.path)
+		vm.Importer(&jsonnet.FileImporter{
+			JPaths: []string{dir},
+		})
+	}
+
 	snippetStream, err := vm.EvaluateAnonymousSnippet("", string(data))
 	if err != nil {
 		return fmt.Errorf("evaluate anonymous snippet: %w", err)

--- a/parser/jsonnet/jsonnet_test.go
+++ b/parser/jsonnet/jsonnet_test.go
@@ -1,6 +1,8 @@
 package jsonnet
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -119,6 +121,87 @@ func TestJsonnetParser(t *testing.T) {
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Parser.Unmarshal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJsonnetImports(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create a library file that will be imported
+	libPath := filepath.Join(tmpDir, "lib.libsonnet")
+	libContent := `{
+  getName(person):: "Hello " + person + "!"
+}`
+	if err := os.WriteFile(libPath, []byte(libContent), os.FileMode(0600)); err != nil {
+		t.Fatalf("failed to write lib file: %v", err)
+	}
+
+	// Create main Jsonnet file that imports the library
+	mainPath := filepath.Join(tmpDir, "main.jsonnet")
+	mainContent := `local lib = import "lib.libsonnet";
+{
+  greeting: lib.getName("Alice")
+}`
+	if err := os.WriteFile(mainPath, []byte(mainContent), os.FileMode(0600)); err != nil {
+		t.Fatalf("failed to write main file: %v", err)
+	}
+
+	// Test cases
+	tests := []struct {
+		name     string
+		path     string
+		content  []byte
+		wantErr  bool
+		validate func(t *testing.T, result interface{})
+	}{
+		{
+			name:    "successful import",
+			path:    mainPath,
+			content: []byte(mainContent),
+			validate: func(t *testing.T, result interface{}) {
+				t.Helper()
+				m, ok := result.(map[string]interface{})
+				if !ok {
+					t.Fatal("result is not a map")
+				}
+				greeting, ok := m["greeting"].(string)
+				if !ok {
+					t.Fatal("greeting is not a string")
+				}
+				if want := "Hello Alice!"; greeting != want {
+					t.Errorf("got greeting %q, want %q", greeting, want)
+				}
+			},
+		},
+		{
+			name:    "import without path set",
+			content: []byte(mainContent),
+			wantErr: true, // Should fail as import path is not set
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Parser{}
+			if tt.path != "" {
+				parser.SetPath(tt.path)
+			}
+
+			var result interface{}
+			err := parser.Unmarshal(tt.content, &result)
+
+			// Check error expectation
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// If we expect success and have a validation function, run it
+			if !tt.wantErr && tt.validate != nil {
+				tt.validate(t, result)
 			}
 		})
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -66,6 +66,13 @@ type Parser interface {
 	Unmarshal(p []byte, v interface{}) error
 }
 
+// PathAwareParser is an optional interface that parsers may implement
+// if they need the original file path for relative imports or other logic.
+type PathAwareParser interface {
+	Parser
+	SetPath(path string)
+}
+
 // New returns a new Parser.
 func New(parser string) (Parser, error) {
 	switch parser {
@@ -324,6 +331,11 @@ func parseConfigurations(paths []string, parser string) (map[string]interface{},
 		contents, err := getConfigurationContent(path)
 		if err != nil {
 			return nil, errWithPathInfo(err, "get configuration content", path)
+		}
+
+		// If our parser needs the path, give it the path
+		if p, ok := fileParser.(PathAwareParser); ok {
+			p.SetPath(path)
 		}
 
 		var parsed interface{}


### PR DESCRIPTION
- Introduce a new `PathAwareParser` interface that extends `Parser` with `SetPath(path string)`.
- Update `parseConfigurations` to detect if a parser implements `PathAwareParser`, and call `SetPath(path)`.
- Implement `SetPath` in the Jsonnet parser, setting the JPath (library path) to the file’s directory.
- Add tests to ensure that relative imports in Jsonnet now work as expected.

Fixes #939 