### PR TITLE
fix: preserve non-finite INI values as strings

### DIFF
--- a/parser/ini/ini.go
+++ b/parser/ini/ini.go
@@ -2,6 +2,7 @@ package ini
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/go-ini/ini"
@@ -54,8 +55,8 @@ func convertKeyTypes(keysHash map[string]string) map[string]any {
 }
 
 func isNumberLiteral(f string) bool {
-	_, err := strconv.ParseFloat(f, 64)
-	return err == nil
+	n, err := strconv.ParseFloat(f, 64)
+	return err == nil && !math.IsNaN(n) && !math.IsInf(n, 0)
 }
 
 func isBooleanLiteral(b string) bool {

--- a/parser/ini/ini_test.go
+++ b/parser/ini/ini_test.go
@@ -57,3 +57,17 @@ func TestConvertTypes(t *testing.T) {
 		})
 	}
 }
+
+func TestNonFiniteLiterals(t *testing.T) {
+	for _, value := range []string{"NaN", "nan", "Inf", "+Inf", "-Inf", "Infinity", "-Infinity"} {
+		t.Run(value, func(t *testing.T) {
+			var input map[string]map[string]any
+			if err := (&Parser{}).Unmarshal([]byte("[settings]\nvalue="+value), &input); err != nil {
+				t.Fatal(err)
+			}
+			if got := input["settings"]["value"]; got != value {
+				t.Fatalf("got %v, want string %q", got, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
INI values such as `value=NaN` or `value=Inf` are accepted by `strconv.ParseFloat`, then rejected when the parsed data is marshaled to JSON. This prevents the rest of the INI file from being evaluated.

Keep non-finite literals as strings while retaining the existing conversion of finite numbers and booleans.

The seven parser regressions fail before the fix and pass afterwards. `go test ./parser/... -count=1`, `go vet ./parser/ini`, and `git diff --check` pass on Windows with Go 1.27.1. Full-repository and acceptance tests were not run.