### PR TITLE
perf(engine): Move Input AST conversion to occur before rule loop

### DIFF
--- a/policy/engine.go
+++ b/policy/engine.go
@@ -301,6 +301,12 @@ func (e *Engine) check(ctx context.Context, path string, config any, namespace s
 		return output.CheckResult{}, fmt.Errorf("add file info: %w", err)
 	}
 
+	// Convert the input once so OPA doesn't re-parse it on every query call.
+	inputValue, err := ast.InterfaceToValue(config)
+	if err != nil {
+		return output.CheckResult{}, fmt.Errorf("convert input: %w", err)
+	}
+
 	var rules []string
 	var ruleCount int
 	for _, module := range e.Modules() {
@@ -343,7 +349,7 @@ func (e *Engine) check(ctx context.Context, path string, config any, namespace s
 		// is queried, so the severity prefix must be removed.
 		exceptionQuery := fmt.Sprintf("data.%s.exception[_][_] == %q", namespace, removeRulePrefix(rule))
 
-		exceptionQueryResult, err := e.query(ctx, config, exceptionQuery)
+		exceptionQueryResult, err := e.query(ctx, inputValue, exceptionQuery)
 		if err != nil {
 			return output.CheckResult{}, fmt.Errorf("query exception: %w", err)
 		}
@@ -361,7 +367,7 @@ func (e *Engine) check(ctx context.Context, path string, config any, namespace s
 		}
 
 		ruleQuery := fmt.Sprintf("data.%s.%s", namespace, rule)
-		ruleQueryResult, err := e.query(ctx, config, ruleQuery)
+		ruleQueryResult, err := e.query(ctx, inputValue, ruleQuery)
 		if err != nil {
 			return output.CheckResult{}, fmt.Errorf("query rule: %w", err)
 		}
@@ -446,11 +452,11 @@ func (e *Engine) addFileInfo(ctx context.Context, path string) error {
 // Example queries could include:
 // data.main.deny to query the deny rule in the main namespace
 // data.main.warn to query the warn rule in the main namespace
-func (e *Engine) query(ctx context.Context, input any, query string) (output.QueryResult, error) {
+func (e *Engine) query(ctx context.Context, input ast.Value, query string) (output.QueryResult, error) {
 	ph := printHook{s: &[]string{}}
 	builtInErrors := &[]topdown.Error{}
 	options := []func(r *rego.Rego){
-		rego.Input(input),
+		rego.ParsedInput(input),
 		rego.Query(query),
 		rego.Compiler(e.Compiler()),
 		rego.Store(e.Store()),


### PR DESCRIPTION
Moves the conversion of input files to AST to occur before the rule loop. This is to prevent the overhead of input conversion on each rule evaluation which scales directly with the number of rules being evaluated. This will significantly improve policy evaluations with many defined rules and larger input files.

Here are outputs showing examples of the time improvements over a large policy file with many rules. The input file in this example is around 60MB:

The output before making the change:

```shell
➜ opa-policies (feature/optimize-ado-policy-eval) ✗ time conftest test tfplan.json -n terraform_plan.aws.policy,terraform_plan.aws.thrifty,terraform_plan.azure.policy

163 tests, 163 passed, 0 warnings, 0 failures, 0 exceptions
conftest test tfplan.json -n   471.68s user 11.31s system 147% cpu 5:26.51 total
```

The same policies and same input data after the optimizations:

```shell
➜ conftest (perf/only-convert-input-once) ✗ time ./conftest test --policy ../../ADO/opa-policies/policy ../../ADO/opa-policies/tfplan.json -n terraform_plan.aws.policy,terraform_plan.aws.thrifty,terraform_plan.azure.policy

163 tests, 163 passed, 0 warnings, 0 failures, 0 exceptions
./conftest test --policy ../../ADO/opa-policies/policy  -n   2.67s user 0.27s system 172% cpu 1.706 total
```

You can see the significant time gains by only loading the input data once.

I am willing to make any needed changes recommended by the maintainers.


Closes: #1347 

Policy tests output:

```shell
➜ conftest (perf/only-convert-input-once) ✔ go test -v ./policy/...
=== RUN   TestException
--- PASS: TestException (0.01s)
=== RUN   TestTracing
=== RUN   TestTracing/with_tracing_
=== RUN   TestTracing/without_tracing
--- PASS: TestTracing (0.01s)
    --- PASS: TestTracing/with_tracing_ (0.01s)
    --- PASS: TestTracing/without_tracing (0.00s)
=== RUN   TestMultifileYaml
--- PASS: TestMultifileYaml (0.01s)
=== RUN   TestDockerfile
--- PASS: TestDockerfile (0.00s)
=== RUN   TestIsWarning
=== RUN   TestIsWarning/#00
=== RUN   TestIsWarning/warn
=== RUN   TestIsWarning/warnXYZ
=== RUN   TestIsWarning/warn_
=== RUN   TestIsWarning/warn_x
=== RUN   TestIsWarning/warn_1
=== RUN   TestIsWarning/warn_x_y_z
--- PASS: TestIsWarning (0.00s)
    --- PASS: TestIsWarning/#00 (0.00s)
    --- PASS: TestIsWarning/warn (0.00s)
    --- PASS: TestIsWarning/warnXYZ (0.00s)
    --- PASS: TestIsWarning/warn_ (0.00s)
    --- PASS: TestIsWarning/warn_x (0.00s)
    --- PASS: TestIsWarning/warn_1 (0.00s)
    --- PASS: TestIsWarning/warn_x_y_z (0.00s)
=== RUN   TestIsFailure
=== RUN   TestIsFailure/#00
=== RUN   TestIsFailure/deny
=== RUN   TestIsFailure/violation
=== RUN   TestIsFailure/denyXYZ
=== RUN   TestIsFailure/violationXYZ
=== RUN   TestIsFailure/deny_
=== RUN   TestIsFailure/violation_
=== RUN   TestIsFailure/deny_x
=== RUN   TestIsFailure/violation_x
=== RUN   TestIsFailure/deny_1
=== RUN   TestIsFailure/violation_1
=== RUN   TestIsFailure/deny_x_y_z
=== RUN   TestIsFailure/violation_x_y_z
--- PASS: TestIsFailure (0.00s)
    --- PASS: TestIsFailure/#00 (0.00s)
    --- PASS: TestIsFailure/deny (0.00s)
    --- PASS: TestIsFailure/violation (0.00s)
    --- PASS: TestIsFailure/denyXYZ (0.00s)
    --- PASS: TestIsFailure/violationXYZ (0.00s)
    --- PASS: TestIsFailure/deny_ (0.00s)
    --- PASS: TestIsFailure/violation_ (0.00s)
    --- PASS: TestIsFailure/deny_x (0.00s)
    --- PASS: TestIsFailure/violation_x (0.00s)
    --- PASS: TestIsFailure/deny_1 (0.00s)
    --- PASS: TestIsFailure/violation_1 (0.00s)
    --- PASS: TestIsFailure/deny_x_y_z (0.00s)
    --- PASS: TestIsFailure/violation_x_y_z (0.00s)
=== RUN   TestAddFileInfo
=== RUN   TestAddFileInfo/SingleFile
=== RUN   TestAddFileInfo/RelativePath
=== RUN   TestAddFileInfo/FullPath
--- PASS: TestAddFileInfo (0.00s)
    --- PASS: TestAddFileInfo/SingleFile (0.00s)
    --- PASS: TestAddFileInfo/RelativePath (0.00s)
    --- PASS: TestAddFileInfo/FullPath (0.00s)
=== RUN   TestLoadWithData
=== RUN   TestLoadWithData/Load_both_policies_and_data
=== RUN   TestLoadWithData/Load_only_data
=== RUN   TestLoadWithData/Load_only_policies
=== RUN   TestLoadWithData/Invalid_policy_path
=== RUN   TestLoadWithData/Invalid_data_path
--- PASS: TestLoadWithData (0.01s)
    --- PASS: TestLoadWithData/Load_both_policies_and_data (0.00s)
    --- PASS: TestLoadWithData/Load_only_data (0.00s)
    --- PASS: TestLoadWithData/Load_only_policies (0.00s)
    --- PASS: TestLoadWithData/Invalid_policy_path (0.00s)
    --- PASS: TestLoadWithData/Invalid_data_path (0.00s)
=== RUN   TestLoadCapabilities
=== RUN   TestLoadCapabilities/Inaccessible_capabilities_file
=== RUN   TestLoadCapabilities/Invalid_capabilities_file
=== RUN   TestLoadCapabilities/No_path_does_not_error
--- PASS: TestLoadCapabilities (0.00s)
    --- PASS: TestLoadCapabilities/Inaccessible_capabilities_file (0.00s)
    --- PASS: TestLoadCapabilities/Invalid_capabilities_file (0.00s)
    --- PASS: TestLoadCapabilities/No_path_does_not_error (0.00s)
=== RUN   TestNamespaces
=== RUN   TestNamespaces/multiple_namespaces
=== RUN   TestNamespaces/single_namespace
=== RUN   TestNamespaces/no_policies
--- PASS: TestNamespaces (0.00s)
    --- PASS: TestNamespaces/multiple_namespaces (0.00s)
    --- PASS: TestNamespaces/single_namespace (0.00s)
    --- PASS: TestNamespaces/no_policies (0.00s)
=== RUN   TestQueryMetadata
=== RUN   TestQueryMetadata/string_return_type
=== RUN   TestQueryMetadata/map_return_type
=== RUN   TestQueryMetadata/multiple_results
--- PASS: TestQueryMetadata (0.00s)
    --- PASS: TestQueryMetadata/string_return_type (0.00s)
    --- PASS: TestQueryMetadata/map_return_type (0.00s)
    --- PASS: TestQueryMetadata/multiple_results (0.00s)
PASS
ok  	github.com/open-policy-agent/conftest/policy	(cached)
```