### PR TITLE
docs: update default template link to use absolute URL

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -32,7 +32,7 @@ conftest doc path/to/policy
 
 ## Use your own template
 
-You can override the [default template](../document/resources/document.md) with your own template
+You can override the [default template](https://raw.githubusercontent.com/open-policy-agent/conftest/refs/heads/master/document/resources/document.md) with your own template
 
 ```aiignore
 conftest -t template.md path/tp/policies


### PR DESCRIPTION
Change the relative link to the default template to use an absolute URL pointing to the raw GitHub content for better accessibility. Currently the link is broken since the file from the relative path is not deployed to the docs site.

Fixes #1090 