### PR TITLE
ci: Update setup-go to use Go version from go.mod

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,8 +17,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.25.x"
-          cache: false
+          go-version-file: 'go.mod'
 
       - name: validate conventional commit prefix
         working-directory: scripts
@@ -71,8 +70,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.25.x"
-          cache: false
+          go-version-file: 'go.mod'
 
       - name: build
         run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version-file: 'go.mod'
 
       - name: release
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # ratchet:goreleaser/goreleaser-action@v6

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/open-policy-agent/conftest
 
 go 1.25.3
 
+toolchain go1.25.6
+
 require (
 	cuelang.org/go v0.15.3
 	github.com/BurntSushi/toml v1.6.0


### PR DESCRIPTION
This uses the ecosystem standard of defining the minimum Go version to build the package, as well as the Go toolchain the release is built with.