### PR TITLE
fix(output): escape ':' and ',' in GitHub workflow command file names

### DIFF
--- a/output/github.go
+++ b/output/github.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/open-policy-agent/opa/v1/tester"
 )
@@ -97,9 +98,24 @@ func (g *GitHub) writeLn(msg string, args ...any) {
 	fmt.Fprintf(g.writer, msg+"\n", args...)
 }
 
+// escapeProperty escapes a workflow command property value. ':' and ',' delimit
+// the property block, so a file name containing either would end it early.
+// https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands
+func escapeProperty(v string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"\r", "%0D",
+		"\n", "%0A",
+		":", "%3A",
+		",", "%2C",
+	).Replace(v)
+}
+
 func (g *GitHub) writeLoc(level githubLevel, loc *Location, msg string, args ...any) {
-	msg = fmt.Sprintf("::%s file=%s,line=%s::%s", level, loc.File, loc.Line, msg)
-	g.writeLn(msg, args...)
+	// Format the message first: the escaped file name contains '%' sequences
+	// that must not be read as verbs by the final Fprintf.
+	msg = fmt.Sprintf(msg, args...)
+	g.writeLn("%s", fmt.Sprintf("::%s file=%s,line=%s::%s", level, escapeProperty(loc.File), loc.Line, msg))
 }
 
 func (g *GitHub) writeLocs(level githubLevel, fileLoc, ogLoc *Location, msg string, args ...any) {

--- a/output/github_test.go
+++ b/output/github_test.go
@@ -199,6 +199,26 @@ func TestGitHub(t *testing.T) {
 				"",
 			},
 		},
+		{
+			// ',' and ':' end the property block, so an unescaped file name
+			// truncates the annotation and the runner mis-parses the rest.
+			name: "escapes property delimiters in the file name",
+			input: CheckResults{
+				{
+					FileName:  "a,b:c.yaml",
+					Namespace: "namespace",
+					Failures:  []Result{{Message: "first failure"}},
+				},
+			},
+			expected: []string{
+				"::group::Testing \"a,b:c.yaml\" against 1 policies in namespace \"namespace\"",
+				"::error file=a%2Cb%3Ac.yaml,line=1::first failure",
+				"::notice file=a%2Cb%3Ac.yaml,line=1::Number of successful checks: 0",
+				"::endgroup::",
+				"1 test, 0 passed, 0 warnings, 1 failure, 0 exceptions",
+				"",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
A file name containing `:` or `,` breaks the GitHub annotation it appears in, because both characters delimit the workflow command's property block.

```
before: ::error file=a,b.json,line=1::bad thing
after:  ::error file=a%2Cb.json,line=1::bad thing
        ::error file=x%3Ay.json,line=1::bad thing
```

In the `before` line GitHub reads `file=a` and then treats `b.json` as the start of a new property, so the annotation loses both the real path and its line number. `:` is worse, since it closes the command block outright and the rest of the line is printed as literal text rather than attached to the file.

This is reachable in normal use: `conftest test` is often pointed at generated manifests, and Helm and Kustomize both produce names with `:` in them.

## The fix

`escapeProperty` applies the escaping GitHub documents for property values. `%`, `\r` and `\n` were already required for any workflow command; `:` and `,` are the two that are specific to a property value, and they are the two that were missing.

`writeLoc` now formats the message before building the command line. Without that, the `%25` sequences the escaping introduces are read as format verbs by the outer `Fprintf` and the path comes out as `file=a%!C(MISSING)b.json`. I hit exactly that on the first attempt, which is why the `fmt.Sprintf` is split out rather than inlined.

Normal file names are byte-identical before and after.

## Verification

`escapes property delimiters in the file name` in `output/github_test.go` runs a failure whose location is `a,b:c.yaml` and asserts the full emitted line.

Mutating only the call site, `escapeProperty(loc.File)` back to `loc.File`, fails it as an assertion rather than a build error:

```
--- FAIL: TestGitHub/escapes_property_delimiters_in_the_file_name
    - 	",b:",
    + 	"%2Cb%3A",
```

`go build ./...`, `go vet ./output/`, `gofmt -l` and `go test ./output/` are all clean.

*Disclosure: written with AI assistance (Claude Code). I reproduced the truncated annotation at the CLI, hit and fixed the format-verb regression myself, and ran the mutation check.*
