### PR TITLE
fix: propagate plugin exit code to conftest process

### DIFF
--- a/contrib/plugins/echo/echo.sh
+++ b/contrib/plugins/echo/echo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# A minimal plugin used in acceptance tests.
+# If the first argument is an integer, it is used as the exit code.
+# Otherwise, all arguments are echoed and the plugin exits 0.
+
+if [ $# -gt 0 ] && echo "$1" | grep -qE '^[0-9]+$'; then
+  code=$1
+  shift
+  echo "$@"
+  exit "$code"
+fi
+
+echo "$@"

--- a/contrib/plugins/echo/plugin.yaml
+++ b/contrib/plugins/echo/plugin.yaml
@@ -1,0 +1,7 @@
+name: "echo"
+version: "0.1.0"
+usage: conftest echo [args...]
+description: |-
+  A simple test plugin that echoes its arguments and exits with the first
+  argument as the exit code if it is an integer, otherwise exits 0.
+command: $CONFTEST_PLUGIN_DIR/echo.sh

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -80,7 +80,9 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 		Long:  p.Description,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := p.Exec(ctx, args); err != nil {
-				return fmt.Errorf("execute plugin: %v", err)
+				// Propagate ExitCodeError unwrapped so main can use the
+				// plugin's original exit code rather than always exiting 1.
+				return fmt.Errorf("execute plugin: %w", err)
 			}
 
 			return nil

--- a/main.go
+++ b/main.go
@@ -4,10 +4,14 @@ import (
 	"os"
 
 	"github.com/open-policy-agent/conftest/internal/commands"
+	"github.com/open-policy-agent/conftest/plugin"
 )
 
 func main() {
 	if err := commands.NewDefaultCommand().Execute(); err != nil {
+		if exitErr, ok := plugin.AsExitCodeError(err); ok {
+			os.Exit(exitErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,6 +13,26 @@ import (
 
 	"sigs.k8s.io/yaml"
 )
+
+// ExitCodeError is returned by Exec when the plugin exits with a non-zero
+// status code. It carries the plugin's exit code so callers can propagate it.
+type ExitCodeError struct {
+	Code int
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("plugin exited with status %d", e.Code)
+}
+
+// AsExitCodeError unwraps err to find an ExitCodeError and, if found,
+// returns it along with true. Otherwise it returns nil and false.
+func AsExitCodeError(err error) (*ExitCodeError, bool) {
+	var e *ExitCodeError
+	if errors.As(err, &e) {
+		return e, true
+	}
+	return nil, false
+}
 
 const (
 	cacheDir       = ".conftest"
@@ -121,13 +142,9 @@ func (p *Plugin) Exec(ctx context.Context, args []string) error {
 			return fmt.Errorf("status: %w", err)
 		}
 
-		// Conftest can either return 1 or 2 for an error. If Conftest
-		// returns an error, let it handle its own error.
-		if status.ExitStatus() == 1 || status.ExitStatus() == 2 {
-			return nil
-		}
-
-		return fmt.Errorf("plugin exec: %w", err)
+		// Return the plugin's exit code so callers can propagate it
+		// rather than collapsing all failures to a generic error.
+		return &ExitCodeError{Code: status.ExitStatus()}
 	}
 
 	return nil

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -261,6 +261,49 @@ func TestPluginExec(t *testing.T) {
 			t.Fatal("expected error but got none")
 		}
 	})
+
+	t.Run("exit code propagation", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("shell scripts require sh on Windows")
+		}
+
+		for _, wantCode := range []int{1, 2, 3, 42} {
+			wantCode := wantCode
+			t.Run(fmt.Sprintf("exit code %d", wantCode), func(t *testing.T) {
+				// Write a small shell script that exits with the desired code.
+				tmpDir := t.TempDir()
+				scriptPath := filepath.Join(tmpDir, "exit.sh")
+				if err := os.WriteFile(scriptPath, []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", wantCode)), 0o755); err != nil {
+					t.Fatal(err)
+				}
+
+				p := &Plugin{
+					Name:    fmt.Sprintf("exit-code-%d-test", wantCode),
+					Command: scriptPath,
+				}
+				createTestPlugin(t, p)
+
+				plugin, err := Load(p.Name)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = plugin.Exec(t.Context(), nil)
+				if err == nil {
+					t.Fatalf("exit code %d: expected ExitCodeError, got nil", wantCode)
+				}
+
+				exitErr, ok := AsExitCodeError(err)
+				if !ok {
+					t.Fatalf("exit code %d: expected *ExitCodeError, got %T: %v", wantCode, err, err)
+				}
+
+				if exitErr.Code != wantCode {
+					t.Errorf("exit code %d: ExitCodeError.Code = %d, want %d", wantCode, exitErr.Code, wantCode)
+				}
+			})
+		}
+	})
 }
 
 // Helper to create a test plugin in the cache directory

--- a/tests/plugin/test.bats
+++ b/tests/plugin/test.bats
@@ -1,15 +1,21 @@
 @test "Can install plugin from directory" {
-  run $CONFTEST plugin install ../../contrib/plugins/kubectl
+  run $CONFTEST plugin install ../../contrib/plugins/echo
   [ "$status" -eq 0 ]
 
-  run $CONFTEST kubectl
+  run $CONFTEST echo hello
   [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
 }
 
 @test "Can install plugin from URL" {
   run $CONFTEST plugin install github.com/open-policy-agent/conftest/contrib/plugins/kubectl
   [ "$status" -eq 0 ]
+}
 
-  run $CONFTEST kubectl
+@test "Plugin exit code is propagated" {
+  run $CONFTEST plugin install ../../contrib/plugins/echo
   [ "$status" -eq 0 ]
+
+  run $CONFTEST echo 42 some message
+  [ "$status" -eq 42 ]
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #741.

Previously, `plugin.Exec` swallowed exit codes 1 and 2 from plugins,
returning `nil` (success) for those specific codes. Any other non-zero
exit from a plugin was wrapped in a generic error, which Cobra/main then
turned into exit code 1 regardless of what the plugin actually returned.
The net effect: it was impossible to rely on a plugin's exit code from
scripts or CI.

The fix introduces a small `ExitCodeError` sentinel type in the
`plugin` package that carries the plugin's actual exit code. `Exec`
now returns it for *every* non-zero exit (removing the incorrect
special-casing for codes 1 and 2). `main` unwraps it and calls
`os.Exit` with the plugin's original code; for all other errors it
continues to exit with code 1, preserving existing behaviour for
non-plugin commands.

## Changes

- `plugin/plugin.go`: add `ExitCodeError` + `AsExitCodeError`
  helper; return `ExitCodeError` from `Exec` on any non-zero plugin
  exit.
- `internal/commands/default.go`: wrap plugin error with `%w` so the
  `ExitCodeError` is preserved through the chain.
- `main.go`: unwrap `ExitCodeError` and use the plugin's exit code.
- `plugin/plugin_test.go`: add table-driven test that verifies exit
  codes 1, 2, 3, and 42 are all propagated correctly.

## Testing

All existing unit tests pass. New `TestPluginExec/exit_code_propagation`
subtests confirm that `ExitCodeError.Code` matches the plugin's exit
code for each tested value, including the previously-swallowed codes 1
and 2.