### PR TITLE
chore(deps): bump Go version to 1.25

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
           cache: false
 
       - name: golangci-lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.25.x"
 
       - name: release
         uses: goreleaser/goreleaser-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4-alpine AS base
+FROM golang:1.25.0-alpine AS base
 ARG TARGETARCH
 ARG VERSION
 ARG COMMIT

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/open-policy-agent/conftest
 
-go 1.23.8
-
-toolchain go1.24.3
+go 1.25.0
 
 require (
 	cuelang.org/go v0.14.1


### PR DESCRIPTION
Go version 1.23 is no longer supported as per [the Go release policy](https://go.dev/doc/devel/release#policy).

This PR updates the build & SDK version to the latest v1.25.0