### PR TITLE
fix: Use v1 as rego version for fmt, too

### DIFF
--- a/internal/commands/fmt.go
+++ b/internal/commands/fmt.go
@@ -60,7 +60,8 @@ func NewFormatCommand() *cobra.Command {
 					return fmt.Errorf("read policy: %w", err)
 				}
 
-				formattedContents, err := format.SourceWithOpts(policy.Package.Location.File, contents, format.Opts{RegoVersion: selectedRegoVersion, ParserOptions: &ast.ParserOptions{RegoVersion: selectedRegoVersion}})
+				formatOpts := format.Opts{RegoVersion: selectedRegoVersion, ParserOptions: &ast.ParserOptions{RegoVersion: selectedRegoVersion}}
+				formattedContents, err := format.SourceWithOpts(policy.Package.Location.File, contents, formatOpts)
 				if err != nil {
 					return fmt.Errorf("format: %w", err)
 				}


### PR DESCRIPTION
Add `--rego-version` flag to `fmt` command; it mirrors the flag of `test` and `verify`.

Sadly, `loader.AllRegos` does not offer a way to specify the desired rego version: we need to duplicate its implementation that creates a loader and then calls `Filtered`.

Implementation notes / questions:

* I am not sure whether this is more a fix or a feature
* `v1` is the default version (to match to 0.60 release); however, this can be seen as a breaking change, too :shrug: 
* There is a slight overload with `engine.Load`; but it is IMO not worth to consolidate it.

Fixes #1127
