### PR TITLE
fix(downloader): overwrite existing policy when downloading

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -40,11 +40,15 @@ func Download(ctx context.Context, dst string, urls []string) error {
 			return fmt.Errorf("detecting url: %w", err)
 		}
 
-		// Check if file already exists
+		// Remove any existing policy at the target path so that repeated
+		// calls to Download (e.g. via --update) overwrite stale content
+		// instead of failing with a "file already exists" error.
 		filename := filepath.Base(detectedURL)
 		targetPath := filepath.Join(dst, filename)
 		if _, err := os.Stat(targetPath); err == nil {
-			return fmt.Errorf("policy file already exists at %s, refusing to overwrite", targetPath)
+			if err := os.RemoveAll(targetPath); err != nil {
+				return fmt.Errorf("removing existing policy at %s: %w", targetPath, err)
+			}
 		}
 
 		client := &getter.Client{

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-func TestDownloadFailsWhenFileExists(t *testing.T) {
+func TestDownloadOverwritesExistingFile(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a file that would conflict with the download
@@ -39,24 +39,19 @@ func TestDownloadFailsWhenFileExists(t *testing.T) {
 	}()
 	defer server.Close()
 
-	// Try to download a policy file with the same name
+	// Download should succeed even when the policy file already exists,
+	// overwriting the previous content (e.g. when using --update repeatedly).
 	urls := []string{fmt.Sprintf("http://%s/policy.rego", listener.Addr().String())}
-	downloadErr := Download(context.Background(), tmpDir, urls)
-
-	// Verify that download fails with the expected error
-	if downloadErr == nil {
-		t.Error("Expected download to fail when file exists, but it succeeded")
-	}
-	if downloadErr != nil && !filepath.IsAbs(existingFile) {
-		t.Errorf("Expected error message to contain absolute path, got: %v", downloadErr)
+	if err := Download(context.Background(), tmpDir, urls); err != nil {
+		t.Fatalf("Expected download to succeed when file exists, got error: %v", err)
 	}
 
-	// Verify the original file is unchanged
+	// Verify the file was overwritten with new content
 	content, err := os.ReadFile(existingFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != "existing content" {
-		t.Error("Existing file was modified")
+	if string(content) != "new content" {
+		t.Errorf("Expected file to contain 'new content', got: %s", string(content))
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1106

When `--update` is used to fetch a remote policy and the same command is run a second time, conftest would fail with:

```
Error: running test: update policies: policy file already exists at policy/..., refusing to overwrite
```

This is because `downloader.Download` explicitly prevented overwriting existing paths. As [noted by a maintainer](https://github.com/open-policy-agent/conftest/issues/1106#issuecomment-2558049261), the right fix is to make `--update` overwrite whatever is already there.

## Changes

- Remove the "file already exists" guard in `downloader.Download`.
- Instead, delete any existing path at the target location before downloading.
- Update the test to assert the new overwrite behaviour.

## Testing

```
go test ./downloader/... -v
```

All tests pass.