### PR TITLE
refactor(parser): Add Remarshal() helper

### DIFF
--- a/parser/docker/docker.go
+++ b/parser/docker/docker.go
@@ -2,12 +2,13 @@ package docker
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/moby/buildkit/frontend/dockerfile/instructions"
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a Dockerfile parser.
@@ -96,16 +97,7 @@ func (dp *Parser) Unmarshal(p []byte, v any) error {
 	var dockerFile [][]Command
 	dockerFile = append(dockerFile, commands)
 
-	j, err := json.Marshal(dockerFile)
-	if err != nil {
-		return fmt.Errorf("marshal dockerfile to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal dockerfile json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("dockerfile", dockerFile, v)
 }
 
 // Return the index of the stages. If no stages are present,

--- a/parser/dotenv/dotenv.go
+++ b/parser/dotenv/dotenv.go
@@ -2,10 +2,11 @@ package ini
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 
 	"github.com/subosito/gotenv"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is an dotenv parser.
@@ -19,14 +20,5 @@ func (i *Parser) Unmarshal(p []byte, v any) error {
 		return fmt.Errorf("read .env file: %w", err)
 	}
 
-	j, err := json.Marshal(cfg)
-	if err != nil {
-		return fmt.Errorf("marshal dotenv to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal dotenv json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("dotenv", cfg, v)
 }

--- a/parser/hocon/hocon.go
+++ b/parser/hocon/hocon.go
@@ -1,12 +1,12 @@
 package hocon
 
 import (
-	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/go-akka/configuration"
 	"github.com/go-akka/configuration/hocon"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a HOCON parser.
@@ -22,16 +22,7 @@ func (i *Parser) Unmarshal(p []byte, v any) error {
 		result[key] = getConfig(rootCfg, cfg, key)
 	}
 
-	j, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("marshal hocon to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal hocon json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("hocon", result, v)
 }
 
 func getConfig(rootCfg, cfg *configuration.Config, path string) map[string]any {

--- a/parser/ignore/ignore.go
+++ b/parser/ignore/ignore.go
@@ -1,10 +1,11 @@
 package ignore
 
 import (
-	"encoding/json"
 	"fmt"
 
 	ignore "github.com/shteou/go-ignore"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a ignore (dockerignore, gitignore) parser.
@@ -21,14 +22,5 @@ func (pp *Parser) Unmarshal(p []byte, v any) error {
 	// treated as a single file.
 	entryListList := [][]ignore.Entry{ignoreEntries}
 
-	marshalledLines, err := json.Marshal(entryListList)
-	if err != nil {
-		return fmt.Errorf("marshal ignore: %w", err)
-	}
-
-	if err := json.Unmarshal(marshalledLines, v); err != nil {
-		return fmt.Errorf("unmarshal ignore: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("ignore", entryListList, v)
 }

--- a/parser/ini/ini.go
+++ b/parser/ini/ini.go
@@ -1,11 +1,12 @@
 package ini
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"github.com/go-ini/ini"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is an INI parser.
@@ -30,16 +31,7 @@ func (i *Parser) Unmarshal(p []byte, v any) error {
 		result[sectionName] = convertKeyTypes(keysHash)
 	}
 
-	j, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("marshal ini to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal ini json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("ini", result, v)
 }
 
 func convertKeyTypes(keysHash map[string]string) map[string]any {

--- a/parser/internal/convert/convert.go
+++ b/parser/internal/convert/convert.go
@@ -1,0 +1,23 @@
+// Package convert provides conversion helpers shared by the parsers.
+package convert
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Remarshal marshals in to JSON and unmarshals the result into out, which
+// normalizes a parser's intermediate value into plain maps, slices and
+// scalars. The name identifies the parser in error messages.
+func Remarshal(name string, in, out any) error {
+	j, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("marshal %s to json: %w", name, err)
+	}
+
+	if err := json.Unmarshal(j, out); err != nil {
+		return fmt.Errorf("unmarshal %s json: %w", name, err)
+	}
+
+	return nil
+}

--- a/parser/nginx/nginx.go
+++ b/parser/nginx/nginx.go
@@ -1,11 +1,12 @@
 package nginx
 
 import (
-	"encoding/json"
 	"fmt"
 
 	gonginxconfig "github.com/tufanbarisyildirim/gonginx/config"
 	gonginxparser "github.com/tufanbarisyildirim/gonginx/parser"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Config represents a parsed nginx configuration.
@@ -37,16 +38,7 @@ func (p *Parser) Unmarshal(b []byte, v any) error {
 	}
 
 	config := Config{Directives: convertDirectives(cfg.GetDirectives())}
-	j, err := json.Marshal(config)
-	if err != nil {
-		return fmt.Errorf("marshal nginx to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal nginx json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("nginx", config, v)
 }
 
 func convertDirectives(directives []gonginxconfig.IDirective) []Directive {

--- a/parser/properties/properties.go
+++ b/parser/properties/properties.go
@@ -1,10 +1,11 @@
 package properties
 
 import (
-	"encoding/json"
 	"fmt"
 
 	prop "github.com/magiconair/properties"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a properties parser.
@@ -18,14 +19,5 @@ func (pp *Parser) Unmarshal(p []byte, v any) error {
 
 	result := rawProps.Map()
 
-	j, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("marshal properties to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal properties json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("properties", result, v)
 }

--- a/parser/spdx/spdx.go
+++ b/parser/spdx/spdx.go
@@ -2,10 +2,11 @@ package spdx
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 
 	"github.com/spdx/tools-golang/tagvalue"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a SPDX parser.
@@ -18,14 +19,5 @@ func (*Parser) Unmarshal(p []byte, v any) error {
 		return fmt.Errorf("error while parsing %v: %v", p, err)
 	}
 
-	out, err := json.Marshal(doc)
-	if err != nil {
-		return fmt.Errorf("error while marshaling %v: %v", p, err)
-	}
-
-	if err := json.Unmarshal(out, v); err != nil {
-		return fmt.Errorf("unmarshal SPDX json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("spdx", doc, v)
 }

--- a/parser/vcl/vcl.go
+++ b/parser/vcl/vcl.go
@@ -1,10 +1,11 @@
 package vcl
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/KeisukeYamashita/go-vcl/vcl"
+
+	"github.com/open-policy-agent/conftest/parser/internal/convert"
 )
 
 // Parser is a VCL parser.
@@ -17,14 +18,5 @@ func (p *Parser) Unmarshal(b []byte, v any) error {
 		return fmt.Errorf("decode vcl: %w", errs[0])
 	}
 
-	j, err := json.Marshal(result)
-	if err != nil {
-		return fmt.Errorf("marshal vcl to json: %w", err)
-	}
-
-	if err := json.Unmarshal(j, v); err != nil {
-		return fmt.Errorf("unmarshal vcl json: %w", err)
-	}
-
-	return nil
+	return convert.Remarshal("vcl", result, v)
 }


### PR DESCRIPTION
Many parsers need to marshal intermediate structs using json.Marshal() so that the OPA engine can use the data. This provides a utility function to handle this boilterplate logic.