### PR TITLE
refactor(output): Add CheckResults type and helpers

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -132,11 +132,9 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running test: %w", err)
 			}
 
-			var exitCode int
+			exitCode := results.ExitCode()
 			if runner.FailOnWarn {
-				exitCode = output.ExitCodeFailOnWarn(results)
-			} else {
-				exitCode = output.ExitCode(results)
+				exitCode = results.ExitCodeFailOnWarn()
 			}
 
 			if !runner.Quiet || exitCode != 0 {

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -102,7 +102,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("running verification: %w", err)
 			}
 
-			exitCode := output.ExitCode(results)
+			exitCode := results.ExitCode()
 			if !runner.Quiet || exitCode != 0 {
 				outputter := output.Get(runner.Output, output.Options{
 					NoColor:          runner.NoColor,

--- a/output/azuredevops.go
+++ b/output/azuredevops.go
@@ -24,7 +24,7 @@ func NewAzureDevOps(w io.Writer) *AzureDevOps {
 }
 
 // Output outputs the results.
-func (t *AzureDevOps) Output(checkResults []CheckResult) error {
+func (t *AzureDevOps) Output(checkResults CheckResults) error {
 	var totalFailures int
 	var totalExceptions int
 	var totalWarnings int

--- a/output/azuredevops_test.go
+++ b/output/azuredevops_test.go
@@ -9,12 +9,12 @@ import (
 func TestAzureDevOps(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
+		input    CheckResults
 		expected []string
 	}{
 		{
 			name: "no warnings or errors",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -30,7 +30,7 @@ func TestAzureDevOps(t *testing.T) {
 		},
 		{
 			name: "records failure and warnings",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -50,7 +50,7 @@ func TestAzureDevOps(t *testing.T) {
 		},
 		{
 			name: "mixed failure, warnings and skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -70,7 +70,7 @@ func TestAzureDevOps(t *testing.T) {
 		},
 		{
 			name: "handles stdin input",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",

--- a/output/github.go
+++ b/output/github.go
@@ -24,7 +24,7 @@ func NewGitHub(w io.Writer) *GitHub {
 }
 
 // Output outputs the results.
-func (t *GitHub) Output(checkResults []CheckResult) error {
+func (t *GitHub) Output(checkResults CheckResults) error {
 	var totalFailures int
 	var totalExceptions int
 	var totalWarnings int

--- a/output/github_test.go
+++ b/output/github_test.go
@@ -9,12 +9,12 @@ import (
 func TestGitHub(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
+		input    CheckResults
 		expected []string
 	}{
 		{
 			name: "no warnings or errors",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -29,7 +29,7 @@ func TestGitHub(t *testing.T) {
 		},
 		{
 			name: "records failure and warnings",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -48,7 +48,7 @@ func TestGitHub(t *testing.T) {
 		},
 		{
 			name: "mixed failure, warnings and skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -67,7 +67,7 @@ func TestGitHub(t *testing.T) {
 		},
 		{
 			name: "handles stdin input",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",

--- a/output/json.go
+++ b/output/json.go
@@ -25,7 +25,7 @@ func NewJSON(w io.Writer) *JSON {
 }
 
 // Output outputs the results.
-func (j *JSON) Output(results []CheckResult) error {
+func (j *JSON) Output(results CheckResults) error {
 	for r := range results {
 		if results[r].FileName == "-" {
 			results[r].FileName = ""

--- a/output/json_test.go
+++ b/output/json_test.go
@@ -9,12 +9,12 @@ import (
 func TestJSON(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
+		input    CheckResults
 		expected []string
 	}{
 		{
 			name: "No warnings or errors",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -33,7 +33,7 @@ func TestJSON(t *testing.T) {
 		},
 		{
 			name: "A single failure",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -58,7 +58,7 @@ func TestJSON(t *testing.T) {
 		},
 		{
 			name: "A warning, a failure and a skipped test",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -95,7 +95,7 @@ func TestJSON(t *testing.T) {
 		},
 		{
 			name: "Renames standard input file name to empty string",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",
@@ -120,7 +120,7 @@ func TestJSON(t *testing.T) {
 		},
 		{
 			name: "Multiple files",
-			input: []CheckResult{
+			input: CheckResults{
 				{FileName: "examples/kubernetes/service.yaml", Namespace: "namespace"},
 				{FileName: "examples/kubernetes/deployment.yaml", Namespace: "namespace"},
 			},

--- a/output/junit.go
+++ b/output/junit.go
@@ -29,7 +29,7 @@ func NewJUnit(w io.Writer, hideMessage bool) *JUnit {
 }
 
 // Output outputs the results.
-func (j *JUnit) Output(results []CheckResult) error {
+func (j *JUnit) Output(results CheckResults) error {
 	namespaceTests := make(map[string][]*parser.Test)
 	for _, result := range results {
 		ns := result.Namespace

--- a/output/junit_test.go
+++ b/output/junit_test.go
@@ -11,13 +11,13 @@ import (
 func TestJUnit(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       []CheckResult
+		input       CheckResults
 		hideMessage bool
 		expected    []string
 	}{
 		{
 			name: "No warnings or failures",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -31,7 +31,7 @@ func TestJUnit(t *testing.T) {
 		},
 		{
 			name: "A warning, a failure and a skipped test",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -63,7 +63,7 @@ func TestJUnit(t *testing.T) {
 		},
 		{
 			name: "Failure with a long description",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -90,7 +90,7 @@ This is the rest of the description of the failed test`}},
 		{
 			name:        "Failure with --junit-hide-message set",
 			hideMessage: true,
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",

--- a/output/output.go
+++ b/output/output.go
@@ -9,7 +9,7 @@ import (
 // Outputter controls how results of an evaluation will
 // be recorded and reported to the end user.
 type Outputter interface {
-	Output([]CheckResult) error
+	Output(CheckResults) error
 	Report([]*tester.Result, string) error
 }
 

--- a/output/result_test.go
+++ b/output/result_test.go
@@ -4,6 +4,88 @@ import (
 	"testing"
 )
 
+func TestCheckResultsHelpers(t *testing.T) {
+	tests := []struct {
+		desc             string
+		results          CheckResults
+		wantHasFailure   bool
+		wantHasWarning   bool
+		wantHasException bool
+		wantOnlySuccess  bool
+	}{
+		{
+			desc:            "Empty returns success only",
+			wantOnlySuccess: true,
+		},
+		{
+			desc:            "Result with only success returns success only",
+			results:         CheckResults{{Successes: 12345}},
+			wantOnlySuccess: true,
+		},
+		{
+			desc: "Mix of success and non-success",
+			results: CheckResults{
+				{Successes: 12345},
+				{Failures: []Result{{Message: "Failure"}}},
+				{Warnings: []Result{{Message: "Failure"}}},
+				{Exceptions: []Result{{Message: "Failure"}}},
+			},
+			wantHasFailure:   true,
+			wantHasWarning:   true,
+			wantHasException: true,
+		},
+		{
+			desc: "Failure, warning, exception",
+			results: CheckResults{
+				{Failures: []Result{{Message: "Failure"}}},
+				{Warnings: []Result{{Message: "Failure"}}},
+				{Exceptions: []Result{{Message: "Failure"}}},
+			},
+			wantHasFailure:   true,
+			wantHasWarning:   true,
+			wantHasException: true,
+		},
+		{
+			desc: "Failure only",
+			results: CheckResults{
+				{Failures: []Result{{Message: "Failure"}}},
+			},
+			wantHasFailure: true,
+		},
+		{
+			desc: "Warning only",
+			results: CheckResults{
+				{Warnings: []Result{{Message: "Failure"}}},
+			},
+			wantHasWarning: true,
+		},
+		{
+			desc: "Exception only",
+			results: CheckResults{
+				{Exceptions: []Result{{Message: "Failure"}}},
+			},
+			wantHasException: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if gotFailure := tc.results.HasFailure(); gotFailure != tc.wantHasFailure {
+				t.Errorf("HasFailure() = %v, want %v", gotFailure, tc.wantHasFailure)
+			}
+			if gotWarning := tc.results.HasWarning(); gotWarning != tc.wantHasWarning {
+				t.Errorf("HasWarning() = %v, want %v", gotWarning, tc.wantHasWarning)
+			}
+			if gotException := tc.results.HasException(); gotException != tc.wantHasException {
+				t.Errorf("HasException() = %v, want %v", gotException, tc.wantHasException)
+			}
+			if gotSuccess := tc.results.OnlySuccess(); gotSuccess != tc.wantOnlySuccess {
+				t.Errorf("OnlySuccess() = %v, want %v", gotSuccess, tc.wantOnlySuccess)
+			}
+		})
+	}
+}
+
 func TestExitCode(t *testing.T) {
 	warning := CheckResult{
 		Warnings: []Result{{}},
@@ -18,19 +100,18 @@ func TestExitCode(t *testing.T) {
 	}
 
 	testCases := []struct {
-		results  []CheckResult
+		results  CheckResults
 		expected int
 	}{
-		{results: []CheckResult{}, expected: 0},
-		{results: []CheckResult{warning}, expected: 0},
-		{results: []CheckResult{skipped}, expected: 0},
-		{results: []CheckResult{failure}, expected: 1},
-		{results: []CheckResult{warning, failure}, expected: 1},
+		{results: CheckResults{}, expected: 0},
+		{results: CheckResults{warning}, expected: 0},
+		{results: CheckResults{skipped}, expected: 0},
+		{results: CheckResults{failure}, expected: 1},
+		{results: CheckResults{warning, failure}, expected: 1},
 	}
 
 	for _, testCase := range testCases {
-		actual := ExitCode(testCase.results)
-
+		actual := testCase.results.ExitCode()
 		if actual != testCase.expected {
 			t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
 		}
@@ -47,18 +128,17 @@ func TestExitCodeFailOnWarn(t *testing.T) {
 	}
 
 	testCases := []struct {
-		results  []CheckResult
+		results  CheckResults
 		expected int
 	}{
-		{results: []CheckResult{}, expected: 0},
-		{results: []CheckResult{warning}, expected: 1},
-		{results: []CheckResult{failure}, expected: 2},
-		{results: []CheckResult{warning, failure}, expected: 2},
+		{results: CheckResults{}, expected: 0},
+		{results: CheckResults{warning}, expected: 1},
+		{results: CheckResults{failure}, expected: 2},
+		{results: CheckResults{warning, failure}, expected: 2},
 	}
 
 	for _, testCase := range testCases {
-		actual := ExitCodeFailOnWarn(testCase.results)
-
+		actual := testCase.results.ExitCodeFailOnWarn()
 		if actual != testCase.expected {
 			t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
 		}

--- a/output/standard.go
+++ b/output/standard.go
@@ -42,7 +42,7 @@ func NewStandard(w io.Writer) *Standard {
 }
 
 // Output outputs the results.
-func (s *Standard) Output(results []CheckResult) error {
+func (s *Standard) Output(results CheckResults) error {
 	colorizer := aurora.NewAurora(true)
 	if s.NoColor {
 		colorizer = aurora.NewAurora(false)
@@ -146,7 +146,7 @@ func (s *Standard) Output(results []CheckResult) error {
 	return nil
 }
 
-func (s *Standard) outputPrints(results []CheckResult, colorizer aurora.Aurora) {
+func (s *Standard) outputPrints(results CheckResults, colorizer aurora.Aurora) {
 	for _, result := range results {
 		for _, query := range result.Queries {
 			for _, t := range query.Outputs {
@@ -156,7 +156,7 @@ func (s *Standard) outputPrints(results []CheckResult, colorizer aurora.Aurora) 
 	}
 }
 
-func (s *Standard) outputTrace(results []CheckResult, colorizer aurora.Aurora) {
+func (s *Standard) outputTrace(results CheckResults, colorizer aurora.Aurora) {
 	for _, result := range results {
 		for _, query := range result.Queries {
 			var color aurora.Color

--- a/output/standard_test.go
+++ b/output/standard_test.go
@@ -10,13 +10,13 @@ import (
 func TestStandard(t *testing.T) {
 	tests := []struct {
 		name        string
-		input       []CheckResult
+		input       CheckResults
 		expected    []string
 		showSkipped bool
 	}{
 		{
 			name: "records failures, warnings and skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "foo.yaml",
 					Namespace: "namespace",
@@ -34,7 +34,7 @@ func TestStandard(t *testing.T) {
 		},
 		{
 			name: "skips filenames for stdin",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",
@@ -52,7 +52,7 @@ func TestStandard(t *testing.T) {
 		},
 		{
 			name: "records failures, warnings and skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "foo.yaml",
 					Namespace: "namespace",
@@ -72,7 +72,7 @@ func TestStandard(t *testing.T) {
 		},
 		{
 			name: "skips filenames for stdin",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",

--- a/output/table.go
+++ b/output/table.go
@@ -24,7 +24,7 @@ func NewTable(w io.Writer) *Table {
 }
 
 // Output outputs the results.
-func (t *Table) Output(checkResults []CheckResult) error {
+func (t *Table) Output(checkResults CheckResults) error {
 	table := tablewriter.NewWriter(t.Writer)
 	table.SetHeader([]string{"result", "file", "namespace", "message"})
 

--- a/output/table_test.go
+++ b/output/table_test.go
@@ -9,12 +9,12 @@ import (
 func TestTable(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
+		input    CheckResults
 		expected []string
 	}{
 		{
 			name: "No warnings or errors",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName: "examples/kubernetes/service.yaml",
 				},
@@ -23,7 +23,7 @@ func TestTable(t *testing.T) {
 		},
 		{
 			name: "A warning, a failure, a skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",

--- a/output/tap.go
+++ b/output/tap.go
@@ -23,7 +23,7 @@ func NewTAP(w io.Writer) *TAP {
 }
 
 // Output outputs the results.
-func (t *TAP) Output(checkResults []CheckResult) error {
+func (t *TAP) Output(checkResults CheckResults) error {
 	for _, result := range checkResults {
 		var indicator string
 		var namespace string

--- a/output/tap_test.go
+++ b/output/tap_test.go
@@ -9,12 +9,12 @@ import (
 func TestTAP(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    []CheckResult
+		input    CheckResults
 		expected []string
 	}{
 		{
 			name: "no warnings or errors",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -24,7 +24,7 @@ func TestTAP(t *testing.T) {
 		},
 		{
 			name: "records failure and warnings",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -42,7 +42,7 @@ func TestTAP(t *testing.T) {
 		},
 		{
 			name: "mixed failure, warnings and skipped",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "examples/kubernetes/service.yaml",
 					Namespace: "namespace",
@@ -60,7 +60,7 @@ func TestTAP(t *testing.T) {
 		},
 		{
 			name: "handles stdin input",
-			input: []CheckResult{
+			input: CheckResults{
 				{
 					FileName:  "-",
 					Namespace: "namespace",

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -172,8 +172,8 @@ func (e *Engine) ShowBuiltinErrors() {
 }
 
 // Check executes all of the loaded policies against the input and returns the results.
-func (e *Engine) Check(ctx context.Context, configs map[string]any, namespace string) ([]output.CheckResult, error) {
-	var checkResults []output.CheckResult
+func (e *Engine) Check(ctx context.Context, configs map[string]interface{}, namespace string) (output.CheckResults, error) {
+	var checkResults output.CheckResults
 	for path, config := range configs {
 
 		// It is possible for a configuration to have multiple configurations. An example of this

--- a/runner/test.go
+++ b/runner/test.go
@@ -39,7 +39,7 @@ type TestRunner struct {
 
 // Run executes the TestRunner, verifying all Rego policies against the given
 // list of configuration files.
-func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.CheckResult, error) {
+func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckResults, error) {
 	files, err := parseFileList(fileList, t.Ignore)
 	if err != nil {
 		return nil, fmt.Errorf("parse files: %w", err)
@@ -90,7 +90,7 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 		namespaces = engine.Namespaces()
 	}
 
-	var results []output.CheckResult
+	var results output.CheckResults
 	for _, namespace := range namespaces {
 		if t.Combine {
 			result, err := engine.CheckCombined(ctx, configurations, namespace)

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -35,7 +35,7 @@ const (
 )
 
 // Run executes the Rego tests for the given policies.
-func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, []*tester.Result, error) {
+func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.Result, error) {
 	capabilities, err := policy.LoadCapabilities(r.Capabilities)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load capabilities: %w", err)
@@ -52,7 +52,6 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, []*tester
 
 	// Traces should be enabled when Trace or Report options are on
 	enableTracing := r.Trace || r.IsReportOptionOn()
-
 	if enableTracing {
 		engine.EnableTracing()
 	}
@@ -69,7 +68,7 @@ func (r *VerifyRunner) Run(ctx context.Context) ([]output.CheckResult, []*tester
 		return nil, nil, fmt.Errorf("running tests: %w", err)
 	}
 
-	var results []output.CheckResult
+	var results output.CheckResults
 	var rawResults []*tester.Result
 	for result := range ch {
 		if result.Error != nil {


### PR DESCRIPTION
Adding a new type for a slice of CheckResult to add helper methods for checking if there were failures, warnings, or exceptions.