### PR TITLE
feat(parser): add Groovy and Jenkinsfile support

### DIFF
--- a/acceptance.bats
+++ b/acceptance.bats
@@ -353,6 +353,23 @@ EOF"
   [[ "$output" = "\"Deployment\"" ]]
 }
 
+@test "Can test a Jenkinsfile with the Groovy parser" {
+  run ./conftest test -p examples/jenkins/policy examples/jenkins/Jenkinsfile --output json
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "Pipeline downloads a script and pipes it directly to an interpreter" ]]
+  [[ "$output" =~ '"line": 6' ]]
+}
+
+@test "Can test a safe Jenkinsfile" {
+  run ./conftest test -p examples/jenkins/policy examples/jenkins/Jenkinsfile.safe
+  [ "$status" -eq 0 ]
+}
+
+@test "Can parse Groovy from stdin" {
+  run bash -c "./conftest parse --parser groovy - < examples/jenkins/Jenkinsfile.safe | jq -e '.kind == \"FileNode\"'"
+  [ "$status" -eq 0 ]
+}
+
 @test "Can parse multiple files with 'conftest parse'" {
   run bash -c "./conftest parse examples/kubernetes/deployment.yaml examples/kubernetes/deployment+service.yaml | jq 'keys'"
   [ "$status" -eq 0 ]

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -21,6 +21,7 @@ including:
 - [HOCON](https://github.com/open-policy-agent/conftest/tree/master/examples/hocon)
 - [Ignore](https://github.com/open-policy-agent/conftest/tree/master/examples/ignore)
 - [INI](https://github.com/open-policy-agent/conftest/tree/master/examples/ini)
+- [Jenkins Pipeline](https://github.com/open-policy-agent/conftest/tree/master/examples/jenkins)
 - [Jsonnet](https://github.com/open-policy-agent/conftest/tree/master/examples/jsonnet)
 - [Kubernetes](https://github.com/open-policy-agent/conftest/tree/master/examples/kubernetes)
 - [Kustomize](https://github.com/open-policy-agent/conftest/tree/master/examples/kustomize)

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ As of today Conftest supports:
 - HOCON
 - Ignore files (.gitignore, .dockerignore)
 - INI
+- Jenkins Pipeline and Groovy 2.4
 - JSON
 - Jsonnet
 - nginx

--- a/docs/options.md
+++ b/docs/options.md
@@ -405,6 +405,54 @@ $ conftest test -p examples/hcl1/policy examples/hcl1/gke.tf --parser hcl2
 2 tests, 2 passed, 0 warnings, 0 failures, 0 exceptions
 ```
 
+### Jenkins Pipeline and Groovy 2.4
+
+The `groovy` parser targets the Groovy 2.4 syntax used by Jenkins Pipeline CPS.
+It is intended for Jenkinsfiles and Groovy source loaded by Jenkins, rather
+than as a general-purpose parser for newer Groovy language versions.
+
+Files with a `.groovy` extension and files named `Jenkinsfile` or
+`Jenkinsfile.*` are detected automatically. Use `--parser groovy` when reading
+Groovy source from standard input.
+
+The parser exposes a concrete syntax tree to Rego. Interior nodes contain a
+syntax `kind`, a one-based source location, and their `children`. Token nodes
+contain their raw source `text` instead of children. For example:
+
+```json
+{
+  "kind": "FileNode",
+  "line": 1,
+  "column": 1,
+  "children": [
+    {
+      "kind": "ExpressionStmt",
+      "line": 1,
+      "column": 1,
+      "children": [
+        {
+          "kind": "IdentExpr",
+          "line": 1,
+          "column": 1,
+          "children": [
+            {
+              "kind": "Identifier",
+              "text": "pipeline",
+              "line": 1,
+              "column": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Comments, whitespace, end-of-file markers, and synthetic zero-width tokens are
+not included in the Rego input. Policies can use `walk()` to find syntax nodes
+without depending on their absolute depth in the tree.
+
 ## `--policy`
 
 Conftest will, by default, look for policies in the `policy` folder. This can be

--- a/examples/jenkins/Jenkinsfile
+++ b/examples/jenkins/Jenkinsfile
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                sh 'curl -fsSL https://example.com/install.sh | bash'
+            }
+        }
+    }
+}

--- a/examples/jenkins/Jenkinsfile.safe
+++ b/examples/jenkins/Jenkinsfile.safe
@@ -1,0 +1,10 @@
+pipeline {
+    agent any
+    stages {
+        stage('Build') {
+            steps {
+                sh 'make test'
+            }
+        }
+    }
+}

--- a/examples/jenkins/policy/deny.rego
+++ b/examples/jenkins/policy/deny.rego
@@ -1,0 +1,42 @@
+package main
+
+import rego.v1
+
+risky_shell_calls contains call if {
+	walk(input, [_, call])
+	call.kind == "CallExpr"
+	call.children[0].kind == "IdentExpr"
+	call.children[0].children[0].kind == "Identifier"
+	call.children[0].children[0].text in {"bat", "powershell", "pwsh", "sh"}
+}
+
+# Join static fragments so slashy strings and split GStrings cannot hide a command.
+shell_command(call) := command if {
+	fragments := [token.text |
+		walk(call, [_, token])
+		token.kind in {
+			"DollarSlashyStringLit",
+			"GStringBegin",
+			"GStringEnd",
+			"GStringFull",
+			"GStringPart",
+			"SlashyStringLit",
+			"StringLiteral",
+		}
+	]
+	command := regex.replace(lower(concat("", fragments)), `["'$]`, "")
+}
+
+deny contains violation if {
+	some call in risky_shell_calls
+	command := shell_command(call)
+	regex.match(`(^|[^[:alnum:]_])(curl|wget)[[:space:]]`, command)
+	regex.match(`\|[[:space:]]*(bash|powershell|pwsh|sh)([^[:alnum:]_]|$)`, command)
+	violation := {
+		"msg": "Pipeline downloads a script and pipes it directly to an interpreter",
+		"_loc": {
+			"file": data.conftest.file.name,
+			"line": call.line,
+		},
+	}
+}

--- a/examples/jenkins/policy/deny_test.rego
+++ b/examples/jenkins/policy/deny_test.rego
@@ -1,0 +1,59 @@
+package main
+
+import rego.v1
+
+test_safe_pipeline if {
+	cfg := parse_config("groovy", `
+		pipeline {
+			agent any
+			stages {
+				stage('Build') {
+					steps {
+						sh 'make test'
+					}
+				}
+			}
+		}
+	`)
+	count(deny) == 0 with input as cfg with data.conftest.file.name as "Jenkinsfile"
+}
+
+test_download_piped_to_shell if {
+	cfg := parse_config("groovy", `
+		node {
+			sh 'curl -fsSL https://example.com/install.sh | bash'
+		}
+	`)
+	some violation in deny with input as cfg with data.conftest.file.name as "Jenkinsfile"
+	violation.msg == "Pipeline downloads a script and pipes it directly to an interpreter"
+}
+
+test_wget_piped_to_powershell if {
+	cfg := parse_config("groovy", `
+		node {
+			powershell 'wget https://example.com/install.ps1 | powershell'
+		}
+	`)
+	some violation in deny with input as cfg with data.conftest.file.name as "Jenkinsfile"
+	violation.msg == "Pipeline downloads a script and pipes it directly to an interpreter"
+}
+
+test_dollar_slashy_download_piped_to_shell if {
+	cfg := parse_config("groovy", `
+		node {
+			sh $/curl -fsSL https://example.com/install.sh | bash/$
+		}
+	`)
+	some violation in deny with input as cfg with data.conftest.file.name as "Jenkinsfile"
+	violation.msg == "Pipeline downloads a script and pipes it directly to an interpreter"
+}
+
+test_interpolated_download_piped_to_shell if {
+	cfg := parse_config("groovy", `
+		node {
+			sh "curl -fsSL https://example.com/install.sh | b${''}ash"
+		}
+	`)
+	some violation in deny with input as cfg with data.conftest.file.name as "Jenkinsfile"
+	violation.msg == "Pipeline downloads a script and pipes it directly to an interpreter"
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/CycloneDX/cyclonedx-go v0.11.0
 	github.com/KeisukeYamashita/go-vcl v0.4.0
+	github.com/albertocavalcante/groovy-parser-go v0.0.0-20260218103838-adf14fa75938
 	github.com/basgys/goxml2json v1.1.0
 	github.com/bufbuild/protocompile v0.6.0
 	github.com/go-akka/configuration v0.0.0-20200606091224-a002c0330665

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
 github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
+github.com/albertocavalcante/groovy-parser-go v0.0.0-20260218103838-adf14fa75938 h1:SnOnF+q25uPy9BXHB0Ka8NQXYSQpRK/kQd90WVh32eU=
+github.com/albertocavalcante/groovy-parser-go v0.0.0-20260218103838-adf14fa75938/go.mod h1:SW4T/28m2QEjCGLrxTw2EPA1Ig3yH/2flNZNkBKiLxY=
 github.com/anchore/go-struct-converter v0.1.0 h1:2rDRssAl6mgKBSLNiVCMADgZRhoqtw9dedlWa0OhD30=
 github.com/anchore/go-struct-converter v0.1.0/go.mod h1:rYqSE9HbjzpHTI74vwPvae4ZVYZd1lue2ta6xHPdblA=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/parser/groovy/groovy.go
+++ b/parser/groovy/groovy.go
@@ -1,0 +1,135 @@
+package groovy
+
+import (
+	"encoding/json"
+	"fmt"
+
+	groovylang "github.com/albertocavalcante/groovy-parser-go"
+	groovycst "github.com/albertocavalcante/groovy-parser-go/cst"
+	groovyparser "github.com/albertocavalcante/groovy-parser-go/parser"
+	groovysource "github.com/albertocavalcante/groovy-parser-go/source"
+	groovytoken "github.com/albertocavalcante/groovy-parser-go/token"
+)
+
+const (
+	// Bound the recursive conversion and JSON encoding of untrusted pipeline source.
+	maxTreeDepth = 256
+	maxTreeNodes = 100_000
+)
+
+// Node represents a Jenkins Groovy concrete syntax tree node. Interior nodes
+// may have children, while token nodes have text. Locations are one-based.
+type Node struct {
+	Kind     string `json:"kind"`
+	Text     string `json:"text,omitempty"`
+	Line     int    `json:"line"`
+	Column   int    `json:"column"`
+	Children []Node `json:"children,omitempty"`
+}
+
+// Parser parses Groovy source using the Groovy 2.4 syntax supported by Jenkins.
+type Parser struct{}
+
+// Unmarshal converts Groovy source into a JSON-compatible concrete syntax tree.
+func (p *Parser) Unmarshal(b []byte, v any) error {
+	source := groovysource.New("", b)
+	parser := groovyparser.New(source, groovylang.ParseOptions{Version: groovylang.Groovy2_4})
+	root, parseErrors := parser.Parse()
+	if len(parseErrors) > 0 {
+		first := parseErrors[0]
+		position := source.Position(first.Offset)
+		return fmt.Errorf("parse groovy at %s: %s", position, first.Message)
+	}
+
+	rootNode := groovycst.NewTree(root)
+	if err := validateTree(rootNode, maxTreeDepth, maxTreeNodes); err != nil {
+		return fmt.Errorf("parse groovy: %w", err)
+	}
+
+	tree := convertNode(rootNode, source)
+	encoded, err := json.Marshal(tree)
+	if err != nil {
+		return fmt.Errorf("marshal groovy to json: %w", err)
+	}
+
+	if err := json.Unmarshal(encoded, v); err != nil {
+		return fmt.Errorf("unmarshal groovy json: %w", err)
+	}
+
+	return nil
+}
+
+func validateTree(root *groovycst.Node, maxDepth, maxNodes int) error {
+	type entry struct {
+		node  *groovycst.Node
+		depth int
+	}
+
+	stack := []entry{{node: root, depth: 1}}
+	nodes := 1
+	if nodes > maxNodes {
+		return fmt.Errorf("syntax tree exceeds maximum node count of %d", maxNodes)
+	}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		current := stack[last]
+		stack = stack[:last]
+
+		if current.depth > maxDepth {
+			return fmt.Errorf("syntax tree exceeds maximum depth of %d", maxDepth)
+		}
+
+		childCount := current.node.NumChildren()
+		if childCount > maxNodes-nodes {
+			return fmt.Errorf("syntax tree exceeds maximum node count of %d", maxNodes)
+		}
+		if childCount > 0 && current.depth == maxDepth {
+			return fmt.Errorf("syntax tree exceeds maximum depth of %d", maxDepth)
+		}
+
+		children := current.node.Children()
+		nodes += childCount
+		for i := len(children) - 1; i >= 0; i-- {
+			stack = append(stack, entry{node: children[i], depth: current.depth + 1})
+		}
+	}
+
+	return nil
+}
+
+func convertNode(node *groovycst.Node, source *groovysource.File) Node {
+	converted := Node{
+		Kind: node.Kind().String(),
+	}
+
+	if node.IsToken() {
+		token := node.Token()
+		position := source.Position(token.Offset)
+		converted.Kind = token.Kind.String()
+		converted.Text = token.Text
+		converted.Line = position.Line
+		converted.Column = position.Column
+		return converted
+	}
+
+	for _, child := range node.Children() {
+		if child.IsToken() && skipToken(child.Token()) {
+			continue
+		}
+		converted.Children = append(converted.Children, convertNode(child, source))
+	}
+	if len(converted.Children) > 0 {
+		converted.Line = converted.Children[0].Line
+		converted.Column = converted.Children[0].Column
+	} else {
+		position := source.Position(0)
+		converted.Line = position.Line
+		converted.Column = position.Column
+	}
+
+	return converted
+}
+
+func skipToken(token groovytoken.Token) bool {
+	return token.Kind == groovytoken.EOF || token.Text == ""
+}

--- a/parser/groovy/groovy_test.go
+++ b/parser/groovy/groovy_test.go
@@ -1,0 +1,196 @@
+package groovy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	groovylang "github.com/albertocavalcante/groovy-parser-go"
+	groovycst "github.com/albertocavalcante/groovy-parser-go/cst"
+	groovyparser "github.com/albertocavalcante/groovy-parser-go/parser"
+	groovysource "github.com/albertocavalcante/groovy-parser-go/source"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParser(t *testing.T) {
+	t.Parallel()
+	sample := `pipeline {
+  agent any
+  stages {
+    stage('Build') {
+      steps {
+        sh 'make build'
+      }
+    }
+  }
+}`
+
+	var got Node
+	if err := (&Parser{}).Unmarshal([]byte(sample), &got); err != nil {
+		t.Fatal("parse Jenkinsfile:", err)
+	}
+
+	if diff := cmp.Diff("FileNode", got.Kind); diff != "" {
+		t.Errorf("root kind mismatch (-want +got):\n%s", diff)
+	}
+
+	pipeline := findToken(got, "Identifier", "pipeline")
+	if pipeline == nil {
+		t.Fatal("expected pipeline identifier")
+	}
+	if pipeline.Line != 1 || pipeline.Column != 1 {
+		t.Errorf("pipeline position = %d:%d, want 1:1", pipeline.Line, pipeline.Column)
+	}
+
+	shell := findToken(got, "Identifier", "sh")
+	if shell == nil {
+		t.Fatal("expected shell identifier")
+	}
+	if shell.Line != 6 || shell.Column != 9 {
+		t.Errorf("shell position = %d:%d, want 6:9", shell.Line, shell.Column)
+	}
+
+	if findNode(got, "ClosureExpr") == nil {
+		t.Error("expected nested closure expressions")
+	}
+	if findToken(got, "StringLiteral", "'make build'") == nil {
+		t.Error("expected command string literal")
+	}
+}
+
+func TestParserScriptedPipelineAndGString(t *testing.T) {
+	t.Parallel()
+	sample := `node {
+  def target = "${env.BRANCH_NAME}"
+  sh "make deploy TARGET=${target}"
+}`
+
+	var got Node
+	if err := (&Parser{}).Unmarshal([]byte(sample), &got); err != nil {
+		t.Fatal("parse scripted pipeline:", err)
+	}
+
+	if findToken(got, "Identifier", "node") == nil {
+		t.Error("expected node call")
+	}
+	if findNode(got, "GStringExpr") == nil {
+		t.Error("expected interpolated string expression")
+	}
+	if findToken(got, "Identifier", "sh") == nil {
+		t.Error("expected command-style shell call")
+	}
+}
+
+func TestParserRejectsInvalidSource(t *testing.T) {
+	t.Parallel()
+	var got any
+	err := (&Parser{}).Unmarshal([]byte("pipeline {"), &got)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse groovy at 1:11") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParserOmitsTriviaAndSyntheticTokens(t *testing.T) {
+	t.Parallel()
+	sample := "// comment\npipeline { agent any }\n"
+
+	var got any
+	if err := (&Parser{}).Unmarshal([]byte(sample), &got); err != nil {
+		t.Fatal("parse Jenkinsfile:", err)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal("marshal parsed tree:", err)
+	}
+	text := string(encoded)
+	for _, unexpected := range []string{"comment", "EOF", `\"text\":\"\"`} {
+		if strings.Contains(text, unexpected) {
+			t.Errorf("output contains omitted value %q: %s", unexpected, text)
+		}
+	}
+}
+
+func TestParserJSONContract(t *testing.T) {
+	t.Parallel()
+
+	var got Node
+	if err := (&Parser{}).Unmarshal([]byte("sh 'echo ok'"), &got); err != nil {
+		t.Fatal("parse Jenkinsfile:", err)
+	}
+
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal("marshal parsed tree:", err)
+	}
+
+	want := `{"kind":"FileNode","line":1,"column":1,"children":[{"kind":"ExpressionStmt","line":1,"column":1,"children":[{"kind":"CallExpr","line":1,"column":1,"children":[{"kind":"IdentExpr","line":1,"column":1,"children":[{"kind":"Identifier","text":"sh","line":1,"column":1}]},{"kind":"LiteralExpr","line":1,"column":4,"children":[{"kind":"StringLiteral","text":"'echo ok'","line":1,"column":4}]}]}]}]}`
+	if diff := cmp.Diff(want, string(encoded)); diff != "" {
+		t.Errorf("JSON contract mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestParserRejectsExcessiveNesting(t *testing.T) {
+	t.Parallel()
+
+	sample := strings.Repeat("(", maxTreeDepth) + "1" + strings.Repeat(")", maxTreeDepth)
+	var got any
+	err := (&Parser{}).Unmarshal([]byte(sample), &got)
+	if err == nil {
+		t.Fatal("expected syntax tree depth error")
+	}
+	if !strings.Contains(err.Error(), "syntax tree exceeds maximum depth") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTreeRejectsExcessiveNodes(t *testing.T) {
+	t.Parallel()
+
+	tree := parseTree(t, "sh 'echo ok'")
+	err := validateTree(tree, maxTreeDepth, 1)
+	if err == nil {
+		t.Fatal("expected syntax tree node count error")
+	}
+	if !strings.Contains(err.Error(), "syntax tree exceeds maximum node count of 1") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func parseTree(t *testing.T, sample string) *groovycst.Node {
+	t.Helper()
+	source := groovysource.New("", []byte(sample))
+	parser := groovyparser.New(source, groovylang.ParseOptions{Version: groovylang.Groovy2_4})
+	root, parseErrors := parser.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse syntax tree: %v", parseErrors)
+	}
+	return groovycst.NewTree(root)
+}
+
+func findNode(node Node, kind string) *Node {
+	if node.Kind == kind {
+		return &node
+	}
+	for _, child := range node.Children {
+		if found := findNode(child, kind); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func findToken(node Node, kind, text string) *Node {
+	if node.Kind == kind && node.Text == text {
+		return &node
+	}
+	for _, child := range node.Children {
+		if found := findToken(child, kind, text); found != nil {
+			return found
+		}
+	}
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/docker"
 	dotenv "github.com/open-policy-agent/conftest/parser/dotenv"
 	"github.com/open-policy-agent/conftest/parser/edn"
+	"github.com/open-policy-agent/conftest/parser/groovy"
 	"github.com/open-policy-agent/conftest/parser/hcl1"
 	"github.com/open-policy-agent/conftest/parser/hcl2"
 	"github.com/open-policy-agent/conftest/parser/hocon"
@@ -43,6 +44,7 @@ const (
 	CYCLONEDX  = "cyclonedx"
 	Dockerfile = "dockerfile"
 	EDN        = "edn"
+	GROOVY     = "groovy"
 	HCL1       = "hcl1"
 	HCL2       = "hcl2"
 	HOCON      = "hocon"
@@ -104,6 +106,8 @@ func New(parser string) (Parser, error) {
 		return &nginx.Parser{}, nil
 	case EDN:
 		return &edn.Parser{}, nil
+	case GROOVY:
+		return &groovy.Parser{}, nil
 	case VCL:
 		return &vcl.Parser{}, nil
 	case XML:
@@ -207,6 +211,12 @@ func NewFromPath(path string) (Parser, error) {
 		return New(NGINX)
 	}
 
+	// A Jenkinsfile can either be named Jenkinsfile or be prefixed with
+	// Jenkinsfile. For example: Jenkinsfile, Jenkinsfile.prod.
+	if fileName == "jenkinsfile" || strings.HasPrefix(fileName, "jenkinsfile.") {
+		return New(GROOVY)
+	}
+
 	if slices.Contains(textproto.TextProtoFileExtensions, fileExtension) {
 		return New(TEXTPROTO)
 	}
@@ -226,6 +236,7 @@ func Parsers() []string {
 		CYCLONEDX,
 		Dockerfile,
 		EDN,
+		GROOVY,
 		HCL1,
 		HCL2,
 		HOCON,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-policy-agent/conftest/parser/docker"
 	dotenv "github.com/open-policy-agent/conftest/parser/dotenv"
+	"github.com/open-policy-agent/conftest/parser/groovy"
 	"github.com/open-policy-agent/conftest/parser/hcl2"
 	"github.com/open-policy-agent/conftest/parser/ignore"
 	"github.com/open-policy-agent/conftest/parser/json"
@@ -59,6 +60,26 @@ func TestNewFromPath(t *testing.T) {
 		{
 			"Dockerfile.foo",
 			&docker.Parser{},
+			false,
+		},
+		{
+			"test.groovy",
+			&groovy.Parser{},
+			false,
+		},
+		{
+			"Jenkinsfile",
+			&groovy.Parser{},
+			false,
+		},
+		{
+			"jEnKiNsFiLe",
+			&groovy.Parser{},
+			false,
+		},
+		{
+			"Jenkinsfile.prod",
+			&groovy.Parser{},
 			false,
 		},
 		{
@@ -154,5 +175,20 @@ func TestNewFromPath(t *testing.T) {
 func TestParsersIncludesCycloneDX(t *testing.T) {
 	if !slices.Contains(Parsers(), CYCLONEDX) {
 		t.Fatalf("Parsers() should include %q", CYCLONEDX)
+	}
+}
+
+func TestGroovyParserRegistered(t *testing.T) {
+	actual, err := New(GROOVY)
+	if err != nil {
+		t.Fatal("new groovy parser:", err)
+	}
+
+	if _, ok := actual.(*groovy.Parser); !ok {
+		t.Fatalf("unexpected parser type %T", actual)
+	}
+
+	if !slices.Contains(Parsers(), GROOVY) {
+		t.Errorf("expected %q in registered parsers", GROOVY)
 	}
 }


### PR DESCRIPTION
## Summary

Add a Groovy parser for testing Jenkins pipelines with Conftest policies.

The parser:

- targets the Groovy 2.4 syntax used by Jenkins Pipeline CPS;
- automatically detects `.groovy`, `Jenkinsfile`, and `Jenkinsfile.*`;
- exposes a compact concrete syntax tree with stable node kinds, source
  locations, token text, and child nodes;
- rejects invalid input instead of returning a partial syntax tree;
- omits comments, whitespace, EOF markers, and synthetic zero-width tokens;
- limits syntax-tree depth and node count when processing untrusted input.

Groovy input from stdin can be parsed explicitly with:

```console
conftest parse --parser groovy -
```

## Rego input

The parser exposes a JSON-compatible CST rather than the dependency's internal
types. For example:

```json
{
  "kind": "FileNode",
  "line": 1,
  "column": 1,
  "children": [
    {
      "kind": "ExpressionStmt",
      "line": 1,
      "column": 1,
      "children": [
        {
          "kind": "IdentExpr",
          "line": 1,
          "column": 1,
          "children": [
            {
              "kind": "Identifier",
              "text": "pipeline",
              "line": 1,
              "column": 1
            }
          ]
        }
      ]
    }
  ]
}
```

Keeping this representation in Conftest provides a stable policy-facing
contract and isolates policies from changes to the parser library's internal
CST types.

## Parser dependency

This uses
[`github.com/albertocavalcante/groovy-parser-go`](https://github.com/albertocavalcante/groovy-parser-go)
pinned to commit `adf14fa75938`.

The library is implemented in pure Go, requires no CGO, and adds no transitive
dependencies. This preserves Conftest's static and cross-platform build model.
The parser is always configured for Groovy 2.4, matching the Jenkins CPS
baseline rather than claiming general support for newer Groovy versions.

## Example

The Jenkins example demonstrates a policy that walks the CST and rejects shell
steps that download content with `curl` or `wget` and pipe it directly to an
interpreter. It includes safe, regular string, GString, and dollar-slashy string
test cases.

## Testing

- `go test ./...`
- `96/96` main Bats acceptance tests
- `5/5` Jenkins example policy tests
- Regal bugs lint: no violations
- Markdown formatting and `git diff --check`
- `go mod verify`
- CGO-disabled cross-builds:
  - Linux amd64
  - Linux arm64
  - Windows amd64
- Local Jenkins corpus check: `81/81` pipeline examples/files parsed
  successfully

The parser also has tests covering declarative and scripted pipelines,
GStrings, nested closures, command-style calls, invalid input, omitted trivia,
source locations, the exact JSON contract, and syntax-tree resource limits.

Fixes #1342
