### PR TITLE
feat: Default loading path for data

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -34,9 +34,15 @@ Some policies are dependant on external data. This data is loaded in separately
 from policies. The location of any data directory or file can be specified with
 the '--data' flag. If a directory is specified, it will be recursively searched for
 any data files. Right now any '.json' or '.yaml' file will be loaded in
-and made available in the Rego policies. Data will be made available in Rego based on
-the file path where the data was found. For example, if data is stored
-under 'policy/exceptions/my_data.yaml', and we execute the following command:
+and made available in the Rego policies.
+
+If no '--data' flag is specified and a 'data' directory exists in the current
+working directory, it will be used as the default data directory. This allows
+for convenient consumption of bundles that include both policies and data.
+
+Data will be made available in Rego based on the file path where the data was
+found. For example, if data is stored under 'policy/exceptions/my_data.yaml',
+and we execute the following command:
 
 	$ conftest test --data policy <input-file>
 
@@ -192,7 +198,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 	cmd.Flags().StringSliceP("update", "u", []string{}, "A list of URLs can be provided to the update flag, which will download before the tests run")
 	cmd.Flags().StringSliceP("namespace", "n", []string{"main"}, "Test policies in a specific namespace")
-	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
+	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded (default [data] if the directory exists)")
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")
 	cmd.Flags().Bool("tls", true, "Use TLS to access the registry")

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -34,6 +34,9 @@ If a directory is specified, it will be recursively searched for
 any data files. Data will be made available in Rego based on
 the structure of the data that was loaded.
 
+If no '--data' flag is specified and a 'data' directory exists in the current
+working directory, it will be used as the default data directory.
+
 For example, if a yaml file was loaded that had the structure:
 
 people:
@@ -146,7 +149,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
 	cmd.Flags().String("rego-version", "v1", "Which version of Rego syntax to use. Options: v0, v1")
-	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
+	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded (default [data] if the directory exists)")
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")

--- a/runner/test.go
+++ b/runner/test.go
@@ -40,6 +40,13 @@ type TestRunner struct {
 // Run executes the TestRunner, verifying all Rego policies against the given
 // list of configuration files.
 func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckResults, error) {
+	// Apply default data path if no data paths are specified and the default directory exists
+	if len(t.Data) == 0 {
+		if info, err := os.Stat("data"); err == nil && info.IsDir() {
+			t.Data = []string{"data"}
+		}
+	}
+
 	files, err := parseFileList(fileList, t.Ignore)
 	if err != nil {
 		return nil, fmt.Errorf("parse files: %w", err)

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/open-policy-agent/conftest/output"
@@ -36,6 +37,13 @@ const (
 
 // Run executes the Rego tests for the given policies.
 func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.Result, error) {
+	// Apply default data path if no data paths are specified and the default directory exists
+	if len(r.Data) == 0 {
+		if info, err := os.Stat("data"); err == nil && info.IsDir() {
+			r.Data = []string{"data"}
+		}
+	}
+
 	capabilities, err := policy.LoadCapabilities(r.Capabilities)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load capabilities: %w", err)


### PR DESCRIPTION
Fixes #800

## Changes
- Auto-load `data` directory when no `--data` flag is specified and the directory exists
- Updated documentation for `test` and `verify` commands to describe this behavior
- Gracefully skips if the `data` directory doesn't exist