### PR TITLE
Exit with the plugin's status when it fails a test

### DIFF
--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -78,8 +78,16 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 		Use:   p.Name,
 		Short: p.Usage,
 		Long:  p.Description,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := p.Exec(ctx, args); err != nil {
+				var exitErr plugin.ExitError
+				if errors.As(err, &exitErr) {
+					// The plugin has already reported whatever went wrong;
+					// only its exit status still has to reach the caller.
+					cmd.SilenceErrors = true
+					return err
+				}
+
 				return fmt.Errorf("execute plugin: %v", err)
 			}
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/open-policy-agent/conftest/internal/commands"
+	"github.com/open-policy-agent/conftest/plugin"
 )
 
 func main() {
 	if err := commands.NewDefaultCommand().Execute(); err != nil {
+		// A plugin that failed a test exits 1 or 2. Exit with the status it
+		// chose, so that a caller can tell a failing plugin from a passing
+		// one.
+		var exitErr plugin.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,19 @@ const (
 	cacheDirectory = xdgPath(cacheDir)
 )
 
+// ExitError reports that the plugin ran and chose to fail.
+//
+// Code is the status the plugin exited with. Conftest exits with the same
+// one, and prints nothing further: the plugin has already said what went
+// wrong on its own stdout and stderr.
+type ExitError struct {
+	Code int
+}
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("plugin exited with status %d", e.Code)
+}
+
 // Plugin represents a plugin.
 type Plugin struct {
 	Name        string `yaml:"name"`
@@ -122,9 +135,11 @@ func (p *Plugin) Exec(ctx context.Context, args []string) error {
 		}
 
 		// Conftest can either return 1 or 2 for an error. If Conftest
-		// returns an error, let it handle its own error.
+		// returns an error, let it handle its own error -- but carry the
+		// status, or a plugin that failed a test is indistinguishable from
+		// one that passed.
 		if status.ExitStatus() == 1 || status.ExitStatus() == 2 {
-			return nil
+			return ExitError{Code: status.ExitStatus()}
 		}
 
 		return fmt.Errorf("plugin exec: %w", err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -243,6 +244,43 @@ func TestPluginExec(t *testing.T) {
 			t.Errorf("expected %q, got %q", expected, string(content))
 		}
 	})
+
+	// A plugin that fails a test exits 1 or 2. Conftest prints nothing more --
+	// the plugin has already reported -- but the status has to survive, or a
+	// failing plugin is indistinguishable from a passing one.
+	for _, code := range []int{1, 2} {
+		t.Run(fmt.Sprintf("test failure exit code %d", code), func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("the test plugin is a shell script")
+			}
+
+			script := filepath.Join(t.TempDir(), "exit.sh")
+			body := fmt.Sprintf("#!/bin/sh\nexit %d\n", code)
+			if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			p := &Plugin{
+				Name:    fmt.Sprintf("exit-%d-test", code),
+				Command: script,
+			}
+			createTestPlugin(t, p)
+
+			loaded, err := Load(p.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var exitErr ExitError
+			err = loaded.Exec(t.Context(), nil)
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected an ExitError, got %v", err)
+			}
+			if exitErr.Code != code {
+				t.Errorf("expected exit code %d, got %d", code, exitErr.Code)
+			}
+		})
+	}
 
 	t.Run("command error handling", func(t *testing.T) {
 		p := &Plugin{


### PR DESCRIPTION
Fixes #741.

`Plugin.Exec` treats a plugin's exit code 1 or 2 as "Conftest already printed the failure, don't print it again" — which is right, and is what [the docs promise](https://www.conftest.dev/plugins/): those two codes "indicate a test failure and no error message will be printed". But *not printing* was implemented as returning `nil`, which also discards the status, so Conftest exits **0** and a plugin that failed a test looks exactly like one that passed.

Measured on today's `master` against the reporter's plugin:

| plugin exits | `master` | this branch |
| --- | --- | --- |
| 0 | 0 | 0 |
| 1 | **0** | **1** |
| 2 | **0** | **2** |
| 7 | 1, `Error: execute plugin: plugin exec: exit status 7` | unchanged |

`Exec` now returns a typed `ExitError` carrying the code; the plugin command silences cobra's error printing for it, and `main` exits with the code. The message stays suppressed for 1 and 2 — nothing new is printed for any input.

@jpreese, on the "sort of by design" reading from [this comment](https://github.com/open-policy-agent/conftest/issues/741#issuecomment-1285194938): I've taken the design as given rather than changed it. Codes outside 1 and 2 still collapse to exit 1 with the same message they produce today, because the docs tell plugin authors to use those for "any reason other than a test failure" and I didn't want to alter what a caller sees there. The only thing that changes is that a *documented test failure* no longer reports success. If you'd rather every code were passed through verbatim, that's a one-line change to the same branch and I'm happy to make it.

@jalseth — this is the PR you offered to take in [this comment](https://github.com/open-policy-agent/conftest/issues/741#issuecomment-1264265818).

`TestPluginExec` gains two subtests, for exit 1 and exit 2, asserting the code survives; they're skipped on Windows since the fixture is a shell script. `go test ./...` is green, as are `gofmt` and `go vet`. The table above comes from two binaries built from this tree with and without the change, each with a freshly installed plugin.

AI-assisted (LLM used for drafting); the runs above are mine.
