### PR TITLE
fix: Only use XDG directories for plugin if they are writable

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -142,8 +142,13 @@ func (p *Plugin) Directory() string {
 // CacheDirectory returns the full path to the
 // cache directory where all of the plugins are stored.
 func CacheDirectory() string {
-	dir, _ := cacheDirectory.Find("plugins")
-	return dir
+	// Use pre-existing cache directory if it exists, otherwise
+	// pick the preferred directory based on XDG environment vars.
+	dir, err := cacheDirectory.Find("plugins")
+	if err != nil {
+		return dir
+	}
+	return cacheDirectory.Preferred("plugins")
 }
 
 // FromDirectory returns a plugin from a specific directory.

--- a/plugin/xdg.go
+++ b/plugin/xdg.go
@@ -3,8 +3,11 @@ package plugin
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 const (
@@ -19,48 +22,91 @@ type xdgPath string
 
 // Preferred returns the preferred path according to the XDG specification
 func (p xdgPath) Preferred(path string) string {
-	dataHome := os.Getenv(XDGDataHome)
-	if dataHome != "" {
-		return filepath.ToSlash(filepath.Join(dataHome, string(p), path))
+	return p.preferred(path, os.Getenv(XDGDataHome), os.Getenv(XDGDataDirs))
+}
+
+func (p xdgPath) preferred(path, xdgDataHome, xdgDataDirs string) string {
+	user, err := user.Current()
+	if err != nil {
+		return p.homeDir(path)
 	}
 
-	dataDirs := os.Getenv(XDGDataDirs)
-	if dataDirs != "" {
-		dirs := strings.Split(dataDirs, ":")
-		return filepath.ToSlash(filepath.Join(dirs[0], string(p), path))
+	if xdgDataHome != "" && p.writable(xdgDataHome, user) {
+		return filepath.ToSlash(filepath.Join(xdgDataHome, string(p), path))
 	}
 
-	homeDir, _ := os.UserHomeDir()
-	return filepath.ToSlash(filepath.Join(homeDir, string(p), path))
+	if xdgDataDirs != "" {
+		// Pick the first dir that is writable.
+		for dir := range strings.SplitSeq(xdgDataDirs, ":") {
+			if p.writable(dir, user) {
+				return filepath.ToSlash(filepath.Join(dir, string(p), path))
+			}
+		}
+	}
+
+	return p.homeDir(path)
+}
+
+func (p xdgPath) homeDir(path string) string {
+	dir, _ := os.UserHomeDir()
+	return filepath.ToSlash(filepath.Join(dir, string(p), path))
+}
+
+func (p xdgPath) writable(path string, user *user.User) bool {
+	fd, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	perms := fd.Mode().Perm()
+
+	// First check if the directory is world-writable.
+	if perms&os.FileMode(0002) != 0 {
+		return true
+	}
+
+	// Then check user and group permissions.
+	if fd.Sys() == nil {
+		return false
+	}
+	stat, ok := fd.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	if user.Uid == strconv.Itoa(int(stat.Uid)) && perms&os.FileMode(0200) != 0 {
+		return true
+	}
+	if user.Gid == strconv.Itoa(int(stat.Gid)) && perms&os.FileMode(0020) != 0 {
+		return true
+	}
+	return false
 }
 
 // Find verifies whether the file exists somewhere in the expected XDG
 // preference order. If no error is returned, the given string indicates
 // where the file was found.
 func (p xdgPath) Find(path string) (string, error) {
-	dataHome := os.Getenv(XDGDataHome)
-	if dataHome != "" {
-		dir := filepath.ToSlash(filepath.Join(dataHome, string(p), path))
+	return p.find(path, os.Getenv(XDGDataHome), os.Getenv(XDGDataDirs))
+}
+
+func (p xdgPath) find(path, xdgDataHome, xdgDataDirs string) (string, error) {
+	if xdgDataHome != "" {
+		dir := filepath.ToSlash(filepath.Join(xdgDataHome, string(p), path))
 		_, err := os.Stat(dir)
 		if err != nil && !os.IsNotExist(err) {
 			return "", fmt.Errorf("get data home directory: %w", err)
 		}
-
 		if err == nil {
 			return dir, nil
 		}
 	}
 
-	dataDirs := os.Getenv(XDGDataDirs)
-	if dataDirs != "" {
-		dirs := strings.Split(dataDirs, ":")
-		for _, dataDir := range dirs {
+	if xdgDataDirs != "" {
+		for dataDir := range strings.SplitSeq(xdgDataDirs, ":") {
 			dir := filepath.ToSlash(filepath.Join(dataDir, string(p), path))
 			_, err := os.Stat(dir)
 			if err != nil && !os.IsNotExist(err) {
 				return "", fmt.Errorf("get data dirs directory: %w", err)
 			}
-
 			if err == nil {
 				return dir, nil
 			}


### PR DESCRIPTION
This fixes an issue on macOS where XDG_DATA_DIRS points to an unwritable location.

Also update the XDG test code to not rely on OS environment variables, unblocking parallel test execution.

Fixes: https://github.com/open-policy-agent/conftest/issues/1179