### PR TITLE
feat(parser): Add nginx parser

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,7 @@ As of today Conftest supports:
 - INI
 - JSON
 - Jsonnet
+- nginx
 - Property files (.properties)
 - SPDX
 - TextProto (Protocol Buffers)

--- a/examples/nginx/nginx.conf
+++ b/examples/nginx/nginx.conf
@@ -1,0 +1,19 @@
+worker_processes 1;
+
+http {
+    server {
+        listen 80;
+        server_name example.com;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name example.com;
+
+        location / {
+            root /var/www/html;
+            index index.html;
+        }
+    }
+}

--- a/examples/nginx/policy/deny.rego
+++ b/examples/nginx/policy/deny.rego
@@ -1,0 +1,33 @@
+package main
+
+import rego.v1
+
+# Collect all server blocks nested inside http blocks.
+server_blocks contains server if {
+	some directive in input.directives
+	directive.name == "http"
+	some server in directive.block.directives
+	server.name == "server"
+}
+
+# A server listens without SSL if any listen directive does not include "ssl" as a parameter.
+listens_without_ssl(server) if {
+	some directive in server.block.directives
+	directive.name == "listen"
+	not "ssl" in directive.parameters
+}
+
+# A server redirects to HTTPS if it has a "return 301 https://..." directive.
+redirects_to_https(server) if {
+	some directive in server.block.directives
+	directive.name == "return"
+	directive.parameters[0] == "301"
+	startswith(directive.parameters[1], "https://")
+}
+
+deny contains msg if {
+	some server in server_blocks
+	listens_without_ssl(server)
+	not redirects_to_https(server)
+	msg := "Server listening without SSL must redirect to HTTPS"
+}

--- a/examples/nginx/policy/deny_test.rego
+++ b/examples/nginx/policy/deny_test.rego
@@ -1,0 +1,104 @@
+package main
+
+import rego.v1
+
+empty(value) if {
+	count(value) == 0
+}
+
+no_violations if {
+	empty(deny)
+}
+
+# A config with only an SSL listener should have no violations.
+test_ssl_listener if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 443 ssl;
+				server_name example.com;
+			}
+		}
+	`)
+	no_violations with input as cfg
+}
+
+# A server that redirects port 80 to HTTPS should have no violations.
+test_port_80_redirects_to_https if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 80;
+				server_name example.com;
+				return 301 https://$host$request_uri;
+			}
+		}
+	`)
+	no_violations with input as cfg
+}
+
+# A server listening on port 80 without a redirect should be denied.
+test_port_80_without_redirect if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 80;
+				server_name example.com;
+				location / {
+					root /var/www/html;
+				}
+			}
+		}
+	`)
+	deny["Server listening without SSL must redirect to HTTPS"] with input as cfg
+}
+
+# A non-HTTPS redirect (e.g. return 301 http://...) should still be denied.
+test_port_80_redirects_to_http if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 80;
+				server_name example.com;
+				return 301 http://other.example.com;
+			}
+		}
+	`)
+	deny["Server listening without SSL must redirect to HTTPS"] with input as cfg
+}
+
+# A non-standard HTTP port (e.g. 8080) without a redirect should also be denied.
+test_non_standard_port_without_redirect if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 8080;
+				server_name example.com;
+				location / {
+					root /var/www/html;
+				}
+			}
+		}
+	`)
+	deny["Server listening without SSL must redirect to HTTPS"] with input as cfg
+}
+
+# A non-standard HTTP port that redirects to HTTPS should have no violations.
+test_non_standard_port_redirects_to_https if {
+	cfg := parse_config("nginx", `
+		http {
+			server {
+				listen 8080;
+				server_name example.com;
+				return 301 https://$host$request_uri;
+			}
+		}
+	`)
+	no_violations with input as cfg
+}
+
+# The sample nginx.conf uses a port-80-to-HTTPS redirect and should pass.
+test_sample_config if {
+	cfg := parse_config_file("../nginx.conf")
+	no_violations with input as cfg
+}

--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.3 // indirect
 	github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 // indirect
+	github.com/tufanbarisyildirim/gonginx v0.0.0-20260220081509-8e17ce617db3 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
 	github.com/valyala/fastjson v1.6.7 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.32 // indirect

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/tmccombs/hcl2json v0.6.7 h1:RYKTs4kd/gzRsEiv7J3M2WQ7TYRYZVc+0H0pZdERk
 github.com/tmccombs/hcl2json v0.6.7/go.mod h1:lJgBOOGDpbhjvdG2dLaWsqB4KBzul2HytfDTS3H465o=
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0 h1:2f304B10LaZdB8kkVEaoXvAMVan2tl9AiK4G0odjQtE=
 github.com/tonistiigi/go-csvvalue v0.0.0-20240814133006-030d3b2625d0/go.mod h1:278M4p8WsNh3n4a1eqiFcV2FGk7wE5fwUpUom9mK9lE=
+github.com/tufanbarisyildirim/gonginx v0.0.0-20260220081509-8e17ce617db3 h1:ClWHRIz18WRVT3RD9y9uTwEWU9eEi+VYFEIumg05FLk=
+github.com/tufanbarisyildirim/gonginx v0.0.0-20260220081509-8e17ce617db3/go.mod h1:ALbEe81QPWOZjDKCKNWodG2iqCMtregG8+ebQgjx2+4=
 github.com/tzrikka/xdg v1.3.2 h1:KhTyYLq58F0vs+Vw9uLMKw44qfEZDW5/ZQyCgTE9P2k=
 github.com/tzrikka/xdg v1.3.2/go.mod h1:qZP8butzr5W+sv0kS17GKvBnoUgKVty9fBo+W8LsnTY=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/parser/nginx/nginx.go
+++ b/parser/nginx/nginx.go
@@ -1,0 +1,75 @@
+package nginx
+
+import (
+	"encoding/json"
+	"fmt"
+
+	gonginxconfig "github.com/tufanbarisyildirim/gonginx/config"
+	gonginxparser "github.com/tufanbarisyildirim/gonginx/parser"
+)
+
+// Config represents a parsed nginx configuration.
+type Config struct {
+	Directives []Directive `json:"directives"`
+}
+
+// Directive represents a single nginx directive.
+type Directive struct {
+	Name       string   `json:"name"`
+	Parameters []string `json:"parameters,omitempty"`
+	Block      *Block   `json:"block,omitempty"`
+}
+
+// Block represents a block of directives.
+type Block struct {
+	Directives []Directive `json:"directives"`
+}
+
+// Parser is an nginx configuration parser.
+type Parser struct{}
+
+// Unmarshal unmarshals nginx configuration files.
+func (p *Parser) Unmarshal(b []byte, v any) error {
+	pr := gonginxparser.NewStringParser(string(b), gonginxparser.WithSkipComments())
+	cfg, err := pr.Parse()
+	if err != nil {
+		return fmt.Errorf("parse nginx: %w", err)
+	}
+
+	config := Config{Directives: convertDirectives(cfg.GetDirectives())}
+	j, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("marshal nginx to json: %w", err)
+	}
+
+	if err := json.Unmarshal(j, v); err != nil {
+		return fmt.Errorf("unmarshal nginx json: %w", err)
+	}
+
+	return nil
+}
+
+func convertDirectives(directives []gonginxconfig.IDirective) []Directive {
+	converted := make([]Directive, 0, len(directives))
+	for _, d := range directives {
+		converted = append(converted, convertDirective(d))
+	}
+	return converted
+}
+
+func convertDirective(d gonginxconfig.IDirective) Directive {
+	params := make([]string, 0, len(d.GetParameters()))
+	for _, p := range d.GetParameters() {
+		params = append(params, p.String())
+	}
+
+	directive := Directive{
+		Name:       d.GetName(),
+		Parameters: params,
+	}
+	if block := d.GetBlock(); block != nil {
+		directive.Block = &Block{Directives: convertDirectives(block.GetDirectives())}
+	}
+
+	return directive
+}

--- a/parser/nginx/nginx_test.go
+++ b/parser/nginx/nginx_test.go
@@ -1,0 +1,112 @@
+package nginx
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNginxParser(t *testing.T) {
+	t.Parallel()
+	parser := &Parser{}
+	sample := `
+worker_processes 1;
+http {
+    server {
+        listen 80;
+        server_name example.com;
+        location / {
+            root /var/www/html;
+        }
+    }
+}
+`
+
+	var got Config
+	if err := parser.Unmarshal([]byte(sample), &got); err != nil {
+		t.Fatalf("parser should not have thrown an error: %v", err)
+	}
+
+	want := Config{
+		Directives: []Directive{
+			{Name: "worker_processes", Parameters: []string{"1"}},
+			{
+				Name: "http",
+				Block: &Block{
+					Directives: []Directive{
+						{
+							Name: "server",
+							Block: &Block{
+								Directives: []Directive{
+									{Name: "listen", Parameters: []string{"80"}},
+									{Name: "server_name", Parameters: []string{"example.com"}},
+									{
+										Name:       "location",
+										Parameters: []string{"/"},
+										Block: &Block{
+											Directives: []Directive{
+												{Name: "root", Parameters: []string{"/var/www/html"}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestConfigMarshalJSON(t *testing.T) {
+	t.Parallel()
+	config := Config{
+		Directives: []Directive{
+			{Name: "worker_processes", Parameters: []string{"1"}},
+			{
+				Name: "http",
+				Block: &Block{
+					Directives: []Directive{
+						{
+							Name: "server",
+							Block: &Block{
+								Directives: []Directive{
+									{Name: "listen", Parameters: []string{"80"}},
+									{Name: "server_name", Parameters: []string{"example.com"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	want := `{"directives":[{"name":"worker_processes","parameters":["1"]},{"name":"http","block":{"directives":[{"name":"server","block":{"directives":[{"name":"listen","parameters":["80"]},{"name":"server_name","parameters":["example.com"]}]}}]}}]}`
+
+	got, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("unexpected error marshaling Config: %v", err)
+	}
+
+	if diff := cmp.Diff(want, string(got)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestNginxParserInvalidConfig(t *testing.T) {
+	t.Parallel()
+	parser := &Parser{}
+	sample := `http {`
+
+	var input any
+	if err := parser.Unmarshal([]byte(sample), &input); err == nil {
+		t.Error("expected error for invalid nginx config with unclosed block")
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,11 +10,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/open-policy-agent/conftest/parser/cyclonedx"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slices"
 
 	"github.com/open-policy-agent/conftest/parser/cue"
+	"github.com/open-policy-agent/conftest/parser/cyclonedx"
 	"github.com/open-policy-agent/conftest/parser/docker"
 	dotenv "github.com/open-policy-agent/conftest/parser/dotenv"
 	"github.com/open-policy-agent/conftest/parser/edn"
@@ -26,6 +26,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/json"
 	"github.com/open-policy-agent/conftest/parser/jsonc"
 	"github.com/open-policy-agent/conftest/parser/jsonnet"
+	"github.com/open-policy-agent/conftest/parser/nginx"
 	"github.com/open-policy-agent/conftest/parser/properties"
 	"github.com/open-policy-agent/conftest/parser/spdx"
 	"github.com/open-policy-agent/conftest/parser/textproto"
@@ -50,6 +51,7 @@ const (
 	JSON       = "json"
 	JSONC      = "jsonc"
 	JSONNET    = "jsonnet"
+	NGINX      = "nginx"
 	PROPERTIES = "properties"
 	SPDX       = "spdx"
 	TEXTPROTO  = "textproto"
@@ -98,6 +100,8 @@ func New(parser string) (Parser, error) {
 		return &jsonc.Parser{}, nil
 	case JSONNET:
 		return &jsonnet.Parser{}, nil
+	case NGINX:
+		return &nginx.Parser{}, nil
 	case EDN:
 		return &edn.Parser{}, nil
 	case VCL:
@@ -199,6 +203,10 @@ func NewFromPath(path string) (Parser, error) {
 		return New(DOTENV)
 	}
 
+	if fileName == "nginx.conf" {
+		return New(NGINX)
+	}
+
 	if slices.Contains(textproto.TextProtoFileExtensions, fileExtension) {
 		return New(TEXTPROTO)
 	}
@@ -224,6 +232,7 @@ func Parsers() []string {
 		INI,
 		JSON,
 		JSONNET,
+		NGINX,
 		PROPERTIES,
 		SPDX,
 		TEXTPROTO,


### PR DESCRIPTION
The parser library does not include JSON tags for marshalling, so this implementation adds a few structs to make that easier.

---

Implements https://github.com/open-policy-agent/conftest/issues/912