### PR TITLE
feat(verify): Add --var-values flag

### DIFF
--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -82,6 +82,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				"strict",
 				"proto-file-dirs",
 				"show-builtin-errors",
+				"var-values",
 			}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
@@ -97,6 +98,10 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("unmarshal parameters: %w", err)
 			}
 
+			if runner.VarValues && !runner.IsReportOptionOn() {
+				runner.Report = "fails"
+			}
+
 			results, raw, err := runner.Run(ctx)
 			if err != nil {
 				return fmt.Errorf("running verification: %w", err)
@@ -109,6 +114,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 					Tracing:          runner.Trace,
 					ShowSkipped:      true,
 					JUnitHideMessage: viper.GetBool("junit-hide-message"),
+					VarValues:        runner.VarValues,
 				})
 				if runner.IsReportOptionOn() {
 					// report currently available with stdout only
@@ -150,6 +156,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")
+	cmd.Flags().Bool("var-values", false, "Show variables and values in failing test expressions")
 
 	return &cmd
 }

--- a/output/output.go
+++ b/output/output.go
@@ -23,6 +23,7 @@ type Options struct {
 	ShowSkipped        bool
 	JUnitHideMessage   bool
 	File               *os.File
+	VarValues          bool
 }
 
 // The defined output formats represent all of the supported formats
@@ -71,6 +72,7 @@ func newOutputter(format string, options Options) Outputter {
 			SuppressExceptions: options.SuppressExceptions,
 			Tracing:            options.Tracing,
 			ShowSkipped:        options.ShowSkipped,
+			VarValues:          options.VarValues,
 		}
 	case OutputJSON:
 		return NewJSON(options.File)

--- a/output/standard.go
+++ b/output/standard.go
@@ -30,6 +30,9 @@ type Standard struct {
 	// ShowSkipped whether to show skipped tests
 	// in the output.
 	ShowSkipped bool
+
+	// VarValues enables showing variable values in failing test expressions.
+	VarValues bool
 }
 
 // NewStandard creates a new Standard with the given writer.
@@ -192,7 +195,9 @@ func (s *Standard) Report(results []*tester.Result, flag string) error {
 	reporter := tester.PrettyReporter{
 		Verbose:     true,
 		Output:      os.Stdout,
-		FailureLine: true}
+		FailureLine: true,
+		LocalVars:   s.VarValues,
+	}
 
 	dup := make(chan *tester.Result)
 

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -26,6 +26,7 @@ type VerifyRunner struct {
 	Report            string
 	Quiet             bool
 	ShowBuiltinErrors bool `mapstructure:"show-builtin-errors"`
+	VarValues         bool `mapstructure:"var-values"`
 }
 
 const (
@@ -51,7 +52,7 @@ func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.
 	}
 
 	// Traces should be enabled when Trace or Report options are on
-	enableTracing := r.Trace || r.IsReportOptionOn()
+	enableTracing := r.Trace || r.IsReportOptionOn() || r.VarValues
 	if enableTracing {
 		engine.EnableTracing()
 	}


### PR DESCRIPTION
This shows the contents of variables when a Rego unit test fails. This can be helpful in troubleshooting tests without having to add print() statements everywhere.

---

Fixes https://github.com/open-policy-agent/conftest/issues/967