### PR TITLE
fix: correct linters-settings in .golangci.yaml to enable misspell

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,4 +1,4 @@
-linter-settings:
+linters-settings:
   misspell:
     locale: US
 

--- a/internal/commands/parse.go
+++ b/internal/commands/parse.go
@@ -85,10 +85,10 @@ func formatSingleJSON(configurations map[string]interface{}) (string, error) {
 	for _, cfg := range configurations {
 		config = cfg
 	}
-	marshalled, err := json.MarshalIndent(config, "", "  ")
+	marshaled, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return "", err
 	}
 
-	return string(marshalled), nil
+	return string(marshaled), nil
 }

--- a/parser/cyclonedx/cyclonedx.go
+++ b/parser/cyclonedx/cyclonedx.go
@@ -29,18 +29,18 @@ func (*Parser) Unmarshal(p []byte, v interface{}) error {
 	if bomFileFormat == cyclonedx.BOMFileFormatXML {
 		var data cyclonedx.BOM
 		if err := xml.Unmarshal(p, &data); err != nil {
-			return fmt.Errorf("unmarshalling XML error: %v", err)
+			return fmt.Errorf("unmarshaling XML error: %v", err)
 		}
 		if d, err := json.Marshal(data); err == nil {
 			temp = d
 		} else {
-			return fmt.Errorf("marshalling JSON error: %v", err)
+			return fmt.Errorf("marshaling JSON error: %v", err)
 		}
 	}
 
 	err := json.Unmarshal(temp, v)
 	if err != nil {
-		return fmt.Errorf("unmarshalling JSON error: %v", err)
+		return fmt.Errorf("unmarshaling JSON error: %v", err)
 	}
 
 	return nil

--- a/parser/format.go
+++ b/parser/format.go
@@ -27,12 +27,12 @@ func Format(configurations map[string]interface{}) (string, error) {
 // object where each key is the path to the file and the contents are the
 // parsed configurations.
 func FormatJSON(configurations map[string]interface{}) (string, error) {
-	marshalled, err := json.MarshalIndent(configurations, "", "  ")
+	marshaled, err := json.MarshalIndent(configurations, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal configs: %w", err)
 	}
 
-	return string(marshalled), nil
+	return string(marshaled), nil
 }
 
 // FormatCombined takes in multiple configurations, combines them, and formats the

--- a/parser/spdx/spdx.go
+++ b/parser/spdx/spdx.go
@@ -20,7 +20,7 @@ func (*Parser) Unmarshal(p []byte, v interface{}) error {
 
 	out, err := json.Marshal(doc)
 	if err != nil {
-		return fmt.Errorf("error while marshalling %v: %v", p, err)
+		return fmt.Errorf("error while marshaling %v: %v", p, err)
 	}
 
 	if err := json.Unmarshal(out, v); err != nil {


### PR DESCRIPTION
* Fix typo in `.golangci.yaml` to enable linter settings
* Fix marshal/unmarshal spelling across codebase