### PR TITLE
feat: auto-load policy/data when --data is unset

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -136,6 +136,13 @@ conftest test -p examples/data/policy -d examples/data/exclusions examples/data/
 The paths at the flag are recursively searched for JSON and YAML files. Data can
 be imported as follows:
 
+If `--data` is not set, conftest looks for a `data` subdirectory inside each
+policy directory and loads it automatically. This makes it possible to ship a
+self-contained bundle with policies under `policy/` and data under
+`policy/data/` without requiring callers to add a `-d` flag.
+
+
+
 Given the following yaml file:
 
 ```yaml

--- a/runner/data.go
+++ b/runner/data.go
@@ -1,0 +1,37 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// defaultDataPaths returns paths to auto-discover when --data is not set.
+//
+// For each policy path that is a directory, a sibling "data" directory inside
+// it is included if present. This makes it possible to publish a self-contained
+// bundle as policy/ with policies and policy/data/ with data, and have
+// conftest pick up both without requiring callers to add a -d flag.
+//
+// When --data is set explicitly, this discovery is skipped so the user's
+// choice is authoritative.
+func defaultDataPaths(policyPaths []string) []string {
+	var paths []string
+	seen := make(map[string]struct{})
+	for _, p := range policyPaths {
+		info, err := os.Stat(p)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(p, "data")
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		dataInfo, err := os.Stat(candidate)
+		if err != nil || !dataInfo.IsDir() {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		paths = append(paths, candidate)
+	}
+	return paths
+}

--- a/runner/data_test.go
+++ b/runner/data_test.go
@@ -1,0 +1,81 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultDataPaths(t *testing.T) {
+	root := t.TempDir()
+
+	withData := filepath.Join(root, "with-data")
+	if err := os.MkdirAll(filepath.Join(withData, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withoutData := filepath.Join(root, "without-data")
+	if err := os.MkdirAll(withoutData, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withDataAsFile := filepath.Join(root, "data-is-file")
+	if err := os.MkdirAll(withDataAsFile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(withDataAsFile, "data"), []byte("noop"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFile := filepath.Join(root, "policy.rego")
+	if err := os.WriteFile(policyFile, []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		policyPaths []string
+		want        []string
+	}{
+		{
+			name:        "discovers sibling data directory",
+			policyPaths: []string{withData},
+			want:        []string{filepath.Join(withData, "data")},
+		},
+		{
+			name:        "skips policy directory without data",
+			policyPaths: []string{withoutData},
+			want:        nil,
+		},
+		{
+			name:        "skips when data is a file, not a directory",
+			policyPaths: []string{withDataAsFile},
+			want:        nil,
+		},
+		{
+			name:        "skips when policy path is a file",
+			policyPaths: []string{policyFile},
+			want:        nil,
+		},
+		{
+			name:        "skips missing policy paths",
+			policyPaths: []string{filepath.Join(root, "does-not-exist")},
+			want:        nil,
+		},
+		{
+			name:        "dedupes when the same policy is passed twice",
+			policyPaths: []string{withData, withData},
+			want:        []string{filepath.Join(withData, "data")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := defaultDataPaths(tt.policyPaths)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/runner/test.go
+++ b/runner/test.go
@@ -72,7 +72,12 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckRe
 		RegoVersion:  t.RegoVersion,
 		Capabilities: capabilities,
 	}
-	engine, err := policy.LoadWithData(t.Policy, t.Data, opts)
+	dataPaths := t.Data
+	if len(dataPaths) == 0 {
+		dataPaths = defaultDataPaths(t.Policy)
+	}
+
+	engine, err := policy.LoadWithData(t.Policy, dataPaths, opts)
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}

--- a/runner/test.go
+++ b/runner/test.go
@@ -74,7 +74,12 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckRe
 		RegoVersion:  t.RegoVersion,
 		Capabilities: capabilities,
 	}
-	engine, err := policy.LoadWithData(t.Policy, t.Data, opts)
+	dataPaths := t.Data
+	if len(dataPaths) == 0 {
+		dataPaths = defaultDataPaths(t.Policy)
+	}
+
+	engine, err := policy.LoadWithData(t.Policy, dataPaths, opts)
 	if err != nil {
 		return nil, fmt.Errorf("load: %w", err)
 	}

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -45,7 +45,12 @@ func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.
 		RegoVersion:  r.RegoVersion,
 		Capabilities: capabilities,
 	}
-	engine, err := policy.LoadWithData(r.Policy, r.Data, opts)
+	dataPaths := r.Data
+	if len(dataPaths) == 0 {
+		dataPaths = defaultDataPaths(r.Policy)
+	}
+
+	engine, err := policy.LoadWithData(r.Policy, dataPaths, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load: %w", err)
 	}

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -47,7 +47,12 @@ func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.
 		RegoVersion:  r.RegoVersion,
 		Capabilities: capabilities,
 	}
-	engine, err := policy.LoadWithData(r.Policy, r.Data, opts)
+	dataPaths := r.Data
+	if len(dataPaths) == 0 {
+		dataPaths = defaultDataPaths(r.Policy)
+	}
+
+	engine, err := policy.LoadWithData(r.Policy, dataPaths, opts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("load: %w", err)
 	}


### PR DESCRIPTION
When \`--data\` is not set, conftest now looks for a \`data\` subdirectory inside
each \`--policy\` directory and includes it automatically. This makes it
possible to publish a self-contained bundle laid out as:

\`\`\`
policy/
├── deployment.rego
└── data/
    └── allowlist.yaml
\`\`\`

…and run \`conftest test\` (or \`conftest verify\`) against it without making
callers remember an explicit \`-d\` flag.

If \`--data\` is set explicitly, behaviour is unchanged so the user's choice
remains authoritative. Discovery is also a no-op when the policy path is a
file, the policy directory has no \`data\` child, or \`data\` exists but is a
file (not a directory).

### Tests
\`runner/data_test.go\` covers each of those branches plus dedup when the
same policy path is passed twice.

Fixes #800