### PR TITLE
feat: support glob wildcards in --namespace

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -84,10 +84,49 @@
   [ "${lines[1]}" = "1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions" ]
 }
 
+@test "Test command matches a single namespace literally" {
+  run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --namespace 'main'
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "unallowed image found" ]]
+  [[ ! "$output" =~ "unallowed commands found" ]]
+}
+
+@test "Test command matches every namespace with a wildcard" {
+  run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --namespace '*'
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "unallowed image found" ]]
+  [[ "$output" =~ "unallowed commands found" ]]
+}
+
+@test "Test command matches namespaces with a wildcard prefix" {
+  run ./conftest test -p examples/docker/policy examples/docker/Dockerfile --namespace 'c*'
+  [ "$status" -eq 1 ]
+  [[ ! "$output" =~ "unallowed image found" ]]
+  [[ "$output" =~ "unallowed commands found" ]]
+}
+
 @test "Verify command has trace flag" {
   run ./conftest verify --policy ./examples/kubernetes/policy --trace
   [ "$status" -eq 0 ]
   [[ "$output" =~ "data.kubernetes.is_service" ]]
+}
+
+@test "Verify command matches a namespace literally" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'main'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
+}
+
+@test "Verify command matches namespaces with a wildcard" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'ma*'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "4 tests, 4 passed" ]]
+}
+
+@test "Verify command filters out non-matching namespaces" {
+  run ./conftest verify --policy ./examples/kubernetes/policy --namespace 'doesnotexist'
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "0 tests, 0 passed" ]]
 }
 
 @test "Fail when verifying with no policies path" {

--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -191,7 +191,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().StringSliceP("policy", "p", []string{"policy"}, "Path to the Rego policy files directory")
 	cmd.Flags().StringSliceP("update", "u", []string{}, "A list of URLs can be provided to the update flag, which will download before the tests run")
-	cmd.Flags().StringSliceP("namespace", "n", []string{"main"}, "Test policies in a specific namespace")
+	cmd.Flags().StringSliceP("namespace", "n", []string{"main"}, "Test policies in specific namespaces. Supports glob wildcards (*, ?, [...]) where * matches any sequence of characters including dots. Example: 'k8s.*' matches both k8s.simple and k8s.simple.deployment")
 	cmd.Flags().StringSliceP("data", "d", []string{}, "A list of paths from which data for the rego policies will be recursively loaded")
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -83,6 +83,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 				"proto-file-dirs",
 				"show-builtin-errors",
 				"var-values",
+				"namespace",
 			}
 			for _, name := range flagNames {
 				if err := viper.BindPFlag(name, cmd.Flags().Lookup(name)); err != nil {
@@ -157,6 +158,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")
 	cmd.Flags().Bool("var-values", false, "Show variables and values in failing test expressions")
+	cmd.Flags().StringSliceP("namespace", "n", []string{}, "Verify policies in specific namespaces. Supports glob wildcards (e.g. 'main.*'). When empty, all namespaces are verified")
 
 	return &cmd
 }

--- a/internal/commands/verify.go
+++ b/internal/commands/verify.go
@@ -158,7 +158,7 @@ func NewVerifyCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().StringSlice("proto-file-dirs", []string{}, "A list of directories containing Protocol Buffer definitions")
 	cmd.Flags().Bool("var-values", false, "Show variables and values in failing test expressions")
-	cmd.Flags().StringSliceP("namespace", "n", []string{}, "Verify policies in specific namespaces. Supports glob wildcards (e.g. 'main.*'). When empty, all namespaces are verified")
+	cmd.Flags().StringSliceP("namespace", "n", []string{}, "Verify policies in specific namespaces. Supports glob wildcards (*, ?, [...]) where * matches any sequence of characters including dots (e.g. 'main.*'). When empty, all namespaces are verified")
 
 	return &cmd
 }

--- a/runner/test.go
+++ b/runner/test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/open-policy-agent/conftest/downloader"
 	"github.com/open-policy-agent/conftest/output"
@@ -89,6 +91,11 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckRe
 	namespaces := t.Namespace
 	if t.AllNamespaces {
 		namespaces = engine.Namespaces()
+	} else if hasWildcard(t.Namespace) {
+		namespaces, err = filterNamespaces(engine.Namespaces(), t.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("filter namespaces: %w", err)
+		}
 	}
 
 	var results output.CheckResults
@@ -210,4 +217,42 @@ func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, erro
 	}
 
 	return files, nil
+}
+
+// hasWildcard reports whether any of the given namespace patterns contains a
+// glob metacharacter (*, ?, or [). When none do, namespaces are matched
+// literally and the previous behaviour is preserved.
+func hasWildcard(patterns []string) bool {
+	for _, pattern := range patterns {
+		if strings.ContainsAny(pattern, "*?[") {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterNamespaces returns the subset of the available namespaces that match at
+// least one of the given patterns. Patterns are matched with path.Match, which
+// supports *, ?, and [...] glob syntax. The "." separator in a namespace is
+// treated as an ordinary character, so "main.*" matches "main.gke" and "*"
+// matches every namespace. The result preserves the order of the available
+// namespaces and contains no duplicates.
+func filterNamespaces(namespaces []string, patterns []string) ([]string, error) {
+	var result []string
+	for _, namespace := range namespaces {
+		for _, pattern := range patterns {
+			matched, err := path.Match(pattern, namespace)
+			if err != nil {
+				return nil, fmt.Errorf("match pattern %q: %w", pattern, err)
+			}
+
+			if matched {
+				result = append(result, namespace)
+				break
+			}
+		}
+	}
+
+	return result, nil
 }

--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -1,0 +1,176 @@
+package runner
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestHasWildcard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []string
+		want     bool
+	}{
+		{
+			name:     "no wildcard",
+			patterns: []string{"main", "kubernetes"},
+			want:     false,
+		},
+		{
+			name:     "dotted literal is not a wildcard",
+			patterns: []string{"main.gke"},
+			want:     false,
+		},
+		{
+			name:     "asterisk wildcard",
+			patterns: []string{"main.*"},
+			want:     true,
+		},
+		{
+			name:     "question mark wildcard",
+			patterns: []string{"main.?"},
+			want:     true,
+		},
+		{
+			name:     "bracket wildcard",
+			patterns: []string{"main.[abc]"},
+			want:     true,
+		},
+		{
+			name:     "wildcard in second pattern",
+			patterns: []string{"main", "test.*"},
+			want:     true,
+		},
+		{
+			name:     "empty patterns",
+			patterns: []string{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasWildcard(tt.patterns); got != tt.want {
+				t.Errorf("hasWildcard(%v) = %v, want %v", tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		namespaces []string
+		patterns   []string
+		want       []string
+		wantErr    bool
+	}{
+		{
+			name:       "suffix wildcard matches dotted children",
+			namespaces: []string{"main", "main.gke", "main.aws", "kubernetes"},
+			patterns:   []string{"main.*"},
+			want:       []string{"main.gke", "main.aws"},
+		},
+		{
+			name:       "prefix wildcard matches dotted children",
+			namespaces: []string{"main.gke", "kubernetes.gke", "main.aws"},
+			patterns:   []string{"*.gke"},
+			want:       []string{"main.gke", "kubernetes.gke"},
+		},
+		{
+			name:       "literal pattern matches exactly",
+			namespaces: []string{"main", "main.gke"},
+			patterns:   []string{"main"},
+			want:       []string{"main"},
+		},
+		{
+			name:       "literal pattern with no match yields nil",
+			namespaces: []string{"main", "kubernetes"},
+			patterns:   []string{"notpresent"},
+			want:       nil,
+		},
+		{
+			name:       "multiple patterns are unioned",
+			namespaces: []string{"main", "main.gke", "terraform", "terraform.aws"},
+			patterns:   []string{"main.*", "terraform.*"},
+			want:       []string{"main.gke", "terraform.aws"},
+		},
+		{
+			name:       "no matches yields nil",
+			namespaces: []string{"main", "kubernetes"},
+			patterns:   []string{"foo.*"},
+			want:       nil,
+		},
+		{
+			name:       "lone star matches everything",
+			namespaces: []string{"main", "kubernetes", "commands"},
+			patterns:   []string{"*"},
+			want:       []string{"main", "kubernetes", "commands"},
+		},
+		{
+			name:       "question mark matches single character",
+			namespaces: []string{"main.a", "main.b", "main.ab"},
+			patterns:   []string{"main.?"},
+			want:       []string{"main.a", "main.b"},
+		},
+		{
+			name:       "bracket class matches enumerated characters",
+			namespaces: []string{"main.a", "main.b", "main.c"},
+			patterns:   []string{"main.[ab]"},
+			want:       []string{"main.a", "main.b"},
+		},
+		{
+			name:       "overlapping patterns do not duplicate a namespace",
+			namespaces: []string{"main.gke"},
+			patterns:   []string{"main.*", "*.gke"},
+			want:       []string{"main.gke"},
+		},
+		{
+			name:       "result preserves available namespace order",
+			namespaces: []string{"zeta", "alpha", "mu"},
+			patterns:   []string{"*"},
+			want:       []string{"zeta", "alpha", "mu"},
+		},
+		{
+			name:       "empty available yields nil",
+			namespaces: []string{},
+			patterns:   []string{"main.*"},
+			want:       nil,
+		},
+		{
+			name:       "empty patterns yields nil",
+			namespaces: []string{"main", "kubernetes"},
+			patterns:   []string{},
+			want:       nil,
+		},
+		{
+			name:       "invalid pattern returns an error",
+			namespaces: []string{"main"},
+			patterns:   []string{"[invalid"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := filterNamespaces(tt.namespaces, tt.patterns)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("filterNamespaces(%v, %v) error = %v, wantErr %v", tt.namespaces, tt.patterns, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterNamespaces(%v, %v) = %v, want %v", tt.namespaces, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -27,6 +27,7 @@ type VerifyRunner struct {
 	Quiet             bool
 	ShowBuiltinErrors bool `mapstructure:"show-builtin-errors"`
 	VarValues         bool `mapstructure:"var-values"`
+	Namespace         []string
 }
 
 const (
@@ -69,9 +70,32 @@ func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.
 		return nil, nil, fmt.Errorf("running tests: %w", err)
 	}
 
+	// When namespaces are requested, restrict the reported results to the
+	// matching namespaces. Patterns may be literal or contain glob wildcards
+	// (see filterNamespaces); an empty list keeps every namespace.
+	var allowedNamespaces map[string]bool
+	if len(r.Namespace) > 0 {
+		matched, err := filterNamespaces(engine.Namespaces(), r.Namespace)
+		if err != nil {
+			return nil, nil, fmt.Errorf("filter namespaces: %w", err)
+		}
+
+		allowedNamespaces = make(map[string]bool, len(matched))
+		for _, namespace := range matched {
+			allowedNamespaces[namespace] = true
+		}
+	}
+
 	var results output.CheckResults
 	var rawResults []*tester.Result
 	for result := range ch {
+		if allowedNamespaces != nil {
+			namespace := strings.TrimPrefix(result.Package, "data.")
+			if !allowedNamespaces[namespace] {
+				continue
+			}
+		}
+
 		if result.Error != nil {
 			return nil, nil, fmt.Errorf("run test: %w", result.Error)
 		}


### PR DESCRIPTION
Fixes #1141

## What this does

`--namespace` currently matches namespaces literally, so picking a group of related namespaces means repeating `-n` once per namespace. This is awkward for the layouts described in the issue, especially together with `--combine`, where you want to run only the `*.simple` namespaces in one invocation and only the `*.combined` namespaces in another.

This change lets a single `--namespace` value be a glob pattern, so the examples from the issue now work directly:

```
# data and terraform simple namespaces
conftest test target/ --namespace '*.simple'

# k8s combined namespaces only
conftest test target/ --namespace 'k8s.combined.*' --combine
```

Patterns are evaluated with Go's `path.Match`, so `*`, `?`, and `[...]` character classes are all supported. The `.` in a namespace is treated as an ordinary character (it is not a path separator here), which is why `main.*` matches `main.gke` and a lone `*` matches every namespace.

## How

Two small helpers live in the runner:

- `hasWildcard` reports whether any of the supplied patterns contains a glob metacharacter (`*`, `?`, or `[`).
- `filterNamespaces` resolves the patterns against the namespaces the engine actually loaded (`engine.Namespaces()`), preserving their order and avoiding duplicates when several patterns match the same namespace.

For `conftest test`, the wildcard path is only taken when a pattern actually contains a wildcard, so a literal `--namespace main` keeps its existing behaviour untouched. `--all-namespaces` still wins when set.

`conftest verify` previously had no `--namespace` flag at all. This adds one that filters the reported test results through the same matcher (the package name is normalised by trimming the leading `data.` so it lines up with what `engine.Namespaces()` returns). Leaving it empty verifies every namespace, exactly as before, so this is additive.

## Approach / prior art

This mirrors the approach from the earlier, already-reviewed #1247 (same `hasWildcard` / `filterNamespaces` shape and `path.Match` semantics). That PR was closed by its own author for inactivity rather than for any design objection, and @jalseth had been supportive of the direction, so I rebuilt it against current `main` (the verify runner has changed since, e.g. the addition of `var-values`), tightened the helper behaviour around ordering and de-duplication, and expanded the tests.

## Tests

- Table-driven unit tests for `hasWildcard` and `filterNamespaces` in `runner/test_test.go`: literal patterns, prefix and suffix wildcards, `?` and `[...]` classes, multi-pattern unions, de-duplication across overlapping patterns, order preservation, empty inputs, and the invalid-pattern error path.
- Acceptance tests in `acceptance.bats` covering both commands end to end: literal match, `*`, and a prefix wildcard for `test`; literal, wildcard, and a no-match case for `verify`.

`go test ./runner/... ./internal/...` passes, and `gofmt` and `go vet` are clean. I also ran the built binary against the bundled `examples/docker` and `examples/kubernetes` policies to confirm the wildcard, literal, and no-match cases behave as expected.
