### PR TITLE
chore: add nilness check to govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,9 @@
 linters-settings:
   misspell:
     locale: US
+  govet:
+    enable:
+      - nilness
 
 linters:
   disable-all: true


### PR DESCRIPTION
* Add nilness check to govet linter configuration

See #1041 for an example