### PR TITLE
fix: propagate plugin exit status

### DIFF
--- a/internal/commands/default.go
+++ b/internal/commands/default.go
@@ -78,8 +78,16 @@ func newCommandFromPlugin(ctx context.Context, p *plugin.Plugin) *cobra.Command 
 		Use:   p.Name,
 		Short: p.Usage,
 		Long:  p.Description,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := p.Exec(ctx, args); err != nil {
+				var exitErr plugin.ExitError
+				if errors.As(err, &exitErr) {
+					// The plugin has already reported whatever went wrong;
+					// only its exit status still has to reach the caller.
+					cmd.SilenceErrors = true
+					return err
+				}
+
 				return fmt.Errorf("execute plugin: %v", err)
 			}
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,23 @@
 package main
 
 import (
+	"errors"
 	"os"
 
 	"github.com/open-policy-agent/conftest/internal/commands"
+	"github.com/open-policy-agent/conftest/plugin"
 )
 
 func main() {
 	if err := commands.NewDefaultCommand().Execute(); err != nil {
+		// A plugin that failed a test exits 1 or 2. Exit with the status it
+		// chose, so that a caller can tell a failing plugin from a passing
+		// one.
+		var exitErr plugin.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.Code)
+		}
+
 		os.Exit(1)
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,6 +18,19 @@ const (
 	cacheDirectory = xdgPath(cacheDir)
 )
 
+// ExitError reports that the plugin ran and chose to fail.
+//
+// Code is the status the plugin exited with. Conftest exits with the same
+// one, and prints nothing further: the plugin has already said what went
+// wrong on its own stdout and stderr.
+type ExitError struct {
+	Code int
+}
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("plugin exited with status %d", e.Code)
+}
+
 // Plugin represents a plugin.
 type Plugin struct {
 	Name        string `yaml:"name"`
@@ -122,9 +135,11 @@ func (p *Plugin) Exec(ctx context.Context, args []string) error {
 		}
 
 		// Conftest can either return 1 or 2 for an error. If Conftest
-		// returns an error, let it handle its own error.
+		// returns an error, let it handle its own error -- but carry the
+		// status, or a plugin that failed a test is indistinguishable from
+		// one that passed.
 		if status.ExitStatus() == 1 || status.ExitStatus() == 2 {
-			return nil
+			return ExitError{Code: status.ExitStatus()}
 		}
 
 		return fmt.Errorf("plugin exec: %w", err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -243,6 +244,43 @@ func TestPluginExec(t *testing.T) {
 			t.Errorf("expected %q, got %q", expected, string(content))
 		}
 	})
+
+	// A plugin that fails a test exits 1 or 2. Conftest prints nothing more --
+	// the plugin has already reported -- but the status has to survive, or a
+	// failing plugin is indistinguishable from a passing one.
+	for _, code := range []int{1, 2} {
+		t.Run(fmt.Sprintf("test failure exit code %d", code), func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("the test plugin is a shell script")
+			}
+
+			script := filepath.Join(t.TempDir(), "exit.sh")
+			body := fmt.Sprintf("#!/bin/sh\nexit %d\n", code)
+			if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			p := &Plugin{
+				Name:    fmt.Sprintf("exit-%d-test", code),
+				Command: script,
+			}
+			createTestPlugin(t, p)
+
+			loaded, err := Load(p.Name)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var exitErr ExitError
+			err = loaded.Exec(t.Context(), nil)
+			if !errors.As(err, &exitErr) {
+				t.Fatalf("expected an ExitError, got %v", err)
+			}
+			if exitErr.Code != code {
+				t.Errorf("expected exit code %d, got %d", code, exitErr.Code)
+			}
+		})
+	}
 
 	t.Run("command error handling", func(t *testing.T) {
 		p := &Plugin{


### PR DESCRIPTION
## Summary

- preserve plugin exit codes 1 and 2 instead of treating them as success
- carry the status through a typed ExitError
- suppress a duplicate Conftest error message while retaining the plugin's original status
- keep the existing behavior for other plugin execution failures

## Why

Plugins commonly use exit code 1 for failure. Conftest currently returns nil for plugin statuses 1 and 2, so callers see a successful Conftest invocation even though the plugin failed.

## Validation

- go test ./plugin ./internal/commands

Fixes #741
