### PR TITLE
feat: add RouterOS configuration file parser

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,9 @@ linters:
         - nilness
     misspell:
       locale: US
+      ignore-rules:
+        # RouterOS is a MikroTik product name, not a misspelling of "routers".
+        - routeros
     revive:
       rules:
         - name: var-naming

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ As of today Conftest supports:
 - Jenkins Pipeline and Groovy 2.4
 - JSON
 - Jsonnet
+- MikroTik RouterOS
 - nginx
 - Property files (.properties)
 - SPDX

--- a/docs/options.md
+++ b/docs/options.md
@@ -453,6 +453,33 @@ Comments, whitespace, end-of-file markers, and synthetic zero-width tokens are
 not included in the Rego input. Policies can use `walk()` to find syntax nodes
 without depending on their absolute depth in the tree.
 
+### MikroTik RouterOS
+
+The `routeros` parser reads the configuration exports produced by the RouterOS
+`/export` command. Files with a `.rsc` extension are detected automatically, so
+use `--parser routeros` only when reading an export from standard input or from
+a file with a different extension.
+
+The parsed input is keyed by section path (for example `/ip firewall filter`).
+Each section holds the list of commands declared under it, in order. Every
+command exposes its verb under `command`, its key=value settings as fields, and
+any remaining tokens (selectors such as `[ find ]`, positional ids, and
+`!`-prefixed flags) under `arguments`. For example:
+
+```json
+{
+  "/ip firewall filter": [
+    {
+      "command": "add",
+      "action": "accept",
+      "chain": "input",
+      "protocol": "tcp",
+      "dst-port": "443"
+    }
+  ]
+}
+```
+
 ## `--policy`
 
 Conftest will, by default, look for policies in the `policy` folder. This can be

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/jsonnet"
 	"github.com/open-policy-agent/conftest/parser/nginx"
 	"github.com/open-policy-agent/conftest/parser/properties"
+	"github.com/open-policy-agent/conftest/parser/routeros"
 	"github.com/open-policy-agent/conftest/parser/spdx"
 	"github.com/open-policy-agent/conftest/parser/textproto"
 	"github.com/open-policy-agent/conftest/parser/toml"
@@ -55,6 +56,7 @@ const (
 	JSONNET    = "jsonnet"
 	NGINX      = "nginx"
 	PROPERTIES = "properties"
+	ROUTEROS   = "routeros"
 	SPDX       = "spdx"
 	TEXTPROTO  = "textproto"
 	TOML       = "toml"
@@ -104,6 +106,8 @@ func New(parser string) (Parser, error) {
 		return &jsonnet.Parser{}, nil
 	case NGINX:
 		return &nginx.Parser{}, nil
+	case ROUTEROS:
+		return &routeros.Parser{}, nil
 	case EDN:
 		return &edn.Parser{}, nil
 	case GROOVY:
@@ -211,6 +215,12 @@ func NewFromPath(path string) (Parser, error) {
 		return New(NGINX)
 	}
 
+	// RouterOS configuration exports produced by "/export file=" use the .rsc
+	// extension.
+	if fileExtension == "rsc" {
+		return New(ROUTEROS)
+	}
+
 	// A Jenkinsfile can either be named Jenkinsfile or be prefixed with
 	// Jenkinsfile. For example: Jenkinsfile, Jenkinsfile.prod.
 	if fileName == "jenkinsfile" || strings.HasPrefix(fileName, "jenkinsfile.") {
@@ -246,6 +256,7 @@ func Parsers() []string {
 		JSONNET,
 		NGINX,
 		PROPERTIES,
+		ROUTEROS,
 		SPDX,
 		TEXTPROTO,
 		TOML,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-policy-agent/conftest/parser/ignore"
 	"github.com/open-policy-agent/conftest/parser/json"
 	"github.com/open-policy-agent/conftest/parser/jsonc"
+	"github.com/open-policy-agent/conftest/parser/routeros"
 	"github.com/open-policy-agent/conftest/parser/textproto"
 	"github.com/open-policy-agent/conftest/parser/yaml"
 )
@@ -152,6 +153,11 @@ func TestNewFromPath(t *testing.T) {
 			&textproto.Parser{},
 			false,
 		},
+		{
+			"config.rsc",
+			&routeros.Parser{},
+			false,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -175,6 +181,21 @@ func TestNewFromPath(t *testing.T) {
 func TestParsersIncludesCycloneDX(t *testing.T) {
 	if !slices.Contains(Parsers(), CYCLONEDX) {
 		t.Fatalf("Parsers() should include %q", CYCLONEDX)
+	}
+}
+
+func TestRouterOSParserRegistered(t *testing.T) {
+	actual, err := New(ROUTEROS)
+	if err != nil {
+		t.Fatal("new routeros parser:", err)
+	}
+
+	if _, ok := actual.(*routeros.Parser); !ok {
+		t.Fatalf("unexpected parser type %T", actual)
+	}
+
+	if !slices.Contains(Parsers(), ROUTEROS) {
+		t.Errorf("expected %q in registered parsers", ROUTEROS)
 	}
 }
 

--- a/parser/routeros/routeros.go
+++ b/parser/routeros/routeros.go
@@ -1,0 +1,207 @@
+// Package routeros parses MikroTik RouterOS configuration exports, the output
+// produced by the RouterOS "/export" command.
+package routeros
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Parser is a RouterOS configuration parser.
+type Parser struct{}
+
+// entry is a single command within a configuration section, for example an
+// "add" or "set" line. The command verb is stored under "command" and any
+// tokens that are not key=value pairs (selectors like "[ find ]", positional
+// ids, or "!"-prefixed flags) are stored under "arguments".
+type entry map[string]any
+
+// Unmarshal unmarshals a RouterOS configuration export. The result is an object
+// keyed by section path (for example "/ip address"), where each value is the
+// list of commands declared under that section in the order they appear.
+func (p *Parser) Unmarshal(input []byte, out any) error {
+	sections := map[string][]entry{}
+	var order []string
+
+	var current string
+	haveSection := false
+
+	for _, line := range logicalLines(string(input)) {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "/") {
+			current = trimmed
+			haveSection = true
+			if _, ok := sections[current]; !ok {
+				sections[current] = []entry{}
+				order = append(order, current)
+			}
+			continue
+		}
+
+		if !haveSection {
+			return fmt.Errorf("command %q found before any section header", trimmed)
+		}
+
+		sections[current] = append(sections[current], parseCommand(trimmed))
+	}
+
+	// Preserve section order so the JSON round-trip is deterministic.
+	result := make(map[string]any, len(sections))
+	for _, name := range order {
+		result[name] = sections[name]
+	}
+
+	j, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshal routeros to json: %w", err)
+	}
+	if err := json.Unmarshal(j, out); err != nil {
+		return fmt.Errorf("unmarshal routeros json: %w", err)
+	}
+	return nil
+}
+
+// logicalLines joins RouterOS line continuations. The exporter wraps long lines
+// with a trailing backslash, then indents the continuation. Joining strips the
+// backslash and the continuation's leading whitespace so wrapped values are
+// reassembled exactly as RouterOS stored them.
+func logicalLines(s string) []string {
+	physical := strings.Split(strings.ReplaceAll(s, "\r\n", "\n"), "\n")
+
+	var out []string
+	var buf strings.Builder
+	continuing := false
+
+	for _, line := range physical {
+		part := line
+		if continuing {
+			part = strings.TrimLeft(part, " \t")
+		}
+
+		if strings.HasSuffix(part, "\\") {
+			buf.WriteString(strings.TrimSuffix(part, "\\"))
+			continuing = true
+			continue
+		}
+
+		buf.WriteString(part)
+		out = append(out, buf.String())
+		buf.Reset()
+		continuing = false
+	}
+
+	if continuing {
+		out = append(out, buf.String())
+	}
+	return out
+}
+
+// parseCommand splits a command line into its verb, key=value pairs, and any
+// remaining positional arguments or flags.
+func parseCommand(line string) entry {
+	tokens := tokenize(line)
+	e := entry{}
+	var args []string
+
+	for i, tok := range tokens {
+		if i == 0 {
+			e["command"] = tok
+			continue
+		}
+
+		// Bracketed selectors and "!" flags are not assignments, even though a
+		// selector such as "[ find name=all ]" contains an "=".
+		if strings.HasPrefix(tok, "[") || strings.HasPrefix(tok, "!") {
+			args = append(args, tok)
+			continue
+		}
+
+		if key, value, ok := strings.Cut(tok, "="); ok {
+			e[key] = unquote(value)
+			continue
+		}
+
+		args = append(args, tok)
+	}
+
+	if len(args) > 0 {
+		e["arguments"] = args
+	}
+	return e
+}
+
+// tokenize splits a logical line on whitespace while keeping double-quoted
+// strings and bracketed "[ ... ]" expressions as single tokens.
+func tokenize(line string) []string {
+	var tokens []string
+	var cur strings.Builder
+	inQuote := false
+	escaped := false
+	depth := 0
+
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+
+	for _, r := range line {
+		switch {
+		case escaped:
+			cur.WriteRune(r)
+			escaped = false
+		case r == '\\':
+			cur.WriteRune(r)
+			escaped = true
+		case r == '"':
+			inQuote = !inQuote
+			cur.WriteRune(r)
+		case inQuote:
+			cur.WriteRune(r)
+		case r == '[':
+			depth++
+			cur.WriteRune(r)
+		case r == ']':
+			if depth > 0 {
+				depth--
+			}
+			cur.WriteRune(r)
+		case (r == ' ' || r == '\t') && depth == 0:
+			flush()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	flush()
+	return tokens
+}
+
+// unquote removes surrounding double quotes and unescapes the escape sequences
+// RouterOS emits inside quoted values. Unquoted values are returned unchanged.
+func unquote(value string) string {
+	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+		return value
+	}
+
+	inner := value[1 : len(value)-1]
+	var b strings.Builder
+	for i := 0; i < len(inner); i++ {
+		if inner[i] == '\\' && i+1 < len(inner) {
+			next := inner[i+1]
+			switch next {
+			case '"', '\\':
+				b.WriteByte(next)
+				i++
+				continue
+			}
+		}
+		b.WriteByte(inner[i])
+	}
+	return b.String()
+}

--- a/parser/routeros/routeros_test.go
+++ b/parser/routeros/routeros_test.go
@@ -1,0 +1,156 @@
+package routeros
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRouterOSParser(t *testing.T) {
+	sample := `# 2025-01-12 06:20:22 by RouterOS 7.17rc7
+# software id = XGWP-9N00
+#
+/ip address
+add address=192.168.88.1/24 comment=defconf interface=bridge1 network=192.168.88.0
+/system identity
+set name=MikroTik`
+
+	var parsed any
+	if err := (&Parser{}).Unmarshal([]byte(sample), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	root, ok := parsed.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map root, got %T", parsed)
+	}
+
+	addr, ok := root["/ip address"].([]any)
+	if !ok || len(addr) != 1 {
+		t.Fatalf("expected one /ip address entry, got %v", root["/ip address"])
+	}
+
+	first := addr[0].(map[string]any)
+	if first["command"] != "add" {
+		t.Errorf("command = %v, want add", first["command"])
+	}
+	if first["address"] != "192.168.88.1/24" {
+		t.Errorf("address = %v, want 192.168.88.1/24", first["address"])
+	}
+	if first["interface"] != "bridge1" {
+		t.Errorf("interface = %v, want bridge1", first["interface"])
+	}
+
+	identity := root["/system identity"].([]any)
+	if identity[0].(map[string]any)["name"] != "MikroTik" {
+		t.Errorf("identity name = %v, want MikroTik", identity[0])
+	}
+}
+
+func TestLineContinuation(t *testing.T) {
+	// A value wrapped mid-token (no space before the backslash) must rejoin
+	// tightly, while a wrap between tokens (space before the backslash) keeps
+	// the tokens separated.
+	sample := `/interface ethernet
+set advertise="10M-baseT-half,100M\
+    -baseT-full" arp=enabled \
+    name=ether1`
+
+	var parsed any
+	if err := (&Parser{}).Unmarshal([]byte(sample), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	e := parsed.(map[string]any)["/interface ethernet"].([]any)[0].(map[string]any)
+	if e["advertise"] != "10M-baseT-half,100M-baseT-full" {
+		t.Errorf("advertise = %q, want %q", e["advertise"], "10M-baseT-half,100M-baseT-full")
+	}
+	if e["arp"] != "enabled" {
+		t.Errorf("arp = %v, want enabled", e["arp"])
+	}
+	if e["name"] != "ether1" {
+		t.Errorf("name = %v, want ether1", e["name"])
+	}
+}
+
+func TestSelectorsAndFlags(t *testing.T) {
+	sample := `/interface list
+set [ find name=all ] comment="contains all interfaces" name=all
+/interface ethernet switch port
+set 0 !egress-rate !ingress-rate`
+
+	var parsed any
+	if err := (&Parser{}).Unmarshal([]byte(sample), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	root := parsed.(map[string]any)
+
+	list := root["/interface list"].([]any)[0].(map[string]any)
+	if list["comment"] != "contains all interfaces" {
+		t.Errorf("comment = %v, want quoted string", list["comment"])
+	}
+	args, ok := list["arguments"].([]any)
+	if !ok || len(args) != 1 || args[0] != "[ find name=all ]" {
+		t.Errorf("arguments = %v, want the find selector kept intact", list["arguments"])
+	}
+
+	port := root["/interface ethernet switch port"].([]any)[0].(map[string]any)
+	portArgs := port["arguments"].([]any)
+	want := []any{"0", "!egress-rate", "!ingress-rate"}
+	if !reflect.DeepEqual(portArgs, want) {
+		t.Errorf("port arguments = %v, want %v", portArgs, want)
+	}
+}
+
+func TestMultipleEntriesPreserveOrder(t *testing.T) {
+	sample := `/ip firewall filter
+add action=accept chain=input comment=first
+add action=drop chain=input comment=second`
+
+	var parsed any
+	if err := (&Parser{}).Unmarshal([]byte(sample), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	rules := parsed.(map[string]any)["/ip firewall filter"].([]any)
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules, got %d", len(rules))
+	}
+	if rules[0].(map[string]any)["comment"] != "first" {
+		t.Errorf("first rule comment = %v", rules[0])
+	}
+	if rules[1].(map[string]any)["comment"] != "second" {
+		t.Errorf("second rule comment = %v", rules[1])
+	}
+}
+
+func TestEmptyAndCommentOnly(t *testing.T) {
+	var parsed any
+	if err := (&Parser{}).Unmarshal([]byte("# just a comment\n\n"), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m, ok := parsed.(map[string]any); !ok || len(m) != 0 {
+		t.Errorf("expected empty map, got %v", parsed)
+	}
+}
+
+func TestCommandBeforeSectionErrors(t *testing.T) {
+	err := (&Parser{}).Unmarshal([]byte("add name=oops"), new(any))
+	if err == nil {
+		t.Fatal("expected an error for a command outside any section")
+	}
+}
+
+func TestUnquote(t *testing.T) {
+	cases := map[string]string{
+		`"plain"`:           "plain",
+		`""`:                "",
+		`unquoted`:          "unquoted",
+		`"with \"quotes\""`: `with "quotes"`,
+		`"back\\slash"`:     `back\slash`,
+	}
+	for in, want := range cases {
+		if got := unquote(in); got != want {
+			t.Errorf("unquote(%s) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Adds a parser for MikroTik RouterOS `/export` configuration files, as requested in #1034.

The output is keyed by section path (like `/ip firewall filter`). Each command becomes an entry with its verb under `command`, its key=value settings as fields, and anything left over (find selectors, positional ids, `!` flags) under `arguments`. So a firewall rule is queryable in Rego as `input["/ip firewall filter"][_].action == "accept"`.

Files ending in `.rsc` are detected automatically, otherwise `--parser routeros` works from stdin or any extension.

I ran it against the verbose export attached to the issue (735 lines, 125 sections) and it parses cleanly. There are unit tests covering line continuation, quoted values, selectors and flags.

One small thing: I added `routeros` to misspell's ignore list in `.golangci.yaml`, since it kept flagging the product name as a typo of "routers".

Fixes #1034