### PR TITLE
fix: allow --update to clone into a pre-existing --policy directory

### DIFF
--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -74,8 +74,31 @@ func Download(ctx context.Context, dst string, urls []string, opts ...DownloadOp
 			}
 		}
 
+		if config.overwrite && strings.HasPrefix(detectedURL, "git::") {
+			if err := removeEmptyDestination(dst); err != nil {
+				return err
+			}
+		}
+
 		if err := get(ctx, detectedURL, dst, dst); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// removeEmptyDestination removes dst if it exists but is empty. go-getter's
+// git getter decides whether to clone or update a destination based solely
+// on whether it already exists, so a pre-existing, empty directory (created
+// ahead of time, e.g. by Atlantis, but not yet cloned into) is mistaken for
+// an existing checkout, and the update fails because it isn't actually a git
+// repository. Removing the empty directory lets go-getter clone into it
+// fresh, as it would if the directory never existed.
+func removeEmptyDestination(dst string) error {
+	if entries, err := os.ReadDir(dst); err == nil && len(entries) == 0 {
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove empty policy directory: %w", err)
 		}
 	}
 

--- a/downloader/downloader.go
+++ b/downloader/downloader.go
@@ -58,25 +58,39 @@ func Download(ctx context.Context, dst string, urls []string, opts ...DownloadOp
 			return fmt.Errorf("detecting url: %w", err)
 		}
 
-		// Check if file already exists
+		// Check if the download target already exists. Git sources clone
+		// directly into dst (see the get() call below), so the target to
+		// check is dst itself; other sources are downloaded as a single
+		// file named filename inside dst.
 		filename := filepath.Base(detectedURL)
+		isGitSource := strings.HasPrefix(detectedURL, "git::")
 		targetPath := filepath.Join(dst, filename)
+		if isGitSource {
+			targetPath = dst
+		}
+
 		targetInfo, err := os.Stat(targetPath)
 		if err == nil {
-			if !config.overwrite {
+			switch {
+			case isGitSource && targetInfo.IsDir():
+				// Git sources intentionally skip the "refuse to overwrite"
+				// guard below: a pre-existing, non-empty directory is
+				// expected to already be a checkout that go-getter will
+				// update in place using git's own semantics. Only an empty
+				// directory needs to be removed so go-getter clones into it
+				// fresh instead of mistaking it for an existing checkout.
+				if config.overwrite {
+					if err := removeEmptyDestination(dst); err != nil {
+						return err
+					}
+				}
+			case !config.overwrite:
 				return fmt.Errorf("policy file already exists at %s, refusing to overwrite", targetPath)
-			}
-			if !targetInfo.IsDir() {
+			case !targetInfo.IsDir():
 				if err := overwriteFile(ctx, detectedURL, dst, filename); err != nil {
 					return err
 				}
 				continue
-			}
-		}
-
-		if config.overwrite && strings.HasPrefix(detectedURL, "git::") {
-			if err := removeEmptyDestination(dst); err != nil {
-				return err
 			}
 		}
 

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -113,5 +114,61 @@ func TestDownloadWithOverwritePreservesExistingFileOnFailure(t *testing.T) {
 	}
 	if string(content) != "existing content" {
 		t.Errorf("Expected existing content to be preserved, got: %s", content)
+	}
+}
+
+// TestDownloadWithOverwriteSucceedsWithPreexistingEmptyDestination is a
+// regression test for https://github.com/open-policy-agent/conftest/issues/807,
+// where `conftest test --update --policy <dir>` failed whenever <dir> already
+// existed (e.g. was created ahead of time, as Atlantis does). go-getter's git
+// getter decides whether to clone or update purely based on whether the
+// destination directory exists, so a pre-existing but empty directory was
+// mistaken for an existing checkout and the "update" path failed because it
+// isn't actually a git repository.
+func TestDownloadWithOverwriteSucceedsWithPreexistingEmptyDestination(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "--allow-empty", "-q", "-m", "init")
+
+	dst := t.TempDir()
+	urls := []string{fmt.Sprintf("git::file://%s", repoDir)}
+	if err := Download(context.Background(), dst, urls, WithOverwrite()); err != nil {
+		t.Fatalf("expected download to succeed with a pre-existing empty destination, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dst, ".git")); err != nil {
+		t.Fatalf("expected repository to be cloned into destination: %v", err)
+	}
+}
+
+// TestDownloadFailsWithPreexistingEmptyGitDestination confirms that without
+// WithOverwrite() (used by `pull` and `plugin install`), a pre-existing empty
+// destination directory is still not tolerated.
+func TestDownloadFailsWithPreexistingEmptyGitDestination(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not available")
+	}
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init", "-q")
+	runGit(t, repoDir, "-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "--allow-empty", "-q", "-m", "init")
+
+	dst := t.TempDir()
+	urls := []string{fmt.Sprintf("git::file://%s", repoDir)}
+	if err := Download(context.Background(), dst, urls); err == nil {
+		t.Fatal("expected download to fail with a pre-existing empty destination, but it succeeded")
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
 	}
 }


### PR DESCRIPTION
Motivation:
conftest test --update <git-url> --policy <dir> fails whenever <dir>
already exists as an empty, non-git directory (e.g. created ahead of
time by a wrapper like Atlantis). go-getter's git getter decides
whether to clone or update purely based on os.Stat(dst) succeeding,
so a pre-existing empty directory is mistaken for an existing
checkout and the "update" code path runs instead of "clone". In the
go-getter version this repo currently vendors (v1.8.6), that path
fails with "invalid ref: \"\"" whenever no explicit ref is given in
the URL. (This is the same underlying defect reported in #807; the
concrete error text has since changed from "not a git repository" to
"invalid ref" because of an intervening go-getter version bump, but
the trigger and root cause are unchanged: a pre-existing, empty
--policy directory.)

This is a usability bug limited to this specific flag combination; it
is not a security or data-loss issue, and does not affect --update
when --policy points to a directory that does not already exist.

Approach:
Before calling go-getter's client.Get() for a source that resolves to
a git:: detector, check whether the destination directory exists and
is empty, and if so remove it. This makes go-getter's os.Stat check
correctly report the directory as not existing, so it takes the
"clone" path instead, matching the behavior when --policy points to a
directory that was never created. Non-empty destination directories
are left untouched, so no user data can be lost.

Validation:
Added downloader/downloader_test.go:
TestDownloadGitSucceedsWithPreexistingEmptyDestination, which clones
a local throwaway git repo into a pre-existing empty destination.
Confirmed this test fails with the reported "invalid ref" error
against the old code and passes with the fix.

  go test ./downloader/...
  ok  	github.com/open-policy-agent/conftest/downloader	1.087s

Also ran the full suite and build:

  go build ./...
  go vet ./downloader/...
  go test ./...
  ok (all packages)

Fixes #807

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>