### PR TITLE
docs: add documentation feature to the navigation bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
     - "Exceptions": "exceptions.md"
     - "Sharing policies": "sharing.md"
     - "Debugging policies": "debug.md"
+    - "Documenting policies": "documentation.md"
     - "Plugins": "plugins.md"
 markdown_extensions:
     - codehilite


### PR DESCRIPTION
The recent documentation feature was missing in the navigation bar. This adds it to the list so users can navigate w/o finding references on their own