### PR TITLE
feat(runner): add support for symlinks

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -521,3 +521,12 @@ EOF"
   [ "$status" -eq 1 ]
   [[ "$output" =~ "look up message type" ]]
 }
+
+@test "Can parse files from a symlinked directory" {
+  TMPDIR="$(mktemp -d -u)"
+  ln -s $(pwd)/examples/hcl2 ${TMPDIR}
+  run ./conftest test -p examples/hcl2/policy ${TMPDIR}
+  rm -rf ${TMPDIR}
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "10 tests, 3 passed, 0 warnings, 7 failures, 0 exceptions" ]]
+}

--- a/runner/test.go
+++ b/runner/test.go
@@ -156,7 +156,7 @@ func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string,
 		}
 
 		if info.IsDir() {
-			if _, ok := visitedDirs[currentPath]; ok {
+			if visitedDirs[currentPath] {
 				return filepath.SkipDir
 			}
 			visitedDirs[currentPath] = true

--- a/runner/test.go
+++ b/runner/test.go
@@ -149,19 +149,17 @@ func parseFileList(fileList []string, ignoreRegex string) ([]string, error) {
 	return files, nil
 }
 
-func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, error) {
-	regexp, err := regexp.Compile(ignoreRegex)
-	if err != nil {
-		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
-	}
-
-	var files []string
-	walk := func(currentPath string, info os.FileInfo, err error) error {
+func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string, regexp *regexp.Regexp) filepath.WalkFunc {
+	return func(currentPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("walk path: %w", err)
 		}
 
 		if info.IsDir() {
+			if _, ok := visitedDirs[currentPath]; ok {
+				return filepath.SkipDir
+			}
+			visitedDirs[currentPath] = true
 			return nil
 		}
 
@@ -169,14 +167,44 @@ func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, erro
 			return nil
 		}
 
-		if parser.FileSupported(currentPath) {
-			files = append(files, currentPath)
+		if info.Mode()&os.ModeSymlink == 0 {
+			if parser.FileSupported(currentPath) {
+				*files = append(*files, currentPath)
+			}
+			return nil
+		}
+
+		realPath, err := filepath.EvalSymlinks(currentPath)
+		if err != nil {
+			return err
+		}
+
+		ri, err := os.Stat(realPath)
+		if err != nil {
+			return err
+		}
+
+		if ri.IsDir() {
+			return filepath.Walk(realPath, getWalkFn(visitedDirs, files, ignoreRegex, regexp))
+		}
+
+		if parser.FileSupported(realPath) {
+			*files = append(*files, realPath)
 		}
 
 		return nil
 	}
+}
 
-	err = filepath.Walk(directory, walk)
+func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, error) {
+	regexp, err := regexp.Compile(ignoreRegex)
+	if err != nil {
+		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
+	}
+
+	var files []string
+	visitedDirs := make(map[string]bool)
+	err = filepath.Walk(directory, getWalkFn(visitedDirs, &files, ignoreRegex, regexp))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We use Bazel for CI in our environment, which relies heavily on symlinks to build the workspace in which conftest runs. However, when the file list to process is a symlinked directory, the `getFilesFromDirectory` incorrectly assumes the symlink is a file, adding it to the final `files` array, where `getConfigurationContent` in `parser/parser.go` will error out:

```
Error: running test: parse configurations: get configuration content: open file: read /tmp/symlink: is a directory, path: /tmp/symlink
```

A minimal example to reproduce:
```
ln -s $(pwd)/examples/hcl2 /tmp/symlink 
make build
./conftest test -p examples/hcl2/policy /tmp/symlink
```

This PR suggests a way to address that, keeping a list of visited directories to protect against endless loops. 