### PR TITLE
chore: disable goconst in Go test files

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -46,6 +46,11 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      # Repeated string literals in table-driven tests are intentional.
+      - path: _test\.go
+        linters:
+          - goconst
     paths:
       - third_party$
       - builtin$


### PR DESCRIPTION
Repeated string literals in table-driven tests are intentional. Having a ton of constants decoupling some test inputs from others while reading the test cases is worse.

I verified by running golangci-lint locally and checking this linter no longer produces findings for test files.