### PR TITLE
fix: apply --ignore to explicitly provided files

### DIFF
--- a/runner/test.go
+++ b/runner/test.go
@@ -137,6 +137,15 @@ func renameStdinConfiguration(configurations map[string]any, stdinFilename strin
 }
 
 func parseFileList(fileList []string, ignoreRegex string) ([]string, error) {
+	var ignoreRegexp *regexp.Regexp
+	if ignoreRegex != "" {
+		var err error
+		ignoreRegexp, err = regexp.Compile(ignoreRegex)
+		if err != nil {
+			return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
+		}
+	}
+
 	var files []string
 	for _, file := range fileList {
 		if file == "" {
@@ -154,13 +163,13 @@ func parseFileList(fileList []string, ignoreRegex string) ([]string, error) {
 		}
 
 		if fileInfo.IsDir() {
-			directoryFiles, err := getFilesFromDirectory(file, ignoreRegex)
+			directoryFiles, err := getFilesFromDirectory(file, ignoreRegexp)
 			if err != nil {
 				return nil, fmt.Errorf("get files from directory: %w", err)
 			}
 
 			files = append(files, directoryFiles...)
-		} else {
+		} else if ignoreRegexp == nil || !ignoreRegexp.MatchString(file) {
 			files = append(files, file)
 		}
 	}
@@ -172,7 +181,7 @@ func parseFileList(fileList []string, ignoreRegex string) ([]string, error) {
 	return files, nil
 }
 
-func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string, regexp *regexp.Regexp) filepath.WalkFunc {
+func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegexp *regexp.Regexp) filepath.WalkFunc {
 	return func(currentPath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("walk path: %w", err)
@@ -186,7 +195,7 @@ func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string,
 			return nil
 		}
 
-		if ignoreRegex != "" && regexp.MatchString(currentPath) {
+		if ignoreRegexp != nil && ignoreRegexp.MatchString(currentPath) {
 			return nil
 		}
 
@@ -208,7 +217,7 @@ func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string,
 		}
 
 		if ri.IsDir() {
-			return filepath.Walk(realPath, getWalkFn(visitedDirs, files, ignoreRegex, regexp))
+			return filepath.Walk(realPath, getWalkFn(visitedDirs, files, ignoreRegexp))
 		}
 
 		if parser.FileSupported(realPath) {
@@ -219,15 +228,10 @@ func getWalkFn(visitedDirs map[string]bool, files *[]string, ignoreRegex string,
 	}
 }
 
-func getFilesFromDirectory(directory string, ignoreRegex string) ([]string, error) {
-	regexp, err := regexp.Compile(ignoreRegex)
-	if err != nil {
-		return nil, fmt.Errorf("given regexp couldn't be parsed :%w", err)
-	}
-
+func getFilesFromDirectory(directory string, ignoreRegexp *regexp.Regexp) ([]string, error) {
 	var files []string
 	visitedDirs := make(map[string]bool)
-	err = filepath.Walk(directory, getWalkFn(visitedDirs, &files, ignoreRegex, regexp))
+	err := filepath.Walk(directory, getWalkFn(visitedDirs, &files, ignoreRegexp))
 	if err != nil {
 		return nil, err
 	}

--- a/runner/test_test.go
+++ b/runner/test_test.go
@@ -1,9 +1,35 @@
 package runner
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
+
+func TestParseFileListIgnoresExplicitFiles(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	ignoredFile := filepath.Join(tempDir, "provider.tf")
+	includedFile := filepath.Join(tempDir, "main.tf")
+
+	for _, file := range []string{ignoredFile, includedFile} {
+		if err := os.WriteFile(file, nil, 0o600); err != nil {
+			t.Fatalf("write test file %q: %v", file, err)
+		}
+	}
+
+	got, err := parseFileList([]string{ignoredFile, includedFile}, `provider\.tf$`)
+	if err != nil {
+		t.Fatalf("parseFileList() error = %v", err)
+	}
+
+	want := []string{includedFile}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseFileList() = %v, want %v", got, want)
+	}
+}
 
 func TestRenameStdinConfiguration(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #1318

## Summary

`--ignore` patterns were applied while walking directories, but explicit file paths bypassed the check. This meant commands using shell-expanded file lists could still evaluate files that matched the ignore pattern.

This change compiles the ignore regex once in `parseFileList` and applies it to explicit files as well as directory-walked files. The `-` stdin path is unchanged.

The scope is limited to file-list filtering; parser and policy evaluation behavior are unchanged.

## Test plan

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `gofmt -l runner/test.go runner/test_test.go`
- [x] `git diff --check`

On Windows, the full test run used Git for Windows' `usr/bin` directory on PATH so the existing plugin tests could find `touch`, `echo`, and `true`. No plugin code was changed.
