### PR TITLE
ci: Remove PR workflow access to all permissions from GITHUB_TOKEN

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,17 +2,7 @@ name: pr
 
 on: [pull_request]
 
-permissions:
-  actions: read
-  checks: none
-  contents: none
-  deployments: none
-  issues: none
-  packages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+permissions: {}
 
 jobs:
   style:


### PR DESCRIPTION
It doesn't need them.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token