### PR TITLE
ci: surface goconst and inline only for new issues

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,8 +24,10 @@ jobs:
         run: ./validate-conventional-commit-prefix.sh
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # ratchet:golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # ratchet:golangci/golangci-lint-action@v9
         with:
+          version: v2.12.2
+          only-new-issues: true
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 
       - name: setup regal

--- a/scripts/push-pull-e2e.sh
+++ b/scripts/push-pull-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail
@@ -143,8 +143,8 @@ done
 
 export SSL_CERT_FILE="${PWD}/${WORKDIR}"/certs/domain.crt
 
-if ! echo supersecret | docker login --username=test --password-stdin registry.127.0.0.1.nip.io:5000 >/dev/null 2>&1; then
-    echo "LOGGING TO TEST REGISTRY"
+if ! echo supersecret | docker login --username=test --password-stdin registry.127.0.0.1.nip.io:5000; then
+    echo "ERROR: Failed to login to test registry"
     exit 1
 fi
 
@@ -155,7 +155,6 @@ fi
 
 if ! $CONFTEST pull --tls oci://registry.127.0.0.1.nip.io:5000/testdataonly -p "${WORKDIR}"/tlstest; then
     echo "PULLING FROM REGISTRY VIA TLS AND WITH AUTHENTICATION FAILED"
-    sleep infinity
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Alternative approach to PR #1332 - instead of completely disabling `goconst` and `inline` linters, this PR uses golangci-lint's `only-new-issues` mode to keep them active without blocking CI on existing violations.

### Changes

**`.github/workflows/pr.yaml`**:
- Add `only-new-issues: true` to golangci-lint-action (only lint code changed in the PR)
- Upgrade golangci-lint-action from v8 → v9
- Add `version: v2.12.2` to use golangci-lint v2

**`scripts/push-pull-e2e.sh`**:
- Fix shebang to use portable `#!/usr/bin/env bash`
- Improve docker login error message
- Remove debug `sleep infinity` statement

### Why this approach?

**Better than complete removal (PR #1332)**:
✅ Keeps linters active for new code  
✅ Catches new violations in PRs  
✅ Prevents quality regression going forward

**Better than severity configuration**:
✅ Severity doesn't control exit codes in golangci-lint v2  
✅ `only-new-issues` actually prevents CI failures

**Better than fixing all 155+ existing violations**:
✅ Team can address them gradually without blocking development  
✅ Unblocks CI immediately

### How it works

The `only-new-issues: true` setting makes golangci-lint only check code changed in the PR (using `--new-from-patch`). Existing violations in unchanged code won't fail the build, but any new violations introduced in the PR will be caught and block merging.

---

Fixes the CI failures mentioned in #1332 while maintaining code quality checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)