### PR TITLE
cli: Make Rego v1 syntax the default

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -184,7 +184,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
 	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
 	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
-	cmd.Flags().String("rego-version", "v0", "Which version of Rego syntax to use. Options: v0, v1")
+	cmd.Flags().String("rego-version", "v1", "Which version of Rego syntax to use. Options: v0, v1")
 
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
 	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -145,7 +145,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")
 
 	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
-	cmd.Flags().String("rego-version", "v0", "Which version of Rego syntax to use. Options: v0, v1")
+	cmd.Flags().String("rego-version", "v1", "Which version of Rego syntax to use. Options: v0, v1")
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 


### PR DESCRIPTION
As discussed in https://github.com/open-policy-agent/conftest/issues/1067, we want to make v1 syntax the default. This is a breaking change, but has been announced in the release notes as an upcoming change since the Feb release.

Fixes https://github.com/open-policy-agent/conftest/issues/1070