### PR TITLE
docs: Make examples in the docs compatible with v1 syntax

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -5,10 +5,10 @@ There might be cases where rules might not apply under certain circumstances. Fo
 Inputs matched by the `exception` will be exempted from the rules specified in `rules`, prefixed by `deny_` or `violation_`:
 
 ```rego
-exception[rules] {
+exception contains rules if {
   # Logic
 
-  rules = ["foo","bar"]
+  rules := ["foo","bar"]
 }
 ```
 
@@ -29,14 +29,14 @@ In the below example, a Kubernetes deployment named `can-run-as-root` will be al
 ```rego
 package main
 
-deny_run_as_root[msg] {
+deny_run_as_root contains msg if {
   input.kind == "Deployment"
   not input.spec.template.spec.securityContext.runAsNonRoot
 
   msg := "Containers must not run as root"
 }
 
-exception[rules] {
+exception contains rules if {
   input.kind == "Deployment"
   input.metadata.name == "can-run-as-root"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,14 @@ For instance, save the following as `policy/deployment.rego`:
 ```rego
 package main
 
-deny[msg] {
+deny contains msg if {
   input.kind == "Deployment"
   not input.spec.template.spec.securityContext.runAsNonRoot
 
   msg := "Containers must not run as root"
 }
 
-deny[msg] {
+deny contains msg if {
   input.kind == "Deployment"
   not input.spec.selector.matchLabels.app
 
@@ -127,7 +127,7 @@ When writing unit tests, it is common to use the `with` keyword to override the
 `input` and `data` documents. For example:
 
 ```rego
-test_foo {
+test_foo if {
   input := {
     "abc": 123,
     "foo": ["bar", "baz"],
@@ -157,7 +157,7 @@ in a unit test.
 **deny.rego**
 
 ```rego
-deny[msg] {
+deny contains msg if {
   proto := input.resource.aws_alb_listener[lb].protocol
   proto == "HTTP"
   msg = sprintf("ALB `%v` is using HTTP rather than HTTPS", [lb])

--- a/docs/options.md
+++ b/docs/options.md
@@ -35,7 +35,7 @@ Save the following as `policy/combine.rego`:
 ```rego
 package main
 
-deny[msg] {
+deny contains msg if {
   input[i].contents.kind == "Deployment"
 
   deployment := input[i].contents
@@ -45,7 +45,7 @@ deny[msg] {
   msg := sprintf("Deployment %v with selector %v does not match any Services", [deployment.metadata.name, deployment.spec.selector.matchLabels])
 }
 
-service_selects_app(app) {
+service_selects_app(app) if {
   input[service].contents.kind == "Service"
   input[service].contents.spec.selector.app == app
 }


### PR DESCRIPTION
Fixes https://github.com/open-policy-agent/conftest/issues/1069