### PR TITLE
docs: show local OCI registry examples

### DIFF
--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -35,6 +35,13 @@ conftest pull git::https://<PersonalAccessToken>@github.com/<Organization>/<Repo
 conftest pull oci://opa.azurecr.io/test
 ```
 
+Local OCI registries are also supported. When testing against a local registry,
+include the registry host and port in the repository name:
+
+```console
+conftest pull localhost:5000/testpolicy
+```
+
 See the [go-getter](https://github.com/hashicorp/go-getter) repository for more
 examples.
 
@@ -49,6 +56,12 @@ bundle like so:
 
 ```console
 conftest push opa.azurecr.io/test
+```
+
+For a local registry, use the same `host:port/repository` form:
+
+```console
+conftest push localhost:5000/testpolicy
 ```
 
 ## `--update` flag


### PR DESCRIPTION
## Summary
- document local OCI registry pull syntax with `localhost:5000/...`
- add a matching local registry push example

Closes open-policy-agent/conftest#924

## Verification
- `uvx --from mkdocs-material mkdocs build` (passes; MkDocs emits the existing README/index warning)
- `uvx --from mkdocs-material mkdocs build --strict` was also attempted, but strict mode aborts on the existing `docs/README.md` vs `docs/index.md` warning unrelated to this change.