### PR TITLE
feat: name stdin input in test output

### DIFF
--- a/internal/commands/test.go
+++ b/internal/commands/test.go
@@ -106,6 +106,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 				"parser",
 				"policy",
 				"proto-file-dirs",
+				"stdin-filename",
 				"capabilities",
 				"rego-version",
 				"trace",
@@ -183,6 +184,7 @@ func NewTestCommand(ctx context.Context) *cobra.Command {
 
 	cmd.Flags().String("ignore", "", "A regex pattern which can be used for ignoring paths")
 	cmd.Flags().String("parser", "", fmt.Sprintf("Parser to use to parse the configurations. Valid parsers: %s", parser.Parsers()))
+	cmd.Flags().String("stdin-filename", "", "Filename to use in output when testing configuration from stdin")
 	cmd.Flags().String("capabilities", "", "Path to JSON file that can restrict opa functionality against a given policy. Default: all operations allowed")
 	cmd.Flags().String("rego-version", "v1", "Which version of Rego syntax to use. Options: v0, v1")
 

--- a/runner/test.go
+++ b/runner/test.go
@@ -27,6 +27,7 @@ type TestRunner struct {
 	Update             []string
 	Ignore             string
 	Parser             string
+	StdinFilename      string `mapstructure:"stdin-filename"`
 	Namespace          []string
 	AllNamespaces      bool `mapstructure:"all-namespaces"`
 	FailOnWarn         bool `mapstructure:"fail-on-warn"`
@@ -56,6 +57,7 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckRe
 	if err != nil {
 		return nil, fmt.Errorf("parse configurations: %w", err)
 	}
+	renameStdinConfiguration(configurations, t.StdinFilename)
 
 	// When there are policies to download, they are currently placed in the first
 	// directory that appears in the list of policies.
@@ -118,6 +120,20 @@ func (t *TestRunner) Run(ctx context.Context, fileList []string) (output.CheckRe
 	}
 
 	return results, nil
+}
+
+func renameStdinConfiguration(configurations map[string]any, stdinFilename string) {
+	if stdinFilename == "" {
+		return
+	}
+
+	configuration, ok := configurations["-"]
+	if !ok {
+		return
+	}
+
+	delete(configurations, "-")
+	configurations[stdinFilename] = configuration
 }
 
 func parseFileList(fileList []string, ignoreRegex string) ([]string, error) {

--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -5,6 +5,47 @@ import (
 	"testing"
 )
 
+func TestRenameStdinConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		configs       map[string]any
+		stdinFilename string
+		want          map[string]any
+	}{
+		{
+			name:          "renames stdin configuration",
+			configs:       map[string]any{"-": map[string]any{"kind": "ConfigMap"}},
+			stdinFilename: "components/api",
+			want:          map[string]any{"components/api": map[string]any{"kind": "ConfigMap"}},
+		},
+		{
+			name:          "empty stdin filename leaves stdin key",
+			configs:       map[string]any{"-": map[string]any{"kind": "ConfigMap"}},
+			stdinFilename: "",
+			want:          map[string]any{"-": map[string]any{"kind": "ConfigMap"}},
+		},
+		{
+			name:          "non-stdin configuration is unchanged",
+			configs:       map[string]any{"deployment.yaml": map[string]any{"kind": "Deployment"}},
+			stdinFilename: "components/api",
+			want:          map[string]any{"deployment.yaml": map[string]any{"kind": "Deployment"}},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			renameStdinConfiguration(tt.configs, tt.stdinFilename)
+			if !reflect.DeepEqual(tt.configs, tt.want) {
+				t.Errorf("renameStdinConfiguration() = %v, want %v", tt.configs, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasWildcard(t *testing.T) {
 	t.Parallel()
 

--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -35,7 +35,6 @@ func TestRenameStdinConfiguration(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			renameStdinConfiguration(tt.configs, tt.stdinFilename)


### PR DESCRIPTION
## Summary
- add a `--stdin-filename` option for `conftest test -`
- use the provided name in check results instead of the default `-` stdin key
- cover stdin-name rewriting with a focused unit test

Fixes #1095

## Verification
- `go test ./runner ./internal/commands`
- `printf 'kind: ConfigMap\\n' | go run . test -p "$tmp/policy" --stdin-filename components/api -o json -` (verified JSON output contains `"filename": "components/api"`; command exits 1 because the test policy intentionally denies the sample input)\n