### PR TITLE
refactor(ci): replace Makefile-based Docker builds with GitHub Action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,12 @@ name: pr
 
 on: [pull_request]
 
+
 permissions: {}
+
+env:
+  IMAGE: openpolicyagent/conftest
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   style:
@@ -59,6 +64,18 @@ jobs:
 
       - name: build
         run: make build
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE }}:latest
+          platforms: ${{ env.PLATFORMS }}
 
       - name: unit test
         run: make test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+env:
+  IMAGE: openpolicyagent/conftest
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   release:
@@ -36,10 +39,27 @@ jobs:
       - name: setup docker buildx
         run: docker buildx create --name conftestbuild --use
 
-      - name: push images
-        env:
-          VERSION: ${{ steps.get-version.outputs.VERSION }}
-        run: make push TAG=$VERSION
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.get-version.outputs.VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.get-version.outputs.VERSION }}
+            ${{ env.IMAGE }}:latest
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Build and push examples image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          target: examples
+          tags: |
+            ${{ env.IMAGE }}:examples
+          platforms: ${{ env.PLATFORMS }}
 
       - name: setup go
         uses: actions/setup-go@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,16 @@ jobs:
             VERSION=${{ steps.get-version.outputs.VERSION }}
           tags: |
             ${{ env.IMAGE }}:${{ steps.get-version.outputs.VERSION }}
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Build and push Docker latest image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: true
+          build-args: |
+            VERSION=${{ steps.get-version.outputs.VERSION }}
+          tags: |
             ${{ env.IMAGE }}:latest
           platforms: ${{ env.PLATFORMS }}
 

--- a/Makefile
+++ b/Makefile
@@ -64,18 +64,3 @@ help:
 #
 ##@ Releases
 #
-
-.PHONY: image
-image: ## Builds a Docker image for Conftest.
-	@$(DOCKER) build . -t $(IMAGE):latest
-
-.PHONY: examples
-examples: ## Builds the examples Docker image.
-	@$(DOCKER) build . --target examples -t $(IMAGE):examples
-
-.PHONY: push
-push: ## Pushes the examples and Conftest image to DockerHub. Requires `TAG` parameter.
-	@test -n "$(TAG)" || (echo "TAG parameter not set." && exit 1)
-	@$(DOCKER) buildx build . --push --build-arg VERSION="$(TAG)" -t $(IMAGE):$(TAG) --platform $(DOCKER_PLATFORMS)
-	@$(DOCKER) buildx build . --push --build-arg VERSION="$(TAG)" -t $(IMAGE):latest --platform $(DOCKER_PLATFORMS)
-	@$(DOCKER) buildx build . --push --target examples -t $(IMAGE):examples --platform $(DOCKER_PLATFORMS)


### PR DESCRIPTION
Fixes #1066 

Migrate from Makefile to GitHub Actions for Docker Builds

This change uses pre-made GitHub Actions workflow for Docker to replace docker-related Makefile commands.