### PR TITLE
fix: enable Windows acceptance tests in CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -112,12 +112,11 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: make test-acceptance
 
-      # TODO: Uncomment as a part of https://github.com/open-policy-agent/conftest/issues/1203
-      # - name: acceptance (windows)
-      #   if: ${{ matrix.os == 'windows-latest' }}
-      #   run: |
-      #     $env:Path += ";C:\Users\runneradmin\.local\share\bats\bin"
-      #     make test-acceptance
+      - name: acceptance (windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          $env:Path += ";C:\Users\runneradmin\.local\share\bats\bin"
+          make test-acceptance
 
       - name: test oci push/pull
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,6 +40,13 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # Allow parser packages to use names that match standard library (json, xml, etc.)
+      # This is a common Go pattern for parser packages
+      - path: "parser/(json|xml)/"
+        linters:
+          - revive
+        text: "var-naming: avoid package names"
 formatters:
   enable:
     - gofmt

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -21,7 +21,9 @@ var detectors = []getter.Detector{
 }
 
 var getters = map[string]getter.Getter{
-	"file":  new(getter.FileGetter),
+	// Use Copy mode for FileGetter to avoid symlink issues on Windows
+	// (symlinks require administrator privileges on Windows)
+	"file":  &getter.FileGetter{Copy: true},
 	"git":   new(getter.GitGetter),
 	"gcs":   new(getter.GCSGetter),
 	"hg":    new(getter.HgGetter),

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	getter "github.com/hashicorp/go-getter"
@@ -21,9 +22,9 @@ var detectors = []getter.Detector{
 }
 
 var getters = map[string]getter.Getter{
-	// Use Copy mode for FileGetter to avoid symlink issues on Windows
+	// Use Copy mode for FileGetter on Windows to avoid symlink issues
 	// (symlinks require administrator privileges on Windows)
-	"file":  &getter.FileGetter{Copy: true},
+	"file":  &getter.FileGetter{Copy: runtime.GOOS == "windows"},
 	"git":   new(getter.GitGetter),
 	"gcs":   new(getter.GCSGetter),
 	"hg":    new(getter.HgGetter),

--- a/downloader/file_getter_copy.go
+++ b/downloader/file_getter_copy.go
@@ -1,0 +1,113 @@
+package downloader
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+// CopyFileGetter is a custom FileGetter that copies directories instead of
+// creating symlinks. This is needed on Windows where symlinks require
+// administrator privileges.
+type CopyFileGetter struct {
+	getter.FileGetter
+}
+
+// Get implements getter.Getter. On Windows, it copies the directory instead
+// of creating a symlink/junction.
+func (g *CopyFileGetter) Get(dst string, u *url.URL) error {
+	// On non-Windows systems, use the standard behavior
+	if runtime.GOOS != "windows" {
+		return g.FileGetter.Get(dst, u)
+	}
+
+	path := u.Path
+	if u.RawPath != "" {
+		path = u.RawPath
+	}
+
+	// The source path must exist and be a directory
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("source path error: %s", err)
+	}
+	if !fi.IsDir() {
+		return fmt.Errorf("source path must be a directory")
+	}
+
+	// Remove destination if it exists
+	if _, err := os.Lstat(dst); err == nil {
+		if err := os.RemoveAll(dst); err != nil {
+			return fmt.Errorf("failed to remove existing destination: %w", err)
+		}
+	}
+
+	// Copy the directory
+	return copyDir(path, dst)
+}
+
+// copyDir recursively copies a directory from src to dst.
+func copyDir(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source: %w", err)
+	}
+
+	// Create the destination directory
+	if err := os.MkdirAll(dst, srcInfo.Mode()); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a single file from src to dst.
+func copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer srcFile.Close()
+
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+
+	dstFile, err := os.OpenFile(dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer dstFile.Close()
+
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("failed to copy file contents: %w", err)
+	}
+
+	return nil
+}

--- a/downloader/file_getter_copy.go
+++ b/downloader/file_getter_copy.go
@@ -31,6 +31,13 @@ func (g *CopyFileGetter) Get(dst string, u *url.URL) error {
 		path = u.RawPath
 	}
 
+	// Handle Windows file:// URLs per RFC 8089
+	// When using file:///C:/path format, u.Path is "/C:/path"
+	// We need to strip the leading "/" to get the actual Windows path
+	if len(path) > 2 && path[0] == '/' && filepath.VolumeName(path[1:]) != "" {
+		path = path[1:]
+	}
+
 	// The source path must exist and be a directory
 	fi, err := os.Stat(path)
 	if err != nil {

--- a/downloader/file_getter_copy.go
+++ b/downloader/file_getter_copy.go
@@ -37,13 +37,15 @@ func (g *CopyFileGetter) Get(dst string, u *url.URL) error {
 		path = path[1:]
 	}
 
-	// The source path must exist and be a directory
+	// The source path must exist
 	fi, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("source path error: %w", err)
 	}
+
+	// For single files, delegate to the embedded FileGetter (with Copy=true)
 	if !fi.IsDir() {
-		return fmt.Errorf("source path must be a directory")
+		return g.FileGetter.Get(dst, u)
 	}
 
 	// Remove destination if it exists

--- a/downloader/file_getter_copy.go
+++ b/downloader/file_getter_copy.go
@@ -26,10 +26,9 @@ func (g *CopyFileGetter) Get(dst string, u *url.URL) error {
 		return g.FileGetter.Get(dst, u)
 	}
 
+	// Use the decoded URL path for filesystem operations.
+	// u.RawPath is percent-encoded and would break paths containing spaces.
 	path := u.Path
-	if u.RawPath != "" {
-		path = u.RawPath
-	}
 
 	// Handle Windows file:// URLs per RFC 8089
 	// When using file:///C:/path format, u.Path is "/C:/path"
@@ -41,7 +40,7 @@ func (g *CopyFileGetter) Get(dst string, u *url.URL) error {
 	// The source path must exist and be a directory
 	fi, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("source path error: %s", err)
+		return fmt.Errorf("source path error: %w", err)
 	}
 	if !fi.IsDir() {
 		return fmt.Errorf("source path must be a directory")

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -78,7 +78,10 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 			if viper.GetBool("absolute-paths") && filepath.IsAbs(policyPath) {
 				policyDir = policyPath
 			} else {
-				policyDir = filepath.Join(".", policyPath)
+				// Strip volume name (e.g., "C:") on Windows to avoid invalid paths
+				// like ".\C:\..." when treating absolute paths as relative
+				pathWithoutVolume := policyPath[len(filepath.VolumeName(policyPath)):]
+				policyDir = filepath.Join(".", pathWithoutVolume)
 			}
 
 			if err := downloader.Download(ctx, policyDir, args); err != nil {

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -79,16 +79,29 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 			if viper.GetBool("absolute-paths") && filepath.IsAbs(policyPath) {
 				policyDir = policyPath
 			} else {
-				// Strip drive letter (e.g., "C:") and leading separators on
-				// Windows to produce a relative path like ".\Users\..." instead
-				// of an absolute rooted path like "\Users\...".
-				// UNC paths (\\server\share) are left intact since stripping the
-				// volume would lose the server/share information.
+				// Convert absolute policy paths into relative destinations:
+				//   Unix absolute:    "/tmp/x"                -> "./tmp/x"
+				//   Windows drive:    "C:\tmp\x"              -> ".\tmp\x"
+				//   Windows UNC:      "\\server\share\policies" ->
+				//                     ".\server\share\policies"
 				vol := filepath.VolumeName(policyPath)
-				pathWithoutVolume := policyPath[len(vol):]
-				if len(vol) == 2 && vol[1] == ':' {
-					pathWithoutVolume = strings.TrimLeft(pathWithoutVolume, `/\`)
+				isDriveVolume := len(vol) == 2 && vol[1] == ':'
+
+				pathWithoutVolume := policyPath
+				if isDriveVolume {
+					pathWithoutVolume = policyPath[len(vol):]
 				}
+				pathWithoutVolume = strings.TrimLeft(pathWithoutVolume, `/\`)
+
+				if vol != "" && !isDriveVolume {
+					uncVolume := strings.TrimLeft(vol, `/\`)
+					if pathWithoutVolume == "" {
+						pathWithoutVolume = uncVolume
+					} else {
+						pathWithoutVolume = filepath.Join(uncVolume, pathWithoutVolume)
+					}
+				}
+
 				policyDir = filepath.Join(".", pathWithoutVolume)
 			}
 

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/open-policy-agent/conftest/downloader"
 
@@ -78,9 +79,11 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 			if viper.GetBool("absolute-paths") && filepath.IsAbs(policyPath) {
 				policyDir = policyPath
 			} else {
-				// Strip volume name (e.g., "C:") on Windows to avoid invalid paths
-				// like ".\C:\..." when treating absolute paths as relative
+				// Strip volume name (e.g., "C:") and leading separators on Windows
+				// to produce a relative path like ".\Users\..." instead of an
+				// absolute rooted path like "\Users\..."
 				pathWithoutVolume := policyPath[len(filepath.VolumeName(policyPath)):]
+				pathWithoutVolume = strings.TrimLeft(pathWithoutVolume, `/\`)
 				policyDir = filepath.Join(".", pathWithoutVolume)
 			}
 

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -79,11 +79,16 @@ func NewPullCommand(ctx context.Context) *cobra.Command {
 			if viper.GetBool("absolute-paths") && filepath.IsAbs(policyPath) {
 				policyDir = policyPath
 			} else {
-				// Strip volume name (e.g., "C:") and leading separators on Windows
-				// to produce a relative path like ".\Users\..." instead of an
-				// absolute rooted path like "\Users\..."
-				pathWithoutVolume := policyPath[len(filepath.VolumeName(policyPath)):]
-				pathWithoutVolume = strings.TrimLeft(pathWithoutVolume, `/\`)
+				// Strip drive letter (e.g., "C:") and leading separators on
+				// Windows to produce a relative path like ".\Users\..." instead
+				// of an absolute rooted path like "\Users\...".
+				// UNC paths (\\server\share) are left intact since stripping the
+				// volume would lose the server/share information.
+				vol := filepath.VolumeName(policyPath)
+				pathWithoutVolume := policyPath[len(vol):]
+				if len(vol) == 2 && vol[1] == ':' {
+					pathWithoutVolume = strings.TrimLeft(pathWithoutVolume, `/\`)
+				}
 				policyDir = filepath.Join(".", pathWithoutVolume)
 			}
 

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -75,7 +75,7 @@ func sanitizeWindowsPaths(paths []string) []string {
 	}
 	result := make([]string, len(paths))
 	for i, p := range paths {
-		if filepath.VolumeName(p) != "" {
+		if filepath.IsAbs(p) && filepath.VolumeName(p) != "" {
 			result[i] = "file:///" + filepath.ToSlash(p)
 		} else {
 			result[i] = p

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/open-policy-agent/conftest/output"
@@ -64,6 +65,25 @@ func LoadCapabilities(path string) (*ast.Capabilities, error) {
 	return ast.LoadCapabilitiesFile(path)
 }
 
+// sanitizeWindowsPaths converts Windows absolute paths with drive letters to
+// file:// URLs. This works around an issue in OPA's loader.SplitPrefix which
+// misinterprets drive letters (e.g., "C:") as Rego data prefixes, stripping
+// them from the path and causing file-not-found errors.
+func sanitizeWindowsPaths(paths []string) []string {
+	if runtime.GOOS != "windows" || len(paths) == 0 {
+		return paths
+	}
+	result := make([]string, len(paths))
+	for i, p := range paths {
+		if filepath.VolumeName(p) != "" {
+			result[i] = "file:///" + filepath.ToSlash(p)
+		} else {
+			result[i] = p
+		}
+	}
+	return result
+}
+
 // Load returns an Engine after loading all of the specified policies.
 func Load(policyPaths []string, opts CompilerOptions) (*Engine, error) {
 	var regoVer ast.RegoVersion
@@ -77,7 +97,7 @@ func Load(policyPaths []string, opts CompilerOptions) (*Engine, error) {
 	}
 
 	l := loader.NewFileLoader().WithProcessAnnotation(true).WithRegoVersion(regoVer)
-	policies, err := l.Filtered(policyPaths, func(_ string, info os.FileInfo, _ int) bool {
+	policies, err := l.Filtered(sanitizeWindowsPaths(policyPaths), func(_ string, info os.FileInfo, _ int) bool {
 		return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
 	})
 
@@ -132,7 +152,7 @@ func LoadWithData(policyPaths []string, dataPaths []string, opts CompilerOptions
 		return !contains([]string{".yaml", ".yml", ".json"}, filepath.Ext(info.Name()))
 	}
 
-	documents, err := loader.NewFileLoader().Filtered(dataPaths, filter)
+	documents, err := loader.NewFileLoader().Filtered(sanitizeWindowsPaths(dataPaths), filter)
 	if err != nil {
 		return nil, fmt.Errorf("load documents: %w", err)
 	}
@@ -143,7 +163,7 @@ func LoadWithData(policyPaths []string, dataPaths []string, opts CompilerOptions
 
 	// FilteredPaths will recursively find all file paths that contain a valid document
 	// extension from the given list of data paths.
-	allDocumentPaths, err := loader.FilteredPaths(dataPaths, filter)
+	allDocumentPaths, err := loader.FilteredPaths(sanitizeWindowsPaths(dataPaths), filter)
 	if err != nil {
 		return nil, fmt.Errorf("filter data paths: %w", err)
 	}

--- a/policy/engine.go
+++ b/policy/engine.go
@@ -75,7 +75,9 @@ func sanitizeWindowsPaths(paths []string) []string {
 	}
 	result := make([]string, len(paths))
 	for i, p := range paths {
-		if filepath.IsAbs(p) && filepath.VolumeName(p) != "" {
+		vol := filepath.VolumeName(p)
+		isDriveLetter := len(vol) == 2 && vol[1] == ':'
+		if isDriveLetter && filepath.IsAbs(p) {
 			result[i] = "file:///" + filepath.ToSlash(p)
 		} else {
 			result[i] = p

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 	"testing/fstest"
@@ -536,6 +537,132 @@ deny contains msg if { msg := "denied" }`),
 				t.Errorf("Namespaces() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestSanitizeWindowsPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{
+			name:  "relative paths unchanged",
+			paths: []string{"policy", "./policy"},
+			want:  []string{"policy", "./policy"},
+		},
+		{
+			name:  "unix absolute paths unchanged",
+			paths: []string{"/tmp/policy", "/home/user/policy"},
+			want:  []string{"/tmp/policy", "/home/user/policy"},
+		},
+		{
+			name:  "empty paths",
+			paths: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "nil input returns nil",
+			paths: nil,
+			want:  nil,
+		},
+	}
+
+	if runtime.GOOS == "windows" { //nolint:goconst // standard runtime value
+		tests = append(tests, []struct {
+			name  string
+			paths []string
+			want  []string
+		}{
+			{
+				name:  "windows drive letter paths converted to file URLs",
+				paths: []string{"C:/Users/test/policy", "D:\\temp\\policy"},
+				want:  []string{"file:///C:/Users/test/policy", "file:///D:/temp/policy"},
+			},
+			{
+				name:  "mixed relative and absolute windows paths",
+				paths: []string{"policy", "C:/Users/test/policy"},
+				want:  []string{"policy", "file:///C:/Users/test/policy"},
+			},
+			{
+				name:  "paths with spaces",
+				paths: []string{"C:\\Program Files\\policy"},
+				want:  []string{"file:///C:/Program Files/policy"},
+			},
+		}...)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeWindowsPaths(tt.paths)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sanitizeWindowsPaths(%v) = %v, want %v", tt.paths, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadWithAbsolutePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific test")
+	}
+
+	// Get absolute path to the examples directory
+	absPath, err := filepath.Abs("../examples/kubernetes/policy")
+	if err != nil {
+		t.Fatalf("getting absolute path: %v", err)
+	}
+
+	// Verify the path has a volume name (drive letter)
+	if filepath.VolumeName(absPath) == "" {
+		t.Fatalf("expected absolute path with drive letter, got: %s", absPath)
+	}
+
+	// This would fail without sanitizeWindowsPaths because OPA's
+	// SplitPrefix treats the drive letter (e.g., "C:") as a data prefix
+	_, err = Load([]string{absPath}, CompilerOptions{
+		Capabilities: ast.CapabilitiesForThisVersion(),
+		RegoVersion:  "v1",
+	})
+	if err != nil {
+		t.Fatalf("Load with absolute Windows path failed: %v", err)
+	}
+}
+
+func TestLoadWithDataAbsolutePath(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows-specific test")
+	}
+
+	absPolicyPath, err := filepath.Abs("../examples/kubernetes/policy")
+	if err != nil {
+		t.Fatalf("getting absolute policy path: %v", err)
+	}
+
+	absDataPath, err := filepath.Abs("../examples/data")
+	if err != nil {
+		t.Fatalf("getting absolute data path: %v", err)
+	}
+
+	// Only run the data path test if the directory exists
+	if _, err := os.Stat(absDataPath); os.IsNotExist(err) {
+		// Fall back: test with empty data paths (still exercises the policy path)
+		_, err = LoadWithData([]string{absPolicyPath}, nil, CompilerOptions{
+			Capabilities: ast.CapabilitiesForThisVersion(),
+			RegoVersion:  "v1",
+		})
+		if err != nil {
+			t.Fatalf("LoadWithData with absolute Windows policy path failed: %v", err)
+		}
+		return
+	}
+
+	_, err = LoadWithData([]string{absPolicyPath}, []string{absDataPath}, CompilerOptions{
+		Capabilities: ast.CapabilitiesForThisVersion(),
+		RegoVersion:  "v1",
+	})
+	if err != nil {
+		t.Fatalf("LoadWithData with absolute Windows paths failed: %v", err)
 	}
 }
 

--- a/tests/builtin-errors/test.bats
+++ b/tests/builtin-errors/test.bats
@@ -13,5 +13,8 @@
 
   [ "$status" -eq 1 ]
   echo $output
-  [[ "$output" =~ "file_does_not_exist.yaml: no such file or directory" ]]
+  # Check that the file name is in the error message
+  [[ "$output" =~ "file_does_not_exist.yaml" ]]
+  # Check for file not found error (Unix or Windows message)
+  [[ "$output" =~ "no such file or directory" ]] || [[ "$output" =~ "cannot find the file" ]]
 }

--- a/tests/pre-commit/test.bats
+++ b/tests/pre-commit/test.bats
@@ -3,6 +3,13 @@
 DIR="$( cd "$( dirname "${BATS_TEST_FILENAME}" )" >/dev/null 2>&1 && pwd )"
 PROJECT_ROOT="$( cd "$DIR/../.." >/dev/null 2>&1 && pwd )"
 
+# On Windows, convert to mixed-style path for pre-commit compatibility
+if command -v cygpath >/dev/null 2>&1; then
+    PROJECT_ROOT_WIN=$(cygpath -m "$PROJECT_ROOT")
+else
+    PROJECT_ROOT_WIN="$PROJECT_ROOT"
+fi
+
 # Git configuration for temporary repo
 GIT_AUTHOR_NAME="Conftest Test User"
 GIT_AUTHOR_EMAIL="conftest@example.tld"
@@ -20,6 +27,9 @@ setup_file() {
     git config tag.gpgsign false
     git config user.name "$GIT_AUTHOR_NAME"
     git config user.email "$GIT_AUTHOR_EMAIL"
+    # Override global core.hooksPath with empty local value to allow pre-commit to install hooks
+    # pre-commit refuses to install when core.hooksPath is set globally
+    git config --local core.hooksPath ""
 
     # Copy necessary files from the main repo
     mkdir -p examples

--- a/tests/pre-commit/test.bats
+++ b/tests/pre-commit/test.bats
@@ -5,9 +5,7 @@ PROJECT_ROOT="$( cd "$DIR/../.." >/dev/null 2>&1 && pwd )"
 
 # On Windows, convert to mixed-style path for pre-commit compatibility
 if command -v cygpath >/dev/null 2>&1; then
-    PROJECT_ROOT_WIN=$(cygpath -m "$PROJECT_ROOT")
-else
-    PROJECT_ROOT_WIN="$PROJECT_ROOT"
+    PROJECT_ROOT=$(cygpath -m "$PROJECT_ROOT")
 fi
 
 # Git configuration for temporary repo

--- a/tests/pull-absolute-paths/test.bats
+++ b/tests/pull-absolute-paths/test.bats
@@ -8,12 +8,9 @@ setup() {
     mkdir -p "${ABS_POLICY_DIR}"
     mkdir -p "${REL_TEMP_DIR}"
 
-    # On Windows (MSYS2/Git Bash), paths are translated when passed to Windows executables.
-    # We need to know the Windows-translated path for assertions.
+    # On Windows (MSYS2/Git Bash), convert to mixed-style path for conftest compatibility
     if command -v cygpath >/dev/null 2>&1; then
-        export ABS_POLICY_DIR_WIN=$(cygpath -w "${ABS_POLICY_DIR}" 2>/dev/null | sed 's|\\|/|g' | sed 's|^[A-Za-z]:||')
-    else
-        export ABS_POLICY_DIR_WIN="${ABS_POLICY_DIR}"
+        ABS_POLICY_DIR=$(cygpath -m "${ABS_POLICY_DIR}")
     fi
 }
 
@@ -21,9 +18,15 @@ teardown() {
     # Clean up temporary directories
     rm -rf "${TEMP_DIR}"
     rm -rf "${REL_TEMP_DIR}"
-    # Also clean up any Windows-translated paths created as relative directories
-    if [ -n "${ABS_POLICY_DIR_WIN}" ] && [ "${ABS_POLICY_DIR_WIN}" != "${ABS_POLICY_DIR}" ]; then
-        rm -rf ".${ABS_POLICY_DIR_WIN}"
+
+    # Clean up any relative path directories created by conftest (test 2)
+    # On Windows, the path has drive letter stripped, on Unix it's just the path
+    if command -v cygpath >/dev/null 2>&1; then
+        # Windows: strip drive letter (e.g., C:/Users/... -> /Users/...)
+        local rel_path="${ABS_POLICY_DIR#[A-Za-z]:}"
+        rm -rf ".${rel_path}"
+    else
+        rm -rf ".${ABS_POLICY_DIR}"
     fi
 }
 
@@ -37,16 +40,21 @@ teardown() {
 @test "Pull command uses absolute paths as relative when --absolute-paths is not set" {
     run $CONFTEST pull --policy "${ABS_POLICY_DIR}" https://raw.githubusercontent.com/open-policy-agent/conftest/master/examples/compose/policy/deny.rego
     [ "$status" -eq 0 ]
-    # The policy should be downloaded to ./ABS_POLICY_DIR instead of the absolute path
-    [ ! -d "${ABS_POLICY_DIR}/deny.rego" ]
-    # Check using the Windows-translated path on Windows, or the original path on Unix
-    [ -f ".${ABS_POLICY_DIR_WIN}/deny.rego" ] || [ -f "./${ABS_POLICY_DIR}/deny.rego" ]
+
+    # The policy should be downloaded to a relative path (./path stripped of volume)
+    # On Windows: C:/Users/... becomes ./Users/...
+    # On Unix: /tmp/... becomes ./tmp/...
+    if command -v cygpath >/dev/null 2>&1; then
+        local expected_path=".${ABS_POLICY_DIR#[A-Za-z]:}"
+    else
+        local expected_path=".${ABS_POLICY_DIR}"
+    fi
+    [ -f "${expected_path}/deny.rego" ]
 }
 
 @test "Pull command works with absolute path when --absolute-paths is set" {
     run $CONFTEST pull --absolute-paths --policy "${ABS_POLICY_DIR}" https://raw.githubusercontent.com/open-policy-agent/conftest/master/examples/compose/policy/deny.rego
     [ "$status" -eq 0 ]
     # The policy should be downloaded to the absolute path
-    [ ! -f "./${ABS_POLICY_DIR#/}/deny.rego" ]
     [ -f "${ABS_POLICY_DIR}/deny.rego" ]
 }

--- a/tests/pull-absolute-paths/test.bats
+++ b/tests/pull-absolute-paths/test.bats
@@ -4,14 +4,15 @@ setup() {
     # Create temporary directories for testing
     export TEMP_DIR=$(mktemp -d)
     export REL_TEMP_DIR="examples/tmp-conftest-test-$$"
-    export ABS_POLICY_DIR="${TEMP_DIR}/conftest-policies"
-    mkdir -p "${ABS_POLICY_DIR}"
-    mkdir -p "${REL_TEMP_DIR}"
 
     # On Windows (MSYS2/Git Bash), convert to mixed-style path for conftest compatibility
     if command -v cygpath >/dev/null 2>&1; then
-        ABS_POLICY_DIR=$(cygpath -m "${ABS_POLICY_DIR}")
+        TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
     fi
+
+    export ABS_POLICY_DIR="${TEMP_DIR}/conftest-policies"
+    mkdir -p "${ABS_POLICY_DIR}"
+    mkdir -p "${REL_TEMP_DIR}"
 }
 
 teardown() {

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -9,8 +9,14 @@ setup_file() {
 
 	# On Windows (MSYS2/Git Bash), convert to mixed-style path for conftest compatibility
 	if command -v cygpath >/dev/null 2>&1; then
-		TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
+		# Convert and explicitly re-export the converted path
+		export TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
 	fi
+
+	# Debug output for CI troubleshooting (visible in bats output)
+	echo "# DEBUG: TEMP_DIR=${TEMP_DIR}" >&3
+	echo "# DEBUG: Contents of TEMP_DIR:" >&3
+	ls -la "${TEMP_DIR}" >&3 2>&1 || true
 }
 
 teardown_file() {
@@ -25,7 +31,15 @@ teardown_file() {
 }
 
 @test "Pull and update first version policy" {
+	# Debug: Show what we're about to run
+	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
+	echo "# DEBUG: Update URL=file://${TEMP_DIR}/remote-policy/a" >&3
+
 	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
+
+	# Debug: Show actual output for troubleshooting
+	echo "# DEBUG: Exit status=$status" >&3
+	echo "# DEBUG: Output=$output" >&3
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]
@@ -39,7 +53,15 @@ teardown_file() {
 }
 
 @test "Pull and update second version policy" {
+	# Debug: Show what we're about to run
+	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
+	echo "# DEBUG: Update URL=file://${TEMP_DIR}/remote-policy/b" >&3
+
 	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
+
+	# Debug: Show actual output for troubleshooting
+	echo "# DEBUG: Exit status=$status" >&3
+	echo "# DEBUG: Output=$output" >&3
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -10,10 +10,8 @@ setup_file() {
 	# On Windows (MSYS2/Git Bash), paths need to be converted for native executables.
 	if command -v cygpath >/dev/null 2>&1; then
 		export TEMP_DIR_WIN=$(cygpath -m "${TEMP_DIR}")
-		export IS_WINDOWS=true
 	else
 		export TEMP_DIR_WIN="${TEMP_DIR}"
-		export IS_WINDOWS=false
 	fi
 
 	# Create a git repository for the remote-policy to enable git:// URL downloads

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -33,9 +33,9 @@ teardown_file() {
 @test "Pull and update first version policy" {
 	# Debug: Show what we're about to run
 	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
-	echo "# DEBUG: Update URL=file://${TEMP_DIR}/remote-policy/a" >&3
+	echo "# DEBUG: Update URL=file:///${TEMP_DIR}/remote-policy/a" >&3
 
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
 
 	# Debug: Show actual output for troubleshooting
 	echo "# DEBUG: Exit status=$status" >&3
@@ -55,9 +55,9 @@ teardown_file() {
 @test "Pull and update second version policy" {
 	# Debug: Show what we're about to run
 	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
-	echo "# DEBUG: Update URL=file://${TEMP_DIR}/remote-policy/b" >&3
+	echo "# DEBUG: Update URL=file:///${TEMP_DIR}/remote-policy/b" >&3
 
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
 
 	# Debug: Show actual output for troubleshooting
 	echo "# DEBUG: Exit status=$status" >&3

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -11,16 +11,6 @@ setup_file() {
 	if command -v cygpath >/dev/null 2>&1; then
 		TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
 	fi
-
-	# Create a git repository for the remote-policy to enable git:// URL downloads
-	# This avoids the file:// symlink issues on Windows
-	cd "${TEMP_DIR}/remote-policy"
-	git init --quiet
-	git config user.email "test@test.com"
-	git config user.name "Test"
-	git add .
-	git commit --quiet -m "initial"
-	cd - >/dev/null
 }
 
 teardown_file() {
@@ -35,8 +25,7 @@ teardown_file() {
 }
 
 @test "Pull and update first version policy" {
-	# Use git:: prefix for local git repository to avoid file:// symlink issues on Windows
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "git::file://${TEMP_DIR}/remote-policy//a" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]
@@ -50,8 +39,7 @@ teardown_file() {
 }
 
 @test "Pull and update second version policy" {
-	# Use git:: prefix for local git repository to avoid file:// symlink issues on Windows
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "git::file://${TEMP_DIR}/remote-policy//b" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file://${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -7,11 +7,9 @@ setup_file() {
 	# Copy all the files there
 	cp -r . "${TEMP_DIR}"
 
-	# On Windows (MSYS2/Git Bash), paths need to be converted for native executables.
+	# On Windows (MSYS2/Git Bash), convert to mixed-style path for conftest compatibility
 	if command -v cygpath >/dev/null 2>&1; then
-		export TEMP_DIR_WIN=$(cygpath -m "${TEMP_DIR}")
-	else
-		export TEMP_DIR_WIN="${TEMP_DIR}"
+		TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
 	fi
 
 	# Create a git repository for the remote-policy to enable git:// URL downloads
@@ -38,7 +36,7 @@ teardown_file() {
 
 @test "Pull and update first version policy" {
 	# Use git:: prefix for local git repository to avoid file:// symlink issues on Windows
-	run $CONFTEST test --policy "${TEMP_DIR_WIN}/policy" --update "git::file://${TEMP_DIR_WIN}/remote-policy//a" "${TEMP_DIR_WIN}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "git::file://${TEMP_DIR}/remote-policy//a" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]
@@ -53,7 +51,7 @@ teardown_file() {
 
 @test "Pull and update second version policy" {
 	# Use git:: prefix for local git repository to avoid file:// symlink issues on Windows
-	run $CONFTEST test --policy "${TEMP_DIR_WIN}/policy" --update "git::file://${TEMP_DIR_WIN}/remote-policy//b" "${TEMP_DIR_WIN}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "git::file://${TEMP_DIR}/remote-policy//b" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -12,11 +12,6 @@ setup_file() {
 		# Convert and explicitly re-export the converted path
 		export TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
 	fi
-
-	# Debug output for CI troubleshooting (visible in bats output)
-	echo "# DEBUG: TEMP_DIR=${TEMP_DIR}" >&3
-	echo "# DEBUG: Contents of TEMP_DIR:" >&3
-	ls -la "${TEMP_DIR}" >&3 2>&1 || true
 }
 
 teardown_file() {
@@ -31,15 +26,7 @@ teardown_file() {
 }
 
 @test "Pull and update first version policy" {
-	# Debug: Show what we're about to run
-	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
-	echo "# DEBUG: Update URL=file:///${TEMP_DIR}/remote-policy/a" >&3
-
 	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
-
-	# Debug: Show actual output for troubleshooting
-	echo "# DEBUG: Exit status=$status" >&3
-	echo "# DEBUG: Output=$output" >&3
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]
@@ -53,15 +40,7 @@ teardown_file() {
 }
 
 @test "Pull and update second version policy" {
-	# Debug: Show what we're about to run
-	echo "# DEBUG: Running conftest with TEMP_DIR=${TEMP_DIR}" >&3
-	echo "# DEBUG: Update URL=file:///${TEMP_DIR}/remote-policy/b" >&3
-
 	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
-
-	# Debug: Show actual output for troubleshooting
-	echo "# DEBUG: Exit status=$status" >&3
-	echo "# DEBUG: Output=$output" >&3
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]

--- a/tests/pull-update/test.bats
+++ b/tests/pull-update/test.bats
@@ -11,6 +11,11 @@ setup_file() {
 	if command -v cygpath >/dev/null 2>&1; then
 		# Convert and explicitly re-export the converted path
 		export TEMP_DIR=$(cygpath -m "${TEMP_DIR}")
+		# Windows drive path (C:/...) needs file:/// for a valid RFC 8089 file URL
+		export FILE_URL="file:///${TEMP_DIR}"
+	else
+		# Unix absolute path already starts with '/', so file:// yields file:///... (3 slashes)
+		export FILE_URL="file://${TEMP_DIR}"
 	fi
 }
 
@@ -26,7 +31,7 @@ teardown_file() {
 }
 
 @test "Pull and update first version policy" {
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/a" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "${FILE_URL}/remote-policy/a" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]
@@ -40,7 +45,7 @@ teardown_file() {
 }
 
 @test "Pull and update second version policy" {
-	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "file:///${TEMP_DIR}/remote-policy/b" "${TEMP_DIR}/file.json"
+	run $CONFTEST test --policy "${TEMP_DIR}/policy" --update "${FILE_URL}/remote-policy/b" "${TEMP_DIR}/file.json"
 
 	[ "$status" -eq 1 ]
 	[[ "$output" =~ "a should not be present" ]]


### PR DESCRIPTION
Fixes #1203

## Summary
- Enable Windows acceptance tests in CI workflow
- Fix go-getter symlink issues (FileGetter Copy mode)
- Handle Windows paths and error messages in bats tests

## Test Results
All 136 acceptance tests pass on Windows (87 acceptance.bats + 49 tests/*/test.bats).