### PR TITLE
docs: Add RELEASING.md

### DIFF
--- a/.github/workflows/post_merge.yaml
+++ b/.github/workflows/post_merge.yaml
@@ -1,0 +1,53 @@
+name: 'post_merge'
+on:
+  push:
+    branches:
+      - 'master'
+
+permissions: {}
+
+jobs:
+  docker-conftest:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: openpolicyagent/conftest
+      PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - name: checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # ratchet:actions/checkout@v5
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
+        with:
+          context: '.'
+          push: false
+          # The foo tag below validates putting one tag per line (like we do in the release flow)
+          # works as expected.
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:foo
+          platforms: ${{ env.PLATFORMS }}
+
+  docker-examples:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: openpolicyagent/conftest
+      PLATFORMS: linux/amd64,linux/arm64
+    steps:
+      - name: checkout source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # ratchet:actions/checkout@v5
+
+      - name: setup docker buildx
+        run: docker buildx create --name conftestbuild --use
+
+      - name: Build Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
+        with:
+          context: '.'
+          target: examples
+          push: false
+          tags: ${{ env.IMAGE }}:examples
+          platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,12 +2,7 @@ name: pr
 
 on: [pull_request]
 
-
 permissions: {}
-
-env:
-  IMAGE: openpolicyagent/conftest
-  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   lint:
@@ -127,46 +122,3 @@ jobs:
       - name: test oci push/pull
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: ./scripts/push-pull-e2e.sh
-
-  docker-conftest:
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-    steps:
-      - name: checkout source
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-
-      - name: setup docker buildx
-        run: docker buildx create --name conftestbuild --use
-
-      - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
-        with:
-          context: .
-          push: false
-          # The foo tag below validates putting one tag per line (like we do in the release flow)
-          # works as expected.
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:foo
-          platforms: ${{ env.PLATFORMS }}
-
-  docker-examples:
-    runs-on: ubuntu-latest
-    needs:
-      - validate
-    steps:
-      - name: checkout source
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
-
-      - name: setup docker buildx
-        run: docker buildx create --name conftestbuild --use
-
-      - name: Build Docker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
-        with:
-          context: .
-          target: examples
-          push: false
-          tags: ${{ env.IMAGE }}:examples
-          platforms: ${{ env.PLATFORMS }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,37 @@
+# Releasing
+
+conftest releases in the first week of each month, after the new version of Open
+Policy Agent is released. Patch releases are not generally created while we are
+on v0, but we may create one if there is a blocking bug in a newly released
+feature.
+
+## New release
+
+1. Check for any open
+   [pull requests](https://github.com/open-policy-agent/conftest/pulls) that are
+   ready to merge, and merge them.
+
+1. Verify that all
+   [post-merge CI tasks](https://github.com/open-policy-agent/conftest/actions/workflows/post_merge.yaml)
+   have completed successfully.
+
+1. Check out to the master branch and ensure you have the latest changes.
+
+   ```sh
+   git checkout master
+   git pull
+   ```
+
+1. Determine the next version number, and create a tag. You can check the
+   [releases](https://github.com/open-policy-agent/conftest/releases) page to
+   see the previous version if you do not know it.
+
+   ```sh
+   git tag v<VERSION>
+   git push --tags
+   ```
+
+1. Monitor the
+   [release workflow](https://github.com/open-policy-agent/conftest/actions/workflows/release.yaml)
+   and verify it does not error. This usually takes ~45min due to slow speeds of
+   the Docker cross-compiles.


### PR DESCRIPTION
... and move slow Docker build workflows that almost always succeed to a post_merge workflow to reduce CI time for PRs.