### PR TITLE
fix: Use "python3" instead of "python" in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test-acceptance: build install-test-deps ## Runs the tests in the test folder.
 
 .PHONY: install-test-deps
 install-test-deps: ## Installs dependencies required for testing.
-	@command -v pre-commit >/dev/null 2>&1 || python -m pip install -r requirements-dev.txt
+	@command -v pre-commit >/dev/null 2>&1 || python3 -m pip install -r requirements-dev.txt
 
 .PHONY: test-oci
 test-oci: ## Runs the OCI integration test for push and pull.


### PR DESCRIPTION
macOS, as well as the latest Debian and Ubuntu use "python3" and not "python" for the name of the Python installation on the system. Using "python" is now legacy and is not present in $PATH even when Python is installed.

Fixes https://github.com/open-policy-agent/conftest/issues/1180.