### PR TITLE
fix: propagate plugin exit code to conftest process

### DIFF
--- a/contrib/plugins/echo/echo.sh
+++ b/contrib/plugins/echo/echo.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# A minimal plugin used in acceptance tests.
+# If the first argument is an integer, it is used as the exit code and the
+# remaining arguments are echoed. Otherwise all arguments are echoed and the
+# plugin exits 0.
+
+if [ $# -gt 0 ] && echo "$1" | grep -qE '^[0-9]+$'; then
+  code=$1
+  shift
+  echo "$@"
+  exit "$code"
+fi
+
+echo "$@"

--- a/contrib/plugins/echo/plugin.yaml
+++ b/contrib/plugins/echo/plugin.yaml
@@ -1,0 +1,7 @@
+name: "echo"
+version: "0.1.0"
+usage: conftest echo [args...]
+description: |-
+  A simple test plugin that echoes its arguments. If the first argument is an
+  integer it is used as the exit code, otherwise the plugin exits 0.
+command: $CONFTEST_PLUGIN_DIR/echo.sh

--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -80,7 +80,9 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 		Long:  p.Description,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if err := p.Exec(ctx, args); err != nil {
-				return fmt.Errorf("execute plugin: %v", err)
+				// Wrap with %w so an ExitCodeError survives unwrapping and main
+				// can exit with the plugin's original exit code (#741).
+				return fmt.Errorf("execute plugin: %w", err)
 			}
 
 			return nil

--- a/main.go
+++ b/main.go
@@ -4,10 +4,16 @@ import (
 	"os"
 
 	"github.com/open-policy-agent/conftest/internal/commands"
+	"github.com/open-policy-agent/conftest/plugin"
 )
 
 func main() {
 	if err := commands.NewDefaultCommand().Execute(); err != nil {
+		// When a plugin exits non-zero, propagate its exit code rather than
+		// always exiting 1, so scripts and CI can rely on it (#741).
+		if exitErr, ok := plugin.AsExitCodeError(err); ok {
+			os.Exit(exitErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +18,27 @@ const (
 	cacheDir       = ".conftest"
 	cacheDirectory = xdgPath(cacheDir)
 )
+
+// ExitCodeError is returned by Exec when a plugin exits with a non-zero status
+// code. It carries the plugin's actual exit code so callers can propagate it to
+// conftest's own process exit code rather than collapsing every failure to 1.
+type ExitCodeError struct {
+	Code int
+}
+
+func (e *ExitCodeError) Error() string {
+	return fmt.Sprintf("plugin exited with status %d", e.Code)
+}
+
+// AsExitCodeError unwraps err looking for an ExitCodeError. If one is found it
+// is returned along with true, otherwise it returns nil and false.
+func AsExitCodeError(err error) (*ExitCodeError, bool) {
+	var e *ExitCodeError
+	if errors.As(err, &e) {
+		return e, true
+	}
+	return nil, false
+}
 
 // Plugin represents a plugin.
 type Plugin struct {
@@ -121,13 +143,11 @@ func (p *Plugin) Exec(ctx context.Context, args []string) error {
 			return fmt.Errorf("status: %w", err)
 		}
 
-		// Conftest can either return 1 or 2 for an error. If Conftest
-		// returns an error, let it handle its own error.
-		if status.ExitStatus() == 1 || status.ExitStatus() == 2 {
-			return nil
-		}
-
-		return fmt.Errorf("plugin exec: %w", err)
+		// Return the plugin's actual exit code so callers can propagate it to
+		// conftest's own exit code. Previously codes 1 and 2 were swallowed as
+		// success and other codes were collapsed to a generic error, which made
+		// it impossible to rely on a plugin's exit code from scripts or CI (#741).
+		return &ExitCodeError{Code: status.ExitStatus()}
 	}
 
 	return nil

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -261,6 +261,67 @@ func TestPluginExec(t *testing.T) {
 			t.Fatal("expected error but got none")
 		}
 	})
+
+	t.Run("exit code propagation", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("shell scripts require sh on Windows")
+		}
+
+		// Exec must surface the plugin's actual exit code via ExitCodeError for
+		// every non-zero value, including 1 and 2 which were previously swallowed
+		// as success (#741).
+		for _, wantCode := range []int{1, 2, 3, 42} {
+			t.Run(fmt.Sprintf("exit code %d", wantCode), func(t *testing.T) {
+				tmpDir := t.TempDir()
+				scriptPath := filepath.Join(tmpDir, "exit.sh")
+				if err := os.WriteFile(scriptPath, []byte(fmt.Sprintf("#!/bin/sh\nexit %d\n", wantCode)), 0o755); err != nil {
+					t.Fatal(err)
+				}
+
+				p := &Plugin{
+					Name:    fmt.Sprintf("exit-code-%d-test", wantCode),
+					Command: scriptPath,
+				}
+				createTestPlugin(t, p)
+
+				plugin, err := Load(p.Name)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				err = plugin.Exec(t.Context(), nil)
+				if err == nil {
+					t.Fatalf("exit code %d: expected ExitCodeError, got nil", wantCode)
+				}
+
+				exitErr, ok := AsExitCodeError(err)
+				if !ok {
+					t.Fatalf("exit code %d: expected *ExitCodeError, got %T: %v", wantCode, err, err)
+				}
+
+				if exitErr.Code != wantCode {
+					t.Errorf("exit code %d: ExitCodeError.Code = %d, want %d", wantCode, exitErr.Code, wantCode)
+				}
+			})
+		}
+	})
+
+	t.Run("successful command returns no error", func(t *testing.T) {
+		p := &Plugin{
+			Name:    "success-test",
+			Command: "true",
+		}
+		createTestPlugin(t, p)
+
+		plugin, err := Load("success-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := plugin.Exec(t.Context(), nil); err != nil {
+			t.Fatalf("expected no error on success, got: %v", err)
+		}
+	})
 }
 
 // Helper to create a test plugin in the cache directory

--- a/tests/plugin/test.bats
+++ b/tests/plugin/test.bats
@@ -13,3 +13,15 @@
   run $CONFTEST kubectl
   [ "$status" -eq 0 ]
 }
+
+@test "Plugin exit code is propagated" {
+  run $CONFTEST plugin install ../../contrib/plugins/echo
+  [ "$status" -eq 0 ]
+
+  run $CONFTEST echo hello
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+
+  run $CONFTEST echo 42 some message
+  [ "$status" -eq 42 ]
+}

--- a/tests/plugin/test.bats
+++ b/tests/plugin/test.bats
@@ -1,3 +1,23 @@
+setup() {
+  # kubectl-conftest.sh calls check_command for both conftest and kubectl and
+  # exits 1 if either is missing. The binary under test is invoked through
+  # $CONFTEST rather than the PATH, so the plugin never found it and always
+  # exited 1 here; that used to be reported as success because Exec mapped a
+  # plugin exit code of 1 to nil. Put both on the PATH so these tests exercise
+  # the plugin rather than its precondition check.
+  local conftest_dir stub_dir
+  conftest_dir="$(cd "$(dirname "$CONFTEST")" >/dev/null 2>&1 && pwd)"
+  stub_dir="${BATS_TEST_TMPDIR:-$BATS_TMPDIR}/bin"
+
+  mkdir -p "$stub_dir"
+  # the tests below run the plugin with no arguments, which only prints usage,
+  # so kubectl needs to exist but is never actually called
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$stub_dir/kubectl"
+  chmod +x "$stub_dir/kubectl"
+
+  PATH="$conftest_dir:$stub_dir:$PATH"
+}
+
 @test "Can install plugin from directory" {
   run $CONFTEST plugin install ../../contrib/plugins/kubectl
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes #741.

When `conftest <plugin>` runs an installed plugin that exits non-zero, conftest does not pass that exit code through to its own process. A plugin exiting 1 makes conftest exit 0, which hides the failure from scripts and CI.

Root cause is in `Plugin.Exec` (`plugin/plugin.go`). It treated exit codes 1 and 2 as success (returned `nil`) and wrapped every other non-zero code in a generic error that `main` then collapsed to exit 1. So a plugin's real exit code was never recoverable.

Repro from the issue:

```sh
cat > plugin.yaml <<'YAML'
name: script
version: 0.1.0
usage: conftest script
command: ./script.sh
YAML
printf '#!/usr/bin/env bash\nset -e\nexit 1\n' > script.sh && chmod +x script.sh

conftest plugin install .
conftest script ; echo $?   # before: 0   after: 1
```

The fix adds a small `ExitCodeError` sentinel in the `plugin` package that carries the plugin's actual exit code. `Exec` returns it for any non-zero exit (no more special-casing 1 and 2), the plugin command wraps the error with `%w` so it survives unwrapping, and `main` unwraps it and exits with the plugin's original code. Non-plugin errors still exit 1, and a plugin that succeeds still exits 0.

Before / after, against an `echo` test plugin that exits with its first argument:

```
conftest echo hello          -> 0   (unchanged)
conftest echo 1 boom         -> was 0, now 1
conftest echo 2 boom         -> was 0, now 2
conftest echo 42 boom        -> was 1, now 42
```

This is the same approach @bejaratommy took in #1296, which was closed by its author as stale rather than for any technical reason. I have rebuilt it on current `master` with the unit and acceptance tests the maintainers asked for there.

Checked:

```sh
go build ./...
go vet ./plugin/... ./internal/commands/... .
go test ./plugin/...        # TestPluginExec/exit_code_propagation covers 1, 2, 3, 42
go test ./...
# end-to-end against the new echo plugin
conftest plugin install contrib/plugins/echo
conftest echo 42 boom ; echo $?   # 42
```

Changes:

- `plugin/plugin.go`: add `ExitCodeError` + `AsExitCodeError`; return `ExitCodeError` from `Exec` on any non-zero plugin exit.
- `internal/commands/default.go`: wrap the plugin error with `%w` so the exit code survives.
- `main.go`: unwrap `ExitCodeError` and exit with the plugin's code.
- `plugin/plugin_test.go`: table-driven test for codes 1, 2, 3, 42 plus a success case.
- `contrib/plugins/echo/`: a minimal echo plugin used by the acceptance test.
- `tests/plugin/test.bats`: acceptance case asserting the plugin exit code is propagated.
