### PR TITLE
docs: add openssf scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Conftest
 
-[![Go Report Card](https://goreportcard.com/badge/open-policy-agent/opa)](https://goreportcard.com/report/open-policy-agent/conftest) [![Netlify](https://api.netlify.com/api/v1/badges/2d928746-3380-4123-b0eb-1fd74ba390db/deploy-status)](https://app.netlify.com/sites/vibrant-villani-65041c/deploys)
+[![Go Report Card](https://goreportcard.com/badge/open-policy-agent/opa)](https://goreportcard.com/report/open-policy-agent/conftest) [![Netlify](https://api.netlify.com/api/v1/badges/2d928746-3380-4123-b0eb-1fd74ba390db/deploy-status)](https://app.netlify.com/sites/vibrant-villani-65041c/deploys) [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/open-policy-agent/conftest/badge)](https://securityscorecards.dev/viewer/?uri=github.com/open-policy-agent/conftest)
+
 
 Conftest helps you write tests against structured configuration data. Using Conftest you can
 write tests for your Kubernetes configuration, Tekton pipeline definitions, Terraform code,


### PR DESCRIPTION
## what
- docs: add openssf scorecard badge

## why
- Showcase the score to bring visibility to help increase it over time

## references
- Relates to #1107 