### PR TITLE
chore: Replace OPA v0 with v1 import paths

### DIFF
--- a/builtins/parse_config.go
+++ b/builtins/parse_config.go
@@ -7,10 +7,10 @@ import (
 	"path/filepath"
 
 	"github.com/open-policy-agent/conftest/parser"
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/ast/location"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/types"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/ast/location"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/types"
 )
 
 func init() {

--- a/builtins/parse_config_test.go
+++ b/builtins/parse_config_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/conftest/parser"
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/document/metadata.go
+++ b/document/metadata.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/loader"
 )
 
 var (

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	opaversion "github.com/open-policy-agent/opa/version"
+	opaversion "github.com/open-policy-agent/opa/v1/version"
 
 	// Load the custom builtins.
 	_ "github.com/open-policy-agent/conftest/builtins"

--- a/internal/commands/fmt.go
+++ b/internal/commands/fmt.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
-	"github.com/open-policy-agent/opa/format"
-	"github.com/open-policy-agent/opa/loader"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
+	"github.com/open-policy-agent/opa/v1/format"
+	"github.com/open-policy-agent/opa/v1/loader"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/parser"
 	"github.com/open-policy-agent/conftest/runner"
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/storage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/output/azuredevops.go
+++ b/output/azuredevops.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // AzureDevOps represents an Outputter that outputs

--- a/output/github.go
+++ b/output/github.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // GitHub represents an Outputter that outputs

--- a/output/json.go
+++ b/output/json.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // JSON represents an Outputter that outputs

--- a/output/junit.go
+++ b/output/junit.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jstemmer/go-junit-report/formatter"
 	"github.com/jstemmer/go-junit-report/parser"
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // JUnit represents an Outputter that outputs

--- a/output/output.go
+++ b/output/output.go
@@ -3,7 +3,7 @@ package output
 import (
 	"os"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // Outputter controls how results of an evaluation will

--- a/output/sarif.go
+++ b/output/sarif.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 	"github.com/owenrumney/go-sarif/v2/sarif"
 )
 

--- a/output/standard.go
+++ b/output/standard.go
@@ -6,9 +6,9 @@ import (
 	"os"
 
 	"github.com/logrusorgru/aurora"
-	"github.com/open-policy-agent/opa/tester"
-	"github.com/open-policy-agent/opa/topdown"
-	"github.com/open-policy-agent/opa/topdown/lineage"
+	"github.com/open-policy-agent/opa/v1/tester"
+	"github.com/open-policy-agent/opa/v1/topdown"
+	"github.com/open-policy-agent/opa/v1/topdown/lineage"
 )
 
 // Standard represents an Outputter that outputs

--- a/output/table.go
+++ b/output/table.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"github.com/olekukonko/tablewriter"
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // Table represents an Outputter that outputs

--- a/output/tap.go
+++ b/output/tap.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-policy-agent/opa/tester"
+	"github.com/open-policy-agent/opa/v1/tester"
 )
 
 // TAP represents an Outputter that outputs

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -12,16 +12,16 @@ import (
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/parser"
 
-	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
-	"github.com/open-policy-agent/opa/loader"
-	"github.com/open-policy-agent/opa/rego"
-	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
-	"github.com/open-policy-agent/opa/topdown"
-	"github.com/open-policy-agent/opa/topdown/cache"
-	"github.com/open-policy-agent/opa/topdown/print"
-	"github.com/open-policy-agent/opa/version"
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
+	"github.com/open-policy-agent/opa/v1/loader"
+	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
+	"github.com/open-policy-agent/opa/v1/storage/inmem"
+	"github.com/open-policy-agent/opa/v1/topdown"
+	"github.com/open-policy-agent/opa/v1/topdown/cache"
+	"github.com/open-policy-agent/opa/v1/topdown/print"
+	"github.com/open-policy-agent/opa/v1/version"
 )
 
 // Engine represents the policy engine.
@@ -491,7 +491,7 @@ func (e *Engine) query(ctx context.Context, input any, query string) (output.Que
 		for _, expression := range result.Expressions {
 
 			// Rego rules that are intended for evaluation should return a slice of values.
-			// For example, deny[msg] or violation[{"msg": msg}].
+			// For example, `deny contains msg if` or `violation contains {"msg": msg} if`.
 			//
 			// When an expression does not have a slice of values, the expression did not
 			// evaluate to true, and no message was returned.
@@ -507,7 +507,7 @@ func (e *Engine) query(ctx context.Context, input any, query string) (output.Que
 			for _, v := range expressionValues {
 				switch val := v.(type) {
 
-				// Policies that only return a single string (e.g. deny[msg])
+				// Policies that only return a single string (e.g. `deny contains msg if`)
 				case string:
 					result := output.Result{
 						Message: val,
@@ -517,7 +517,7 @@ func (e *Engine) query(ctx context.Context, input any, query string) (output.Que
 					}
 					results = append(results, result)
 
-				// Policies that return metadata (e.g. deny[{"msg": msg}])
+				// Policies that return metadata (e.g. `deny contains {"msg": msg} if`)
 				case map[string]any:
 					result, err := output.NewResult(val)
 					if err != nil {

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/open-policy-agent/conftest/output"
 	"github.com/open-policy-agent/conftest/policy"
-	"github.com/open-policy-agent/opa/tester"
-	"github.com/open-policy-agent/opa/topdown"
+	"github.com/open-policy-agent/opa/v1/tester"
+	"github.com/open-policy-agent/opa/v1/topdown"
 )
 
 // VerifyRunner is the runner for the Verify command, executing


### PR DESCRIPTION
This is a no-op in practical sense, just removing the v0 -> v1 redirection layer.

Some test cases had to be updated to use v1 syntax because using the v1 import defaults to v1 syntax.

The `TestProblematicIf` test was removed as it is no longer needed now that v1 syntax is finalized.