### PR TITLE
feat: add conftest-fmt and conftest-pull pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,3 +17,23 @@
   require_serial: true
   minimum_pre_commit_version: "2.9.0"
   stages: [pre-commit, pre-merge-commit, pre-push, manual]
+
+- id: conftest-pull
+  name: Pull Conftest Policy Rego files
+  description: Download Conftest Policies
+  entry: conftest pull
+  language: golang
+  pass_filenames: false
+  require_serial: true
+  minimum_pre_commit_version: "2.9.0"
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+
+- id: conftest-fmt
+  name: Conftest Format Rego files
+  description: Format Rego unit tests for Conftest policies
+  entry: conftest fmt
+  language: golang
+  pass_filenames: true
+  require_serial: false
+  minimum_pre_commit_version: "2.9.0"
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,6 +104,10 @@ repos:
 
 The `conftest-test` hook validates your configuration files against policies, while the `conftest-verify` hook runs unit tests for your policies.
 
+Additional hooks are available including `conftest-pull` for downloading policies and `conftest-fmt` for formatting Rego files.
+See the [.pre-commit-hooks.yaml](https://github.com/open-policy-agent/conftest/blob/main/.pre-commit-hooks.yaml) file
+for the complete list of available hooks and their configuration options.
+
 For more information on pre-commit hooks, refer to the [pre-commit documentation](https://pre-commit.com/).
 
 ### Testing/Verifying Policies

--- a/tests/pre-commit/test.bats
+++ b/tests/pre-commit/test.bats
@@ -39,6 +39,14 @@ repos:
       args:
         - --policy
         - examples/kubernetes/policy
+    # This hook is intended to change/fmt this file
+    - id: conftest-fmt
+      files: examples/kubernetes/deployment.yaml
+    - id: conftest-pull
+      args:
+        - --policy
+        - ./pulled-policies
+        - git::https://github.com/open-policy-agent/conftest//examples/kubernetes/policy
 EOF
 
     # Add and commit files
@@ -68,3 +76,17 @@ teardown_file() {
     run pre-commit run conftest-verify
     [ "$status" -eq 0 ]
 }
+
+@test "pre-commit: verify fmt hook changes a policy file" {
+    cd "$TEST_REPO"
+    run pre-commit run conftest-fmt --files examples/kubernetes/deployment.yaml
+    [ "$status" -ne 0 ]
+}
+
+@test "pre-commit: pull hook downloads policies successfully" {
+  cd "$TEST_REPO"
+  run pre-commit run conftest-pull
+  [ "$status" -eq 0 ]
+}
+
+


### PR DESCRIPTION
Add two new pre-commit hooks, based on `conftest fmt` and `conftest pull`, respectively - to the existing `.pre-commit-hooks.yaml` configuration file.

- `conftest-pull`: Downloads Conftest policies from remote sources
- `conftest-fmt`: Formats Rego policy files

Updates documentation in `index.md` to mention the additional hooks and direct users to examine `.pre-commit-hooks.yaml` for the complete list. Added basic tests to verify the new hooks execute successfully.

This enhances the pre-commit integration by providing a complete set of hooks for policy management, formatting, and validation workflows.

Extends the functionality introduced in #1077 .