### PR TITLE
feat: add glob pattern support for --namespace flag

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -548,3 +548,21 @@ EOF"
   [ "$status" -eq 1 ]
   [[ "$output" =~ "10 tests, 3 passed, 0 warnings, 7 failures, 0 exceptions" ]]
 }
+
+@test "Verify command with namespace wildcard matching" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'ma*'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
+}
+
+@test "Verify command with namespace exact match" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'main'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
+}
+
+@test "Verify command with namespace filtering (exclude)" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'other'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "0 tests, 0 passed" ]]
+}

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -82,6 +82,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				"strict",
 				"proto-file-dirs",
 				"show-builtin-errors",
+				"namespace",
 			}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
@@ -148,6 +149,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().String("rego-version", "v1", "Which version of Rego syntax to use. Options: v0, v1")
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
+	cmd.Flags().StringSliceP("namespace", "n", []string{}, "Test policies in a specific namespace")
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")
 

--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestHasWildcard(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		patterns []string
@@ -44,7 +45,9 @@ func TestHasWildcard(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := hasWildcard(tt.patterns); got != tt.want {
 				t.Errorf("hasWildcard() = %v, want %v", got, tt.want)
 			}
@@ -53,83 +56,97 @@ func TestHasWildcard(t *testing.T) {
 }
 
 func TestFilterNamespaces(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name      string
-		available []string
-		patterns  []string
-		want      []string
+		name       string
+		namespaces []string
+		patterns   []string
+		want       []string
+		wantErr    bool
 	}{
 		{
-			name:      "asterisk matches suffix",
-			available: []string{"main", "main.gke", "main.aws", "test"},
-			patterns:  []string{"main.*"},
-			want:      []string{"main.gke", "main.aws"},
+			name:       "asterisk matches suffix",
+			namespaces: []string{"main", "main.gke", "main.aws", "test"},
+			patterns:   []string{"main.*"},
+			want:       []string{"main.gke", "main.aws"},
 		},
 		{
-			name:      "asterisk matches prefix",
-			available: []string{"main.gke", "test.gke", "main.aws"},
-			patterns:  []string{"*.gke"},
-			want:      []string{"main.gke", "test.gke"},
+			name:       "asterisk matches prefix",
+			namespaces: []string{"main.gke", "test.gke", "main.aws"},
+			patterns:   []string{"*.gke"},
+			want:       []string{"main.gke", "test.gke"},
 		},
 		{
-			name:      "exact match without wildcard",
-			available: []string{"main", "main.gke"},
-			patterns:  []string{"main"},
-			want:      []string{"main"},
+			name:       "exact match without wildcard",
+			namespaces: []string{"main", "main.gke"},
+			patterns:   []string{"main"},
+			want:       []string{"main"},
 		},
 		{
-			name:      "multiple patterns",
-			available: []string{"main", "main.gke", "test", "test.aws"},
-			patterns:  []string{"main.*", "test.*"},
-			want:      []string{"main.gke", "test.aws"},
+			name:       "multiple patterns",
+			namespaces: []string{"main", "main.gke", "test", "test.aws"},
+			patterns:   []string{"main.*", "test.*"},
+			want:       []string{"main.gke", "test.aws"},
 		},
 		{
-			name:      "no matches",
-			available: []string{"main", "test"},
-			patterns:  []string{"foo.*"},
-			want:      nil,
+			name:       "no matches",
+			namespaces: []string{"main", "test"},
+			patterns:   []string{"foo.*"},
+			want:       nil,
 		},
 		{
-			name:      "match all with star",
-			available: []string{"main", "test", "foo"},
-			patterns:  []string{"*"},
-			want:      []string{"main", "test", "foo"},
+			name:       "match all with star",
+			namespaces: []string{"main", "test", "foo"},
+			patterns:   []string{"*"},
+			want:       []string{"main", "test", "foo"},
 		},
 		{
-			name:      "question mark pattern",
-			available: []string{"main.a", "main.b", "main.ab"},
-			patterns:  []string{"main.?"},
-			want:      []string{"main.a", "main.b"},
+			name:       "question mark pattern",
+			namespaces: []string{"main.a", "main.b", "main.ab"},
+			patterns:   []string{"main.?"},
+			want:       []string{"main.a", "main.b"},
 		},
 		{
-			name:      "bracket pattern",
-			available: []string{"main.a", "main.b", "main.c"},
-			patterns:  []string{"main.[ab]"},
-			want:      []string{"main.a", "main.b"},
+			name:       "bracket pattern",
+			namespaces: []string{"main.a", "main.b", "main.c"},
+			patterns:   []string{"main.[ab]"},
+			want:       []string{"main.a", "main.b"},
 		},
 		{
-			name:      "deduplicate matches",
-			available: []string{"main.gke"},
-			patterns:  []string{"main.*", "*.gke"},
-			want:      []string{"main.gke"},
+			name:       "deduplicate matches",
+			namespaces: []string{"main.gke"},
+			patterns:   []string{"main.*", "*.gke"},
+			want:       []string{"main.gke"},
 		},
 		{
-			name:      "empty available",
-			available: []string{},
-			patterns:  []string{"main.*"},
-			want:      nil,
+			name:       "empty available",
+			namespaces: []string{},
+			patterns:   []string{"main.*"},
+			want:       nil,
 		},
 		{
-			name:      "empty patterns",
-			available: []string{"main", "test"},
-			patterns:  []string{},
-			want:      nil,
+			name:       "empty patterns",
+			namespaces: []string{"main", "test"},
+			patterns:   []string{},
+			want:       nil,
+		},
+		{
+			name:       "bad pattern",
+			namespaces: []string{"main"},
+			patterns:   []string{"["}, // Invalid glob pattern
+			wantErr:    true,
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterNamespaces(tt.available, tt.patterns)
+			t.Parallel()
+			got, err := filterNamespaces(tt.namespaces, tt.patterns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterNamespaces() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterNamespaces() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Fixes #1141

## Changes
- Add glob pattern support (*, ?, [...]) for the --namespace flag
- Add helper functions hasWildcard() and filterNamespaces() in runner/test.go
- Add comprehensive unit tests for namespace filtering logic
- Add acceptance tests for wildcard namespace matching