### PR TITLE
fix: name successful test cases in verify junit output

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -343,6 +343,13 @@ EOF"
   [[ "$output" =~ "success" ]]
 }
 
+@test "Names successful test cases in verify junit output" {
+  run ./conftest verify -p examples/kubernetes/policy/ -o junit
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "data.main.test_deployment_without_security_context" ]]
+  [[ "$output" =~ "data.main.test_services_not_denied" ]]
+}
+
 @test "Multi-file tests correctly fail when last file is fine" {
   run ./conftest test -p examples/kubernetes/policy examples/kubernetes/deployment.yaml examples/kubernetes/service.yaml
   [ "$status" -eq 1 ]

--- a/output/junit.go
+++ b/output/junit.go
@@ -63,13 +63,28 @@ func (j *JUnit) Output(results CheckResults) error {
 			namespaceTests[ns] = append(namespaceTests[ns], &skippedTest)
 		}
 
-		for s := 0; s < result.Successes; s++ {
-			successfulTest := parser.Test{
-				Name:   j.formatTestName(result.FileName, ""),
-				Result: parser.PASS,
-			}
+		// When named success results are available (the verify command emits one
+		// per test rule), report each with its rule name so consumers such as
+		// GitLab can tell successful test cases apart. Otherwise fall back to the
+		// aggregate count, which produces an unnamed test case per success.
+		if len(result.SuccessResults) > 0 {
+			for _, success := range result.SuccessResults {
+				successfulTest := parser.Test{
+					Name:   j.formatTestName(result.FileName, success.Message),
+					Result: parser.PASS,
+				}
 
-			namespaceTests[ns] = append(namespaceTests[ns], &successfulTest)
+				namespaceTests[ns] = append(namespaceTests[ns], &successfulTest)
+			}
+		} else {
+			for s := 0; s < result.Successes; s++ {
+				successfulTest := parser.Test{
+					Name:   j.formatTestName(result.FileName, ""),
+					Result: parser.PASS,
+				}
+
+				namespaceTests[ns] = append(namespaceTests[ns], &successfulTest)
+			}
 		}
 	}
 

--- a/output/junit_test.go
+++ b/output/junit_test.go
@@ -114,6 +114,56 @@ This is the rest of the description of the failed test`}},
 				``,
 			},
 		},
+		{
+			name: "Named successes report per-test names (verify command)",
+			input: CheckResults{
+				{
+					FileName:  "examples/kubernetes/service_test.rego",
+					Namespace: "namespace",
+					Successes: 2,
+					SuccessResults: []Result{
+						{Message: "data.main.test_deny_alb_https"},
+						{Message: "data.main.test_deny_alb_protocol_unspecified"},
+					},
+				},
+			},
+			expected: []string{
+				`<?xml version="1.0" encoding="UTF-8"?>`,
+				`<testsuites>`,
+				`	<testsuite tests="2" failures="0" time="0.000" name="conftest.namespace">`,
+				`		<properties>`,
+				`			<property name="go.version" value="%s"></property>`,
+				`		</properties>`,
+				`		<testcase classname="conftest.namespace" name="examples/kubernetes/service_test.rego - data.main.test_deny_alb_https" time="0.000"></testcase>`,
+				`		<testcase classname="conftest.namespace" name="examples/kubernetes/service_test.rego - data.main.test_deny_alb_protocol_unspecified" time="0.000"></testcase>`,
+				`	</testsuite>`,
+				`</testsuites>`,
+				``,
+			},
+		},
+		{
+			name: "Successes without named results fall back to the count (test command)",
+			input: CheckResults{
+				{
+					FileName:  "examples/kubernetes/service.yaml",
+					Namespace: "namespace",
+					Successes: 2,
+				},
+			},
+			expected: []string{
+				`<?xml version="1.0" encoding="UTF-8"?>`,
+				`<testsuites>`,
+				`	<testsuite tests="2" failures="0" time="0.000" name="conftest.namespace">`,
+				`		<properties>`,
+				`			<property name="go.version" value="%s"></property>`,
+				`		</properties>`,
+				`		<testcase classname="conftest.namespace" name="examples/kubernetes/service.yaml" time="0.000"></testcase>`,
+				`		<testcase classname="conftest.namespace" name="examples/kubernetes/service.yaml" time="0.000"></testcase>`,
+				`	</testsuite>`,
+				`</testsuites>`,
+				``,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/output/result.go
+++ b/output/result.go
@@ -138,14 +138,19 @@ func (q QueryResult) Passed() bool {
 // Errors produced by rego should be considered separate
 // from other classes of exceptions.
 type CheckResult struct {
-	FileName   string        `json:"filename"`
-	Namespace  string        `json:"namespace"`
-	Successes  int           `json:"successes"`
-	Skipped    []Result      `json:"skipped,omitempty"`
-	Warnings   []Result      `json:"warnings,omitempty"`
-	Failures   []Result      `json:"failures,omitempty"`
-	Exceptions []Result      `json:"exceptions,omitempty"`
-	Queries    []QueryResult `json:"queries,omitempty"`
+	FileName  string `json:"filename"`
+	Namespace string `json:"namespace"`
+	Successes int    `json:"successes"`
+	// SuccessResults carries the named results of successful tests, one entry
+	// per test rule. When non-empty it lets the JUnit outputter emit per-test
+	// names; the aggregate Successes count remains the source of truth for all
+	// other outputters. Excluded from JSON to keep existing output byte-stable.
+	SuccessResults []Result      `json:"-"`
+	Skipped        []Result      `json:"skipped,omitempty"`
+	Warnings       []Result      `json:"warnings,omitempty"`
+	Failures       []Result      `json:"failures,omitempty"`
+	Exceptions     []Result      `json:"exceptions,omitempty"`
+	Queries        []QueryResult `json:"queries,omitempty"`
 }
 
 // HasFailure returns true if any failures were encountered.

--- a/runner/verify.go
+++ b/runner/verify.go
@@ -107,6 +107,9 @@ func (r *VerifyRunner) Run(ctx context.Context) (output.CheckResults, []*tester.
 			checkResult.Skipped = []output.Result{outputResult}
 		} else {
 			checkResult.Successes++
+			// Each iteration maps to exactly one test rule, so this is a single
+			// named success rather than an accumulated slice.
+			checkResult.SuccessResults = []output.Result{{Message: result.Package + "." + result.Name}}
 		}
 
 		results = append(results, checkResult)


### PR DESCRIPTION
This adds the test rule name to each successful test case in `conftest verify --output junit`, matching the behavior already in place for failures.

Previously every successful test case was emitted with the same `name` (the `.rego` file name), so consumers that key on the test-case name — notably GitLab's test report, which deduplicates identically-named cases — could not tell successful tests apart or track how the suite evolves across runs.

Scoped to the `verify` command only, per the discussion in #775 — the `test` command does not have per-rule named successes (see #731).

## Implementation

- `output/result.go`: add `SuccessResults []Result` to `CheckResult`. It is `json:"-"`, so the JSON output and every non-JUnit outputter stay byte-for-byte unchanged; the aggregate `Successes` count remains the source of truth for them.
- `runner/verify.go`: populate `SuccessResults` with the rule's `data.<pkg>.<name>` for each passing test.
- `output/junit.go`: when `SuccessResults` is present, emit one named test case per success; otherwise fall back to the existing count-based loop, so the `test` command output is unchanged.

## Validation

- `go test ./...` — all pass. New unit cases in `output/junit_test.go` cover both the named-success and count-fallback branches.
- `golangci-lint run` — clean for the changed files.
- `bats acceptance.bats` — added "Names successful test cases in verify junit output"; passes.

Before:
```
<testcase classname="conftest." name="examples/.../base_test.rego" ...></testcase>
<testcase classname="conftest." name="examples/.../base_test.rego" ...></testcase>
```

After:
```
<testcase classname="conftest." name="examples/.../base_test.rego - data.main.test_services_not_denied" ...></testcase>
<testcase classname="conftest." name="examples/.../base_test.rego - data.main.test_deployment_without_security_context" ...></testcase>
```

Closes #775

---

<sub>Developed with the help of Claude Code.</sub>