### PR TITLE
ci: Move docker build to separate job in the PR workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -65,18 +65,6 @@ jobs:
       - name: build
         run: make build
 
-      - name: setup docker buildx
-        run: docker buildx create --name conftestbuild --use
-
-      - name: Build Docker image
-        uses: docker/build-push-action@v6 
-        with:
-          context: .
-          push: false
-          tags: |
-            ${{ env.IMAGE }}:latest
-          platforms: ${{ env.PLATFORMS }}
-
       - name: unit test
         run: make test
 
@@ -106,3 +94,23 @@ jobs:
 
       - name: test oci push/pull
         run: ./scripts/push-pull-e2e.sh
+
+  docker:
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE }}:latest
+          platforms: ${{ env.PLATFORMS }}


### PR DESCRIPTION
This step is slow to run and only needs to be tested after everything else.