### PR TITLE
feat(test): Enable inter-query cache

### DIFF
--- a/runner/test.go
+++ b/runner/test.go
@@ -76,6 +76,7 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) ([]output.Check
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}
+	engine.EnableInterQueryCache()
 
 	if t.Trace {
 		engine.EnableTracing()


### PR DESCRIPTION
This improves performance for some Rego policies, such as those that use the http.send builtin.

Fixes https://github.com/open-policy-agent/conftest/issues/1045