### PR TITLE
fix(ci): update setup-regal action to open-policy-agent org

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -31,7 +31,7 @@ jobs:
           args: --timeout=5m --color=always --max-same-issues=0 --max-issues-per-linter=0
 
       - name: setup regal
-        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776 # ratchet:StyraInc/setup-regal@v1
+        uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f # ratchet:open-policy-agent/setup-regal@v2.0.0
         with:
           version: v0.30
 


### PR DESCRIPTION
## Problem

The `setup-regal` GitHub Action has been moved from `StyraInc/setup-regal` to `open-policy-agent/setup-regal`, causing all PR CI runs to fail with:

```
Unable to resolve action `styrainc/setup-regal`, not found
```

This is affecting:
- All new PRs (e.g., #1343, #1321)
- Master branch CI runs

## Solution

Updated `.github/workflows/pr.yaml` to use the new location:
- **From:** `StyraInc/setup-regal@v1` 
- **To:** `open-policy-agent/setup-regal@v2.0.0`

Also ran `make ratchet-update` to update all action SHAs to their latest commits for the specified versions.

## Verification

The workflow should now pass the lint job. The setup-regal action is now under the Open Policy Agent organization alongside conftest.

cc @anderseknert - FYI, this updates the regal setup action reference since it moved from Styra's org to open-policy-agent org.

## Testing

CI will validate this on the PR itself.