### PR TITLE
ci(golangci-lint): Disable revive package-name-collision-with-go-std

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,16 @@ linters:
         - nilness
     misspell:
       locale: US
+    revive:
+      rules:
+        - name: var-naming
+          # Arguments accepts an allow list, a deny list, and a map of other options.
+          # https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-naming
+          arguments:
+            - [] # Allow list. Do not remove because ordering matters.
+            - [] # Deny list. Do not remove because ordering matters.
+            - 
+              - skip-package-name-collision-with-go-std: true
     staticcheck:
       checks:
         # These are processed in order. It is important that the inclusion

--- a/scripts/validate-conventional-commit-prefix.sh
+++ b/scripts/validate-conventional-commit-prefix.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 code=0
 while read -r commit; do
-    match=$(echo "${commit}" | grep -o -h -E "^[a-z]+(\([a-z]+\))?: " || true)
+    match=$(echo "${commit}" | grep -o -h -E "^[a-z]+(\([a-z-]+\))?: " || true)
     if [[ -z "${match}" ]]; then
         echo "::error::Commit \"${commit}\" does not have the required conventional commit prefix. See https://www.conventionalcommits.org/ for more info."
         code=1


### PR DESCRIPTION
This is blocking PRs due to conflict over package names like 'xml' and 'json' but those names make sense in conftest's context.