### PR TITLE
feat: Include location in the result output

### DIFF
--- a/output/result_test.go
+++ b/output/result_test.go
@@ -1,10 +1,86 @@
 package output
 
 import (
+	"encoding/json"
+	"strconv"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
+func TestNewResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc    string
+		input   map[string]any
+		want    Result
+		wantErr bool
+	}{
+		{
+			desc:    "no metadata is an error",
+			wantErr: true,
+		},
+		{
+			desc:    "missing msg is an error",
+			input:   map[string]any{},
+			wantErr: true,
+		},
+		{
+			desc:    "non-string msg is an error",
+			input:   map[string]any{"msg": 123},
+			wantErr: true,
+		},
+		{
+			desc:  "msg only",
+			input: map[string]any{"msg": "message"},
+			want: Result{
+				Message:  "message",
+				Metadata: make(map[string]any),
+			},
+		},
+		{
+			desc: "msg with location and metadata",
+			input: map[string]any{
+				"msg": "message",
+				"_loc": map[string]any{
+					"file": "some_file.json",
+					"line": json.Number("123"),
+				},
+				"other": "metadata",
+			},
+			want: Result{
+				Message: "message",
+				Location: &Location{
+					File: "some_file.json",
+					Line: json.Number("123"),
+				},
+				Metadata: map[string]any{"other": "metadata"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewResult(tc.input)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("NewResult() error = %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("NewResult() produced an unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCheckResultsHelpers(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		desc             string
 		results          CheckResults
@@ -70,6 +146,8 @@ func TestCheckResultsHelpers(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
 			if gotFailure := tc.results.HasFailure(); gotFailure != tc.wantHasFailure {
 				t.Errorf("HasFailure() = %v, want %v", gotFailure, tc.wantHasFailure)
 			}
@@ -87,6 +165,8 @@ func TestCheckResultsHelpers(t *testing.T) {
 }
 
 func TestExitCode(t *testing.T) {
+	t.Parallel()
+
 	warning := CheckResult{
 		Warnings: []Result{{}},
 	}
@@ -110,15 +190,21 @@ func TestExitCode(t *testing.T) {
 		{results: CheckResults{warning, failure}, expected: 1},
 	}
 
-	for _, testCase := range testCases {
-		actual := testCase.results.ExitCode()
-		if actual != testCase.expected {
-			t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
-		}
+	for i, testCase := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			actual := testCase.results.ExitCode()
+			if actual != testCase.expected {
+				t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
+			}
+		})
 	}
 }
 
 func TestExitCodeFailOnWarn(t *testing.T) {
+	t.Parallel()
+
 	warning := CheckResult{
 		Warnings: []Result{{}},
 	}
@@ -137,10 +223,14 @@ func TestExitCodeFailOnWarn(t *testing.T) {
 		{results: CheckResults{warning, failure}, expected: 2},
 	}
 
-	for _, testCase := range testCases {
-		actual := testCase.results.ExitCodeFailOnWarn()
-		if actual != testCase.expected {
-			t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
-		}
+	for i, testCase := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+
+			actual := testCase.results.ExitCodeFailOnWarn()
+			if actual != testCase.expected {
+				t.Errorf("Unexpected error code. expected %v, actual %v", testCase.expected, actual)
+			}
+		})
 	}
 }

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -391,7 +391,6 @@ func (e *Engine) check(ctx context.Context, path string, config any, namespace s
 		checkResult.Failures = append(checkResult.Failures, failures...)
 		checkResult.Warnings = append(checkResult.Warnings, warnings...)
 		checkResult.Exceptions = append(checkResult.Exceptions, exceptions...)
-
 		checkResult.Queries = append(checkResult.Queries, exceptionQueryResult, ruleQueryResult)
 	}
 

--- a/tests/source-location/data.yaml
+++ b/tests/source-location/data.yaml
@@ -1,0 +1,3 @@
+loc:
+  file: test.txt
+  line: 123

--- a/tests/source-location/policy/main.rego
+++ b/tests/source-location/policy/main.rego
@@ -1,0 +1,7 @@
+package main
+
+deny contains {
+    "msg": "test",
+    "other": "metadata",
+    "_loc": input.loc
+}

--- a/tests/source-location/test.bats
+++ b/tests/source-location/test.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+@test "Location is included in results" {
+  run $CONFTEST test -o json data.yaml
+
+  echo $output
+  [[ "$output" =~ "\"file\": \"test.txt\"" ]]
+  [[ "$output" =~ "\"line\": 123" ]]
+}


### PR DESCRIPTION
This will allow outputters to point to the specific location that caused the result to be created.

---

This is the first part of addressing https://github.com/open-policy-agent/conftest/issues/1194.

---

Also parallelized the other tests in `output/result_test.go`.