### PR TITLE
fix(verify): default `--show-builtin-errors` to false

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -280,8 +280,7 @@ in a unit test.
 
 > **TIP:** It is recommended to use the `--show-builtin-errors` flag when using
 > the `parse_config`, `parse_config_file`, and `parse_combined_config_files`
-> functions. This way errors encountered during parsing will be raised. This
-> flag will be enabled by default in a future release.
+> functions. This way errors encountered during parsing will be raised.
 
 **deny.rego**
 

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -145,7 +145,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 	cmd.Flags().Bool("trace", false, "Enable more verbose trace output for Rego queries")
 	cmd.Flags().Bool("strict", false, "Enable strict mode for Rego policies")
 	cmd.Flags().String("report", "", "Shows output for Rego queries as a report with summary. Available options are {full|notes|fails}.")
-	cmd.Flags().Bool("show-builtin-errors", true, "Collect and return all encountered built-in errors")
+	cmd.Flags().Bool("show-builtin-errors", false, "Collect and return all encountered built-in errors")
 
 	cmd.Flags().StringP("output", "o", output.OutputStandard, fmt.Sprintf("Output format for conftest results - valid options are: %s", output.Outputs()))
 	cmd.Flags().Bool("junit-hide-message", false, "Do not include the violation message in the JUnit test name")

--- a/tests/builtin-errors/test.bats
+++ b/tests/builtin-errors/test.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 @test "Parsing error without show-builtin-errors flag returns test failed" {
-  run $CONFTEST verify --show-builtin-errors=false
+  run $CONFTEST verify
 
   [ "$status" -eq 1 ]
   echo $output


### PR DESCRIPTION
Change the default value of the `--show-builtin-errors` flag from true to false. This aligns the behavior of `conftest verify` with `opa test` and reduces verbosity by hiding Rego built-in errors by default.

Fixes: #1079

I have attached the original policy and tests rego files used as a demo for writing rego functions and their tests. 
[numbers.tgz](https://github.com/user-attachments/files/27208304/numbers.tgz)

These tests files could be used to demo the change of the `--show-builtin-errors` default value from `true` to `false`

Before
```sh
▶ conftest --version
Conftest: dev
OPA: 1.12.1

# show-builtin-erros default set to `true`
▶ conftest verify  \
--policy ./numbers \
--report=fails
Error: running verification: run test: [{eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:51 0x14000a09620} {eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:59 0x14000a40030} {eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:67 0x14000a40990}]

# show-builtin-erros set to `false`
▶ conftest verify  \
--policy ./numbers \
--report=fails --show-builtin-errors=false
numbers/policy_test.rego:
data.acme.numbers_test.test_compare2num_a_null_eq_b_cannot_compare: PASS (3.982ms)
data.acme.numbers_test.test_compare2num_a_str_eq_b: PASS (4.143583ms)
data.acme.numbers_test.test_compare2num_a_lt_b: PASS (4.135542ms)
data.acme.numbers_test.test_compare2num_a_letter_eq_b_cannot_compare: PASS (4.544875ms)
data.acme.numbers_test.test_not_3_is_gt_5: PASS (650.208µs)
data.acme.numbers_test.test_compare2num_a_gt_b: PASS (5.065709ms)
data.acme.numbers_test.test_compare2num_a_eq_b: PASS (1.145416ms)
data.acme.numbers_test.test_not_5_is_gt_5: PASS (5.217917ms)
data.acme.numbers_test.test_7_is_gt_5: PASS (1.174417ms)
data.acme.numbers_test.test_any_match_ok: PASS (5.327958ms)
data.acme.numbers_test.test_allow_ok: PASS (5.429625ms)
data.acme.numbers_test.test_any_match_fail: PASS (5.521375ms)
data.acme.numbers_test.test_allow_fail: PASS (6.16575ms)
--------------------------------------------------------------------------------
PASS: 13/13
```
After the change; Binary compiled with make from the repo
```sh
▶ ~/Projects/conftest/conftest --version
Conftest: 2f12-dirty
OPA: 1.15.2

# show-builtin-erros default set to `false`
▶ ~/Projects/conftest/conftest verify  \
--policy ./numbers \
--report=fails
numbers/policy_test.rego:74:
data.acme.numbers_test.test_compare2num_a_null_eq_b_cannot_compare: PASS (3.808708ms)
numbers/policy_test.rego:58:
data.acme.numbers_test.test_compare2num_a_lt_b: PASS (3.8145ms)
numbers/policy_test.rego:62:
data.acme.numbers_test.test_compare2num_a_eq_b: PASS (3.84475ms)
numbers/policy_test.rego:66:
data.acme.numbers_test.test_compare2num_a_str_eq_b: PASS (3.912875ms)
numbers/policy_test.rego:78:
data.acme.numbers_test.test_7_is_gt_5: PASS (160.125µs)
numbers/policy_test.rego:86:
data.acme.numbers_test.test_not_5_is_gt_5: PASS (4.007834ms)
numbers/policy_test.rego:82:
data.acme.numbers_test.test_not_3_is_gt_5: PASS (159.583µs)
numbers/policy_test.rego:70:
data.acme.numbers_test.test_compare2num_a_letter_eq_b_cannot_compare: PASS (175.708µs)
numbers/policy_test.rego:54:
data.acme.numbers_test.test_compare2num_a_gt_b: PASS (4.792792ms)
numbers/policy_test.rego:18:
data.acme.numbers_test.test_any_match_fail: PASS (5.049333ms)
numbers/policy_test.rego:6:
data.acme.numbers_test.test_any_match_ok: PASS (5.091958ms)
numbers/policy_test.rego:30:
data.acme.numbers_test.test_allow_ok: PASS (5.209208ms)
numbers/policy_test.rego:42:
data.acme.numbers_test.test_allow_fail: PASS (6.88575ms)
--------------------------------------------------------------------------------
PASS: 13/13

# set `show-builtin-errors` to true
▶ ~/Projects/conftest/conftest verify  \
--policy ./numbers \
--report=fails --show-builtin-errors=true
Error: running verification: run test: [{eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:51 0x14000b136e0} {eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:59 0x14000b440c0} {eval_builtin_error to_number: strconv.ParseFloat: parsing "a": invalid syntax numbers/policy.rego:67 0x14000b449f0}]
```