### PR TITLE
fix(sarif): percent-encode artifact paths

### DIFF
--- a/output/sarif.go
+++ b/output/sarif.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -92,11 +93,11 @@ func addResult(run *sarif.Run, result Result, namespace, ruleType, level, fileNa
 	location := sarif.NewPhysicalLocation()
 	if loc := result.Location; loc != nil {
 		line, _ := strconv.Atoi(loc.Line.String())
-		location.ArtifactLocation = sarif.NewSimpleArtifactLocation(filepath.ToSlash(loc.File))
+		fileName = loc.File
 		location.Region = sarif.NewRegion().WithStartLine(line).WithEndLine(line)
-	} else {
-		location.ArtifactLocation = sarif.NewSimpleArtifactLocation(filepath.ToSlash(fileName))
 	}
+	uri := url.URL{Path: filepath.ToSlash(fileName)}
+	location.ArtifactLocation = sarif.NewSimpleArtifactLocation(uri.EscapedPath())
 
 	run.CreateResultForRule(ruleID).
 		WithRuleIndex(idx).

--- a/output/sarif_test.go
+++ b/output/sarif_test.go
@@ -3,11 +3,67 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/conftest/internal/version"
+	"github.com/owenrumney/go-sarif/v2/sarif"
 )
+
+func TestSARIF_OutputArtifactPaths(t *testing.T) {
+	tests := []struct {
+		file string
+		uri  string
+	}{
+		{"config.yaml", "config.yaml"},
+		{filepath.Join("configs", "service #1%.yaml"), "configs/service%20%231%25.yaml"},
+		{"configs/already%20named.yaml", "configs/already%2520named.yaml"},
+		{"configs/caf\u00e9.yaml", "configs/caf%C3%A9.yaml"},
+	}
+	for _, tt := range tests {
+		for _, explicitLocation := range []bool{false, true} {
+			name := "filename/" + tt.file
+			if explicitLocation {
+				name = "location/" + tt.file
+			}
+			t.Run(name, func(t *testing.T) {
+				failure := Result{Message: "policy failed"}
+				filename := tt.file
+				if explicitLocation {
+					filename = "other.yaml"
+					failure.Location = &Location{File: tt.file, Line: json.Number("7")}
+				}
+				var buf bytes.Buffer
+				if err := NewSARIF(&buf).Output(CheckResults{{
+					FileName: filename, Namespace: "main", Failures: []Result{failure},
+				}}); err != nil {
+					t.Fatal(err)
+				}
+				var report sarif.Report
+				if err := json.Unmarshal(buf.Bytes(), &report); err != nil {
+					t.Fatal(err)
+				}
+				location := report.Runs[0].Results[0].Locations[0].PhysicalLocation
+				got := *location.ArtifactLocation.URI
+				if got != tt.uri {
+					t.Errorf("artifact URI = %q, want %q", got, tt.uri)
+				}
+				parsed, err := url.Parse(got)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if parsed.Path != filepath.ToSlash(tt.file) || parsed.Fragment != "" || parsed.RawQuery != "" {
+					t.Errorf("URI does not preserve the filename: %+v", parsed)
+				}
+				if explicitLocation && *location.Region.StartLine != 7 {
+					t.Errorf("start line = %d, want 7", *location.Region.StartLine)
+				}
+			})
+		}
+	}
+}
 
 func TestSARIF_Output(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
SARIF artifact paths are currently written without URI encoding. For example, `configs/service #1%.yaml` produces an invalid URI, while a file literally named `already%20named.yaml` is interpreted as `already named.yaml`.

Escape the path after normalizing its separators, for both the result filename and an explicit `_loc.file`. The tests cover spaces, `#`, literal percent sequences, Unicode, and preservation of the explicit line number. Six regression cases fail before this change.

Validated with Go 1.27.1 on Windows: `go test ./... -p 4 -count=1`, `go vet ./output`, and `go build` passed. The plugin tests use Git for Windows' existing `usr/bin` tools on PATH. A real CLI policy check on `configs/service #1%.yaml` also produces a URI that decodes back to the original file. Bats acceptance tests were not run.