### PR TITLE
refactor(ci): replace Makefile-based Docker builds with GitHub Action…

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,10 @@ name: pr
 
 on: [pull_request]
 
+env:
+  IMAGE: openpolicyagent/conftest
+  PLATFORMS: linux/amd64,linux/arm64
+
 permissions:
   actions: read
   checks: none
@@ -69,6 +73,18 @@ jobs:
 
       - name: build
         run: make build
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE }}:latest
+          platforms: ${{ env.PLATFORMS }}
 
       - name: unit test
         run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,10 @@ on:
   push:
     tags:
       - 'v*'
-
+env:
+  IMAGE: openpolicyagent/conftest
+  PLATFORMS: linux/amd64,linux/arm64
+  
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -36,10 +39,27 @@ jobs:
       - name: setup docker buildx
         run: docker buildx create --name conftestbuild --use
 
-      - name: push images
-        env:
-          VERSION: ${{ steps.get-version.outputs.VERSION }}
-        run: make push TAG=$VERSION
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.get-version.outputs.VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:latest
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Build and push examples image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          target: examples
+          tags: |
+            ${{ env.IMAGE }}:examples
+          platforms: ${{ env.PLATFORMS }}
 
       - name: setup go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Fixes #1066 

Migrate from Makefile to GitHub Actions for Docker Builds


This change uses pre-made GitHub Actions workflow for Docker to replace docker-related Makefile commands.
