### PR TITLE
ci: Run docker builds in parallel during release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: test oci push/pull
         run: ./scripts/push-pull-e2e.sh
 
-  docker:
+  docker-conftest:
     runs-on: ubuntu-latest
     needs:
       - validate
@@ -111,6 +111,29 @@ jobs:
         with:
           context: .
           push: false
+          # The foo tag below validates putting one tag per line (like we do in the release flow)
+          # works as expected.
           tags: |
             ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:foo
+          platforms: ${{ env.PLATFORMS }}
+
+  docker-examples:
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6 
+        with:
+          context: .
+          target: examples
+          push: false
+          tags: ${{ env.IMAGE }}:examples
           platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,13 +9,13 @@ env:
   PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
-  release:
+  check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       # It is important to check the GoReleaser config before pushing to
       # Dockerhub to avoid having mismatches between what is in Dockerhub
@@ -25,6 +25,16 @@ jobs:
         with:
           args: check
           version: "~> v1"
+
+  docker-conftest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - check
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
 
       - name: login to docker hub
         uses: docker/login-action@v3
@@ -48,18 +58,27 @@ jobs:
             VERSION=${{ steps.get-version.outputs.VERSION }}
           tags: |
             ${{ env.IMAGE }}:${{ steps.get-version.outputs.VERSION }}
-          platforms: ${{ env.PLATFORMS }}
-
-      - name: Build and push Docker latest image
-        uses: docker/build-push-action@v6 
-        with:
-          context: .
-          push: true
-          build-args: |
-            VERSION=${{ steps.get-version.outputs.VERSION }}
-          tags: |
             ${{ env.IMAGE }}:latest
           platforms: ${{ env.PLATFORMS }}
+
+  docker-examples:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - check
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+
+      - name: login to docker hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_LOGIN }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
 
       - name: Build and push examples image
         uses: docker/build-push-action@v6
@@ -67,9 +86,21 @@ jobs:
           context: .
           push: true
           target: examples
-          tags: |
-            ${{ env.IMAGE }}:examples
-          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ env.IMAGE }}:examples
+          platforms: ${{ env.PLATFORMS }}     
+
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # GoReleaser creates the GitHub release
+    needs:
+      - docker-conftest
+      - docker-examples
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need to fetch the full history for the GoReleaser changelog.
 
       - name: setup go
         uses: actions/setup-go@v5


### PR DESCRIPTION
The current workflow takes almost 40min due to running the docker builds in series rather than in paralllel.