### PR TITLE
feat: add glob pattern support for --namespace flag

### DIFF
--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -1,0 +1,89 @@
+package runner
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestFilterNamespaces(t *testing.T) {
+	tests := []struct {
+		name      string
+		available []string
+		patterns  []string
+		want      []string
+	}{
+		{
+			name:      "exact match single namespace",
+			available: []string{"main", "group1", "group2"},
+			patterns:  []string{"main"},
+			want:      []string{"main"},
+		},
+		{
+			name:      "exact match multiple namespaces",
+			available: []string{"main", "group1", "group2"},
+			patterns:  []string{"group1", "group2"},
+			want:      []string{"group1", "group2"},
+		},
+		{
+			name:      "wildcard match with asterisk",
+			available: []string{"main", "group1", "group2", "other"},
+			patterns:  []string{"group*"},
+			want:      []string{"group1", "group2"},
+		},
+		{
+			name:      "wildcard match all",
+			available: []string{"main", "group1", "group2"},
+			patterns:  []string{"*"},
+			want:      []string{"main", "group1", "group2"},
+		},
+		{
+			name:      "wildcard with question mark",
+			available: []string{"group1", "group2", "group10"},
+			patterns:  []string{"group?"},
+			want:      []string{"group1", "group2"},
+		},
+		{
+			name:      "mixed exact and wildcard",
+			available: []string{"main", "group1", "group2", "test"},
+			patterns:  []string{"main", "group*"},
+			want:      []string{"main", "group1", "group2"},
+		},
+		{
+			name:      "no matches",
+			available: []string{"main", "group1"},
+			patterns:  []string{"other*"},
+			want:      nil,
+		},
+		{
+			name:      "empty patterns",
+			available: []string{"main", "group1"},
+			patterns:  []string{},
+			want:      nil,
+		},
+		{
+			name:      "empty available",
+			available: []string{},
+			patterns:  []string{"main"},
+			want:      nil,
+		},
+		{
+			name:      "no duplicates in result",
+			available: []string{"group1", "group2"},
+			patterns:  []string{"group1", "group*"},
+			want:      []string{"group1", "group2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterNamespaces(tt.available, tt.patterns)
+			// Sort both slices for comparison since order may vary
+			sort.Strings(got)
+			sort.Strings(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterNamespaces() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/nested/test.bats
+++ b/tests/nested/test.bats
@@ -16,3 +16,10 @@
   [ "$status" -eq 1 ]
   [[ "$output" =~ "2 tests, 0 passed, 0 warnings, 2 failures" ]]
 }
+
+@test "Can use wildcard in namespace flag" {
+  run $CONFTEST test --namespace 'group*' data.json
+
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "2 tests, 0 passed, 0 warnings, 2 failures" ]]
+}


### PR DESCRIPTION
Fixes #1141

## Changes
- Add `filterNamespaces` function to support glob patterns (e.g., `group*`, `main.*`) in the `--namespace` flag
- Uses Go's `filepath.Match` for pattern matching with support for `*`, `?`, and `[...]`
- Add unit tests for the new filtering function
- Add integration test for wildcard namespace usage